### PR TITLE
[FIX] website_animate: fix drag n drop an animated snippet

### DIFF
--- a/website_animate/static/src/js/o_animate.editor.js
+++ b/website_animate/static/src/js/o_animate.editor.js
@@ -21,25 +21,6 @@ sOptions.registry.o_animate = sOptions.Class.extend({
     onFocus: function () {
         this._setActive(); // Needed as in charge of hiding duration/delay/...
     },
-    /**
-     * @override
-     */
-    cleanForSave: function () {
-        // Clean elements
-        this.$target.removeClass('o_animating o_animated o_animate_preview')
-                    .css({
-                        'animation': '',
-                        'animation-name': '',
-                        'animation-play-state': '',
-                        'visibility': '',
-                    });
-        if (this.$target.hasClass('o_animate')) {
-            this.$target.css('animation-play-state', 'paused');
-        }
-
-        // Clean all inView elements
-        $('#wrapwrap').find('.o_animate').removeClass('o_visible');
-    },
 
     //--------------------------------------------------------------------------
     // Options

--- a/website_animate/static/src/js/o_animate.frontend.js
+++ b/website_animate/static/src/js/o_animate.frontend.js
@@ -126,6 +126,19 @@ publicWidget.registry.WebsiteAnimate = publicWidget.Widget.extend({
 
         return this._super.apply(this, arguments);
     },
+    /**
+     * @override
+     */
+    destroy: function () {
+        this._super.apply(this, arguments);
+        this.$target.find('.o_animate')
+            .removeClass('o_animating o_animated o_animate_preview')
+            .css({
+                'animation-name': '',
+                'animation-play-state': '',
+                'visibility': '',
+            });
+    },
 });
 
 // Backward compatibility for enark animation system


### PR DESCRIPTION
Before this commit, when drag n drop a snippet to move it in a website
page. The snippet was invisible after the drop.

task-2215118