### PR TITLE
[FIX] *: add explicit license to all manifest

### DIFF
--- a/theme_anelusia/__manifest__.py
+++ b/theme_anelusia/__manifest__.py
@@ -21,4 +21,5 @@
     'price': 199,
     'currency': 'EUR',
     'live_test_url': 'https://theme-anelusia.odoo.com/page/demo1',
+    'license': 'LGPL-3',
 }

--- a/theme_anelusia_sale/__manifest__.py
+++ b/theme_anelusia_sale/__manifest__.py
@@ -10,4 +10,5 @@
         'views/layout.xml',
     ],
     'auto_install': True,
+    'license': 'LGPL-3',
 }

--- a/theme_artists/__manifest__.py
+++ b/theme_artists/__manifest__.py
@@ -20,4 +20,5 @@
     'price': 4,
     'currency': 'EUR',
     'live_test_url': 'https://theme-artists.odoo.com',
+    'license': 'LGPL-3',
 }

--- a/theme_artists_sale/__manifest__.py
+++ b/theme_artists_sale/__manifest__.py
@@ -6,4 +6,5 @@
     'version': '1.0',
     'depends': ['theme_monglia_sale', 'theme_artists'],
     'auto_install': True,
+    'license': 'LGPL-3',
 }

--- a/theme_avantgarde/__manifest__.py
+++ b/theme_avantgarde/__manifest__.py
@@ -21,4 +21,5 @@
     'price': 199,
     'currency': 'EUR',
     'live_test_url': 'https://theme-avantgarde.odoo.com',
+    'license': 'LGPL-3',
 }

--- a/theme_avantgarde_blog/__manifest__.py
+++ b/theme_avantgarde_blog/__manifest__.py
@@ -9,4 +9,5 @@
     ],
     'depends': ['theme_avantgarde', 'website_blog'],
     'auto_install': True,
+    'license': 'LGPL-3',
 }

--- a/theme_beauty/__manifest__.py
+++ b/theme_beauty/__manifest__.py
@@ -17,4 +17,5 @@
     'price': 4,
     'currency': 'EUR',
     'live_test_url': 'https://theme-beauty.odoo.com',
+    'license': 'LGPL-3',
 }

--- a/theme_beauty_sale/__manifest__.py
+++ b/theme_beauty_sale/__manifest__.py
@@ -6,4 +6,5 @@
     'version': '1.0',
     'depends': ['theme_loftspace_sale', 'theme_beauty'],
     'auto_install': True,
+    'license': 'LGPL-3',
 }

--- a/theme_bewise/__manifest__.py
+++ b/theme_bewise/__manifest__.py
@@ -21,4 +21,5 @@
     'price': 149,
     'currency': 'EUR',
     'live_test_url': 'https://theme-bewise.odoo.com/page/demo_page_demo_1',
+    'license': 'LGPL-3',
 }

--- a/theme_bistro/__manifest__.py
+++ b/theme_bistro/__manifest__.py
@@ -17,5 +17,6 @@
     ],
     'price': 4,
     'currency': 'EUR',
-    'live_test_url': 'https://theme-bistro.odoo.com'
+    'live_test_url': 'https://theme-bistro.odoo.com',
+    'license': 'LGPL-3',
 }

--- a/theme_bookstore/__manifest__.py
+++ b/theme_bookstore/__manifest__.py
@@ -16,5 +16,6 @@
     ],
     'price': 4,
     'currency': 'EUR',
-    'live_test_url': 'https://theme-bookstore.odoo.com'
+    'live_test_url': 'https://theme-bookstore.odoo.com',
+    'license': 'LGPL-3',
 }

--- a/theme_bookstore_sale/__manifest__.py
+++ b/theme_bookstore_sale/__manifest__.py
@@ -9,4 +9,5 @@
         'views/theme.xml',
     ],
     'auto_install': True,
+    'license': 'LGPL-3',
 }

--- a/theme_clean/__manifest__.py
+++ b/theme_clean/__manifest__.py
@@ -21,4 +21,5 @@
     'price': 199,
     'currency': 'EUR',
     'live_test_url': 'https://theme-clean.odoo.com/page/demo_page_home',
+    'license': 'LGPL-3',
 }

--- a/theme_common/__manifest__.py
+++ b/theme_common/__manifest__.py
@@ -70,4 +70,5 @@
         'views/s_event_slide.xml',
     ],
     'application': False,
+    'license': 'LGPL-3',
 }

--- a/theme_enark/__manifest__.py
+++ b/theme_enark/__manifest__.py
@@ -21,4 +21,5 @@
     'price': 199,
     'currency': 'EUR',
     'live_test_url': 'https://theme-enark.odoo.com/page/demo_page_home_1',
+    'license': 'LGPL-3',
 }

--- a/theme_graphene/__manifest__.py
+++ b/theme_graphene/__manifest__.py
@@ -20,5 +20,6 @@
     'depends': ['theme_common', 'website_animate'],
     'price': 199,
     'currency': 'EUR',
-    'live_test_url': 'https://theme-graphene.odoo.com'
+    'live_test_url': 'https://theme-graphene.odoo.com',
+    'license': 'LGPL-3',
 }

--- a/theme_graphene_blog/__manifest__.py
+++ b/theme_graphene_blog/__manifest__.py
@@ -9,4 +9,5 @@
     ],
     'depends': ['theme_graphene', 'website_blog'],
     'auto_install': True,
+    'license': 'LGPL-3',
 }

--- a/theme_kea/__manifest__.py
+++ b/theme_kea/__manifest__.py
@@ -19,4 +19,5 @@
     'price': 195,
     'currency': 'EUR',
     'live_test_url': 'https://theme-kea.odoo.com/page/demo1',
+    'license': 'LGPL-3',
 }

--- a/theme_kea_sale/__manifest__.py
+++ b/theme_kea_sale/__manifest__.py
@@ -10,4 +10,5 @@
         'views/layout.xml',
     ],
     'auto_install': True,
+    'license': 'LGPL-3',
 }

--- a/theme_kiddo/__manifest__.py
+++ b/theme_kiddo/__manifest__.py
@@ -19,5 +19,6 @@
     ],
     'price': 199,
     'currency': 'EUR',
-    'live_test_url': 'https://theme-kiddo.odoo.com/page/demo'
+    'live_test_url': 'https://theme-kiddo.odoo.com/page/demo',
+    'license': 'LGPL-3',
 }

--- a/theme_kiddo_sale/__manifest__.py
+++ b/theme_kiddo_sale/__manifest__.py
@@ -10,4 +10,5 @@
         'views/layout.xml',
     ],
     'auto_install': True,
+    'license': 'LGPL-3',
 }

--- a/theme_loftspace/__manifest__.py
+++ b/theme_loftspace/__manifest__.py
@@ -21,4 +21,5 @@
     'price': 195,
     'currency': 'EUR',
     'live_test_url': 'https://theme-loftspace.odoo.com/page/demo',
+    'license': 'LGPL-3',
 }

--- a/theme_loftspace_sale/__manifest__.py
+++ b/theme_loftspace_sale/__manifest__.py
@@ -10,4 +10,5 @@
         'views/layout.xml',
     ],
     'auto_install': True,
+    'license': 'LGPL-3',
 }

--- a/theme_monglia/__manifest__.py
+++ b/theme_monglia/__manifest__.py
@@ -20,4 +20,5 @@
     'price': 195,
     'currency': 'EUR',
     'live_test_url': 'https://theme-monglia.odoo.com',
+    'license': 'LGPL-3',
 }

--- a/theme_monglia_sale/__manifest__.py
+++ b/theme_monglia_sale/__manifest__.py
@@ -10,4 +10,5 @@
         'views/layout.xml',
     ],
     'auto_install': True,
+    'license': 'LGPL-3',
 }

--- a/theme_nano/__manifest__.py
+++ b/theme_nano/__manifest__.py
@@ -21,5 +21,6 @@
     ],
     'price': 199,
     'currency': 'EUR',
-    'live_test_url': 'https://theme-nano.odoo.com/page/demo_page_01'
+    'live_test_url': 'https://theme-nano.odoo.com/page/demo_page_01',
+    'license': 'LGPL-3',
 }

--- a/theme_notes/__manifest__.py
+++ b/theme_notes/__manifest__.py
@@ -20,4 +20,5 @@
     'price': 199,
     'currency': 'EUR',
     'live_test_url': 'https://theme-notes.odoo.com/page/demo',
+    'license': 'LGPL-3',
 }

--- a/theme_notes_sale/__manifest__.py
+++ b/theme_notes_sale/__manifest__.py
@@ -10,4 +10,5 @@
         'views/layout.xml',
     ],
     'auto_install': True,
+    'license': 'LGPL-3',
 }

--- a/theme_odoo_experts/__manifest__.py
+++ b/theme_odoo_experts/__manifest__.py
@@ -18,4 +18,5 @@
     'price': 4,
     'currency': 'EUR',
     'live_test_url': 'https://theme-odoo-experts.odoo.com',
+    'license': 'LGPL-3',
 }

--- a/theme_odoo_experts_sale/__manifest__.py
+++ b/theme_odoo_experts_sale/__manifest__.py
@@ -6,4 +6,5 @@
     'version': '1.0',
     'depends': ['theme_loftspace_sale', 'theme_odoo_experts'],
     'auto_install': True,
+    'license': 'LGPL-3',
 }

--- a/theme_orchid/__manifest__.py
+++ b/theme_orchid/__manifest__.py
@@ -17,4 +17,5 @@
     'price': 4,
     'currency': 'EUR',
     'live_test_url': 'https://theme-orchid.odoo.com',
+    'license': 'LGPL-3',
 }

--- a/theme_orchid_sale/__manifest__.py
+++ b/theme_orchid_sale/__manifest__.py
@@ -6,4 +6,5 @@
     'version': '1.0',
     'depends': ['theme_loftspace_sale', 'theme_orchid'],
     'auto_install': True,
+    'license': 'LGPL-3',
 }

--- a/theme_real_estate/__manifest__.py
+++ b/theme_real_estate/__manifest__.py
@@ -18,4 +18,5 @@
     'price': 4,
     'currency': 'EUR',
     'live_test_url': 'https://theme-real-estate.odoo.com',
+    'license': 'LGPL-3',
 }

--- a/theme_real_estate_sale/__manifest__.py
+++ b/theme_real_estate_sale/__manifest__.py
@@ -9,4 +9,5 @@
         'views/assets.xml',
     ],
     'auto_install': True,
+    'license': 'LGPL-3',
 }

--- a/theme_treehouse/__manifest__.py
+++ b/theme_treehouse/__manifest__.py
@@ -27,4 +27,5 @@
     'price': 195,
     'currency': 'EUR',
     'live_test_url': 'https://theme-treehouse.odoo.com/page/demo_page_01',
+    'license': 'LGPL-3',
 }

--- a/theme_vehicle/__manifest__.py
+++ b/theme_vehicle/__manifest__.py
@@ -17,4 +17,5 @@
     'price': 4,
     'currency': 'EUR',
     'live_test_url': 'https://theme-vehicle.odoo.com',
+    'license': 'LGPL-3',
 }

--- a/theme_vehicle_sale/__manifest__.py
+++ b/theme_vehicle_sale/__manifest__.py
@@ -9,4 +9,5 @@
         'views/assets.xml',
     ],
     'auto_install': True,
+    'license': 'LGPL-3',
 }

--- a/theme_yes/__manifest__.py
+++ b/theme_yes/__manifest__.py
@@ -18,4 +18,5 @@
     'price': 4,
     'currency': 'EUR',
     'live_test_url': 'https://theme-yes.odoo.com',
+    'license': 'LGPL-3',
 }

--- a/theme_yes_sale/__manifest__.py
+++ b/theme_yes_sale/__manifest__.py
@@ -6,4 +6,5 @@
     'version': '1.0',
     'depends': ['theme_kea_sale', 'theme_yes'],
     'auto_install': True,
+    'license': 'LGPL-3',
 }

--- a/theme_zap/__manifest__.py
+++ b/theme_zap/__manifest__.py
@@ -17,5 +17,6 @@
     ],
     'price': 4,
     'currency': 'EUR',
-    'live_test_url': 'https://theme-zap.odoo.com'
+    'live_test_url': 'https://theme-zap.odoo.com',
+    'license': 'LGPL-3',
 }

--- a/website_animate/__manifest__.py
+++ b/website_animate/__manifest__.py
@@ -12,4 +12,5 @@
     'images': [
         'static/description/icon.png',
     ],
+    'license': 'LGPL-3',
 }


### PR DESCRIPTION
The license is missing in most enterprise manifest so
the decision was taken to make it explicit in all cases.
When not defined, a warning will be triggered starting from
14.0 when falling back on the default LGPL-3.