### PR TITLE
[FIX] *: add explicit license to all manifest

### DIFF
--- a/test_themes/__manifest__.py
+++ b/test_themes/__manifest__.py
@@ -44,4 +44,5 @@
     'application': False,
     'post_init_hook': 'post_init_hook',
     'uninstall_hook': 'uninstall_hook',
+    'license': 'LGPL-3',
 }

--- a/theme_anelusia_sale/__manifest__.py
+++ b/theme_anelusia_sale/__manifest__.py
@@ -10,4 +10,5 @@
         'views/layout.xml',
     ],
     'auto_install': True,
+    'license': 'LGPL-3',
 }

--- a/theme_avantgarde_blog/__manifest__.py
+++ b/theme_avantgarde_blog/__manifest__.py
@@ -9,4 +9,5 @@
     ],
     'depends': ['theme_avantgarde', 'website_blog'],
     'auto_install': True,
+    'license': 'LGPL-3',
 }

--- a/theme_common/__manifest__.py
+++ b/theme_common/__manifest__.py
@@ -69,4 +69,5 @@
         'views/s_event_slide.xml',
     ],
     'application': False,
+    'license': 'LGPL-3',
 }

--- a/theme_graphene_blog/__manifest__.py
+++ b/theme_graphene_blog/__manifest__.py
@@ -9,4 +9,5 @@
     ],
     'depends': ['theme_graphene', 'website_blog'],
     'auto_install': True,
+    'license': 'LGPL-3',
 }

--- a/theme_kea_sale/__manifest__.py
+++ b/theme_kea_sale/__manifest__.py
@@ -10,4 +10,5 @@
         'views/layout.xml',
     ],
     'auto_install': True,
+    'license': 'LGPL-3',
 }

--- a/theme_kiddo_sale/__manifest__.py
+++ b/theme_kiddo_sale/__manifest__.py
@@ -10,4 +10,5 @@
         'views/layout.xml',
     ],
     'auto_install': True,
+    'license': 'LGPL-3',
 }

--- a/theme_loftspace_sale/__manifest__.py
+++ b/theme_loftspace_sale/__manifest__.py
@@ -10,4 +10,5 @@
         'views/layout.xml',
     ],
     'auto_install': True,
+    'license': 'LGPL-3',
 }

--- a/theme_monglia_sale/__manifest__.py
+++ b/theme_monglia_sale/__manifest__.py
@@ -10,4 +10,5 @@
         'views/layout.xml',
     ],
     'auto_install': True,
+    'license': 'LGPL-3',
 }

--- a/theme_notes_sale/__manifest__.py
+++ b/theme_notes_sale/__manifest__.py
@@ -10,4 +10,5 @@
         'views/layout.xml',
     ],
     'auto_install': True,
+    'license': 'LGPL-3',
 }

--- a/website_animate/__manifest__.py
+++ b/website_animate/__manifest__.py
@@ -12,4 +12,5 @@
     'images': [
         'static/description/icon.png',
     ],
+    'license': 'LGPL-3',
 }


### PR DESCRIPTION
The license is missing in most enterprise manifest so
the decision was taken to make it explicit in all cases.
When not defined, a warning will be triggered starting from
14.0 when falling back on the default LGPL-3.