### PR TITLE
[FIX] website: correctly activate tour for each website

### DIFF
--- a/theme_common/__manifest__.py
+++ b/theme_common/__manifest__.py
@@ -7,6 +7,7 @@
     'depends': ['website'],
     'data': [
         'data/data.xml',
+        'data/ir_asset.xml',
         'views/old_snippets/s_column.xml',
         'views/old_snippets/s_page_header.xml',
         'views/old_snippets/s_three_columns_circle.xml',

--- a/theme_common/data/ir_asset.xml
+++ b/theme_common/data/ir_asset.xml
@@ -472,5 +472,13 @@
             <field name="active" eval="False"/>
         </record>
 
+        <record id="theme_common.configurator_tour" model="theme.ir.asset">
+            <field name="key">theme_common.configurator_tour</field>
+            <field name="name">Configurator Tour JS</field>
+            <field name="bundle">website.assets_editor</field>
+            <field name="glob">/theme_common/static/src/js/configurator_tour.js</field>
+            <field name="active" eval="False"/>
+        </record>
+
     </data>
 </odoo>

--- a/theme_common/static/src/js/configurator_tour.js
+++ b/theme_common/static/src/js/configurator_tour.js
@@ -1,0 +1,48 @@
+odoo.define("theme_common.configurator_tour", function (require) {
+"use strict";
+
+const wTourUtils = require("website.tour_utils");
+const core = require("web.core");
+const _t = core._t;
+
+let titleSelector = '#wrap > section:first-child';
+let title = $(titleSelector).find('h1, h2').first();
+if (!title.length) {
+    titleSelector = titleSelector.replace('section:first-child', 'section:nth-child(2)');
+    title = $(titleSelector).find('h1, h2').first();
+}
+let isTitleTextImage = $(titleSelector).hasClass('s_text_image');
+titleSelector = titleSelector.concat(` ${title.is('h1') ? 'h1' : 'h2'}`);
+
+const shapeSelector = '#wrap > section[data-oe-shape-data]';
+const backgroundSelector = '#wrap > section:nth-child(2)';
+
+const imageStep = isTitleTextImage ?
+    wTourUtils.changeImage(titleSelector.replace('h2', 'img')) : wTourUtils.changeBackground();
+
+const backgroundColorStep = [wTourUtils.changeBackgroundColor()];
+if (!isTitleTextImage) {
+    backgroundColorStep.unshift(wTourUtils.clickOnSnippet(backgroundSelector));
+}
+
+const shapeStep = [];
+if ($(shapeSelector).first().length) {
+    if (!$(backgroundSelector).is($(shapeSelector))) {
+        shapeStep.push(wTourUtils.clickOnSnippet(shapeSelector));
+    }
+    shapeStep.push(wTourUtils.changeOption('BackgroundShape', 'we-toggler', _t('Background Shape')));
+    shapeStep.push(wTourUtils.selectNested('we-select-page', 'BackgroundShape', ':not(.o_we_pager_controls', _t('Background Shape')));
+}
+
+const steps = [
+    wTourUtils.clickOnText(titleSelector),
+    imageStep,
+    ...backgroundColorStep,
+    ...shapeStep,
+    wTourUtils.changePaddingSize('top'),
+    wTourUtils.clickOnSave(),
+];
+
+wTourUtils.registerThemeHomepageTour('configurator_tour', steps);
+
+});


### PR DESCRIPTION
- Creating a website through the configurator activated
the configurator tour. This tour was active for every
websites even the ones not created using the configurator.
Theme tours were overridden by the configurator tour when
they should have been the active tour for website not
created using the configurator.

Now the configurator tour is an asset specific to each
website. This asset is deactivated by default and activated
for a website only if it is created using the configurator.

- Some actions of the website tour were also visible when
we were not in edit mode. extra_trigger has been added
on these actions to ensure they are visible only in edit
mode.

Odoo PR: odoo/odoo#71019