### PR TITLE
[FIX] theme_*: use correct contact header SCSS variable

### DIFF
--- a/theme_beauty/static/src/scss/primary_variables.scss
+++ b/theme_beauty/static/src/scss/primary_variables.scss
@@ -133,7 +133,7 @@ $o-website-values-palettes: (
         'headings-font': 'Questrial',
         'navbar-font': 'Questrial',
         'buttons-font': 'Questrial',
-        'header-template': 'contact',
+        'header-template': 'Contact',
         'footer-template': 'default',
         'header-links-style': 'outline',
     ),

--- a/theme_bookstore/static/src/scss/primary_variables.scss
+++ b/theme_bookstore/static/src/scss/primary_variables.scss
@@ -157,7 +157,7 @@ $o-website-values-palettes: (
         'headings-font': 'Poppins',
         'navbar-font': 'Poppins',
         'buttons-font': 'Poppins',
-        'header-template': 'contact',
+        'header-template': 'Contact',
         'footer-template': 'descriptive',
         'header-links-style': 'border-bottom',
     ),

--- a/theme_odoo_experts/static/src/scss/primary_variables.scss
+++ b/theme_odoo_experts/static/src/scss/primary_variables.scss
@@ -133,7 +133,7 @@ $o-website-values-palettes: (
         'headings-font': 'Oswald',
         'navbar-font': 'Oswald',
         'buttons-font': 'Lato',
-        'header-template': 'contact',
+        'header-template': 'Contact',
         'footer-template': 'contact',
         'header-links-style': 'border-bottom',
     ),


### PR DESCRIPTION
The contact header scss variable value was written with an uppercase
unlike other header scss variables. Unfortunately, fixing that typo is
not stable-friendly (as people already using the template now saved
that typo in their DB). Instead, we use that typo as default value for
the related themes.

Related to task-2368576