### PR TITLE
[FIX] theme_*: check cta_btn_text is not False before applying upper

### DIFF
--- a/theme_cobalt/views/customizations.xml
+++ b/theme_cobalt/views/customizations.xml
@@ -169,7 +169,7 @@
 <!-- ==== Call To Action ===== -->
 <template id="s_call_to_action" inherit_id="website.s_call_to_action" name="Cobalt s_call_to_action">
     <xpath expr="//t[@t-esc='cta_btn_text']" position="replace">
-        <t t-esc="cta_btn_text.upper()">START NOW</t>
+        <t t-esc="cta_btn_text and cta_btn_text.upper()">START NOW</t>
     </xpath>
 </template>
 

--- a/theme_paptic/views/customizations.xml
+++ b/theme_paptic/views/customizations.xml
@@ -52,7 +52,7 @@
     <xpath expr="//p[2]" position="replace">
         <p class="text-o-color-3">
             <a href="#" class="btn btn-lg btn-primary mb-2">START NOW</a>&#160;&#160;&#160;&#160;
-            <a t-att-href="cta_btn_href" class="btn btn-lg btn-secondary mb-2"><t t-esc="cta_btn_text.upper()">SCHEDULE A DEMO</t></a>
+            <a t-att-href="cta_btn_href" class="btn btn-lg btn-secondary mb-2"><t t-esc="cta_btn_text and cta_btn_text.upper()">SCHEDULE A DEMO</t></a>
         </p>
     </xpath>
 

--- a/theme_vehicle/views/customizations.xml
+++ b/theme_vehicle/views/customizations.xml
@@ -10,7 +10,7 @@
         <font style="font-size: 62px;font-weight: bold;">Start the Engine</font>
     </xpath>
     <xpath expr="//a[hasclass('btn')]" position="replace">
-        <a t-att-href="cta_btn_href" class="btn btn-primary btn-lg mb-2"><t t-esc="cta_btn_text.upper()">START THE ENGINE</t></a>
+        <a t-att-href="cta_btn_href" class="btn btn-primary btn-lg mb-2"><t t-esc="cta_btn_text and cta_btn_text.upper()">START THE ENGINE</t></a>
     </xpath>
 </template>
 


### PR DESCRIPTION
The themes cobalt, paptic and vehicle apply upper on cta_btn_text for some
snippets. In some case cta_btn_text is a boolean (False) and not a string.
We must check cta_btn_text is not False before calling upper on it.

task-2518565