### PR TITLE
[IMP] website: change CTA for schedule appointment objective

### DIFF
--- a/theme_anelusia/views/snippets/s_cover.xml
+++ b/theme_anelusia/views/snippets/s_cover.xml
@@ -18,7 +18,7 @@
         </xpath>
         <!-- Button -->
         <xpath expr="//a" position="replace">
-            <a href="/contactus" class="btn btn-primary btn-lg mb-2">Discover</a>
+            <a t-att-href="cta_btn_href" class="btn btn-primary btn-lg mb-2"><t t-esc="cta_btn_text">Discover</t></a>
         </xpath>
     </template>
 </odoo>

--- a/theme_bistro/views/snippets/s_cover.xml
+++ b/theme_bistro/views/snippets/s_cover.xml
@@ -18,7 +18,7 @@
         </xpath>
         <!-- Button -->
         <xpath expr="//a[hasclass('btn')]" position="replace">
-            <a href="#" class="btn btn-lg btn-primary rounded-circle mb-2">Menu</a>
+            <a t-att-href="cta_btn_href" class="btn btn-lg btn-primary rounded-circle mb-2"><t t-esc="cta_btn_text">Menu</t></a>
         </xpath>
         <!-- Scroll Down button -->
         <xpath expr="//div[hasclass('container')]" position="after">

--- a/theme_bookstore/views/snippets/s_call_to_action.xml
+++ b/theme_bookstore/views/snippets/s_call_to_action.xml
@@ -15,7 +15,7 @@
         <xpath expr="//div[hasclass('col-lg-3')]" position="replace">
             <div class="col-lg-12 pt8">
                 <p style="text-align: center;">
-                    <a href="/contactus" class="btn btn-secondary btn-lg mb-2">Browse collection</a>
+                    <a t-att-href="cta_btn_href" class="btn btn-secondary btn-lg mb-2"><t t-esc="cta_btn_text">Browse collection</t></a>
                 </p>
             </div>
         </xpath>

--- a/theme_cobalt/views/customizations.xml
+++ b/theme_cobalt/views/customizations.xml
@@ -36,8 +36,8 @@
     <xpath expr="//a" position="before">
         <br/>
     </xpath>
-    <xpath expr="//a" position="replace">
-        <a href="#" class="btn btn-primary mb-2">Start now</a>
+    <xpath expr="//t[@t-esc='cta_btn_text']" position="replace">
+        <t t-esc="cta_btn_text">Start now</t>
     </xpath>
 </template>
 
@@ -168,8 +168,8 @@
 
 <!-- ==== Call To Action ===== -->
 <template id="s_call_to_action" inherit_id="website.s_call_to_action" name="Cobalt s_call_to_action">
-    <xpath expr="//a" position="replace">
-        <a href="/contactus" class="btn btn-primary btn-lg mb-2">START NOW</a>
+    <xpath expr="//t[@t-esc='cta_btn_text']" position="replace">
+        <t t-esc="cta_btn_text.upper()">START NOW</t>
     </xpath>
 </template>
 

--- a/theme_enark/views/snippets/s_banner.xml
+++ b/theme_enark/views/snippets/s_banner.xml
@@ -22,8 +22,8 @@
             <p class="lead">We are a contemporary architecture firm working mainly in the residential, commercial and office sectors. Our projects are built all over the world, in urban and natural environments.</p>
         </xpath>
         <!-- Button -->
-        <xpath expr="//a" position="replace">
-            <a href="#" class="btn btn-primary mb-2">Discover more</a>
+        <xpath expr="//t[@t-esc='cta_btn_text']" position="replace">
+            <t t-esc="cta_btn_text">Discover More</t>
         </xpath>
     </template>
 </odoo>

--- a/theme_graphene/views/customizations.xml
+++ b/theme_graphene/views/customizations.xml
@@ -25,7 +25,7 @@
                     Our mission is to give customers the best experience.<br/>Extensive documentation &amp; guides, an active community,<br/>24/7 support make it a pleasure to work with us.
                 </p>
                 <p style="text-align: right">
-                    <a href="/contactus" class="btn btn-primary btn-lg mb-2 o_default_snippet_text">Contact us</a>
+                    <a t-att-href="cta_btn_href" class="btn btn-primary btn-lg mb-2 o_default_snippet_text"><t t-esc="cta_btn_text">Contact us</t></a>
                 </p>
             </div>
         </div>

--- a/theme_kea/views/snippets/s_cover.xml
+++ b/theme_kea/views/snippets/s_cover.xml
@@ -14,7 +14,7 @@
                 </h1>
                 <p class="lead">Speed up your work with the last laptop. 3.4Ghz, 8 cores.<br/>
                 You’ll be unstoppable all day long (up to 11 hours).</p>
-                <p><a href="/contactus" class="btn btn-primary mb-2">Discover</a></p>
+                <p><a t-att-href="cta_btn_href" class="btn btn-primary mb-2"><t t-esc="cta_btn_text">Discover</t></a></p>
             </div>
         </xpath>
         <!-- Shape -->

--- a/theme_kiddo/views/snippets/s_banner.xml
+++ b/theme_kiddo/views/snippets/s_banner.xml
@@ -16,7 +16,7 @@
                 <p><br/></p>
                 <p class="lead">Because your children deserve the best, we welcome children from 0 to 3 years in a warm and specific environment for the needs of small children</p>
                 <p><br/></p>
-                <a href="#" class="btn btn-primary mb-2">About us</a>
+                <a t-att-href="cta_btn_href" class="btn btn-primary mb-2"><t t-esc="cta_btn_text">About us</t></a>
             </div>
         </xpath>
     </template>

--- a/theme_loftspace/views/snippets/s_cover.xml
+++ b/theme_loftspace/views/snippets/s_cover.xml
@@ -18,7 +18,7 @@
         </xpath>
         <!-- Button -->
         <xpath expr="//a" position="replace">
-            <a href="/contactus" class="btn btn-primary btn-lg mb-2">Discover More</a>
+            <a t-att-href="cta_btn_href" class="btn btn-primary btn-lg mb-2"><t t-esc="cta_btn_text">Discover More</t></a>
         </xpath>
     </template>
 </odoo>

--- a/theme_odoo_experts/views/snippets/s_banner.xml
+++ b/theme_odoo_experts/views/snippets/s_banner.xml
@@ -22,8 +22,8 @@
             <p class="lead">Guided by expertise gained over 20 years of achieving success for clients, we practice with passion and strategic focus on the future.</p>
         </xpath>
         <!-- Button -->
-        <xpath expr="//a" position="replace">
-            <a href="#" class="btn btn-primary mb-2">Discover more</a>
+        <xpath expr="//t[@t-esc='cta_btn_text']" position="replace">
+            <t t-esc="cta_btn_text">Discover More</t>
         </xpath>
     </template>
 </odoo>

--- a/theme_paptic/views/customizations.xml
+++ b/theme_paptic/views/customizations.xml
@@ -48,9 +48,11 @@
     <xpath expr="//p" position="replace">
         <p class="text-o-color-3">&#160;</p>
     </xpath>
+
     <xpath expr="//p[2]" position="replace">
         <p class="text-o-color-3">
-            <a href="#" class="btn btn-lg btn-primary mb-2">START NOW</a>&#160;&#160;&#160;&#160;<a href="#" class="btn btn-lg btn-secondary mb-2">SCHEDULE A DEMO</a>
+            <a href="#" class="btn btn-lg btn-primary mb-2">START NOW</a>&#160;&#160;&#160;&#160;
+            <a t-att-href="cta_btn_href" class="btn btn-lg btn-secondary mb-2"><t t-esc="cta_btn_text.upper()">SCHEDULE A DEMO</t></a>
         </p>
     </xpath>
 

--- a/theme_real_estate/views/snippets/s_banner.xml
+++ b/theme_real_estate/views/snippets/s_banner.xml
@@ -21,8 +21,8 @@
             <p class="lead">We are specialist in the sale and rental of residential real estate.</p>
         </xpath>
         <!-- Button -->
-        <xpath expr="//a" position="replace">
-            <a href="#" class="btn btn-primary mb-2">Properties</a>
+        <xpath expr="//t[@t-esc='cta_btn_text']" position="replace">
+            <t t-esc="cta_btn_text">Properties</t>
         </xpath>
     </template>
 </odoo>

--- a/theme_treehouse/views/snippets/s_cover.xml
+++ b/theme_treehouse/views/snippets/s_cover.xml
@@ -18,7 +18,7 @@
         </xpath>
         <!-- Button -->
         <xpath expr="//a" position="replace">
-            <a href="/contactus" class="btn btn-primary btn-lg mb-2">Get involved</a>
+            <a t-att-href="cta_btn_href" class="btn btn-primary btn-lg mb-2"><t t-esc="cta_btn_text">Get involved</t></a>
         </xpath>
     </template>
 </odoo>

--- a/theme_vehicle/views/customizations.xml
+++ b/theme_vehicle/views/customizations.xml
@@ -10,7 +10,7 @@
         <font style="font-size: 62px;font-weight: bold;">Start the Engine</font>
     </xpath>
     <xpath expr="//a[hasclass('btn')]" position="replace">
-        <a href="/contactus" class="btn btn-primary btn-lg mb-2">START THE ENGINE</a>
+        <a t-att-href="cta_btn_href" class="btn btn-primary btn-lg mb-2"><t t-esc="cta_btn_text.upper()">START THE ENGINE</t></a>
     </xpath>
 </template>
 

--- a/theme_zap/views/snippets/s_banner.xml
+++ b/theme_zap/views/snippets/s_banner.xml
@@ -18,8 +18,8 @@
             <p class="lead">Software Innovation as its best.<br/> Harness the power of disruptive technologies to increase your day-to-day business operations.</p>
         </xpath>
         <!-- Button -->
-        <xpath expr="//a" position="replace">
-            <a href="#" class="btn btn-primary mb-2">Our Solutions</a>
+        <xpath expr="//t[@t-esc='cta_btn_text']" position="replace">
+            <t t-esc="cta_btn_text">Our Solutions</t>
         </xpath>
     </template>
 </odoo>


### PR DESCRIPTION
If user selects 'schedule appointments' as main objective in the configurator
and if the website_calendar module is installed then the Call To Action of
snippets s_banner, s_cover and s_call_to_action is changed to 'Schedule an
appointment' and redirect user to '/calendar' on click.