### PR TITLE
[FIX] *: add explicit license to all manifest

### DIFF
--- a/test_themes/__manifest__.py
+++ b/test_themes/__manifest__.py
@@ -46,4 +46,5 @@
     'installable': True,
     'application': False,
     'post_init_hook': 'post_init_hook',
+    'license': 'LGPL-3',
 }

--- a/theme_common/__manifest__.py
+++ b/theme_common/__manifest__.py
@@ -47,4 +47,5 @@
         'views/old_snippets/s_two_columns.xml',
     ],
     'application': False,
+    'license': 'LGPL-3',
 }

--- a/website_animate/__manifest__.py
+++ b/website_animate/__manifest__.py
@@ -12,4 +12,5 @@
     'images': [
         'static/description/icon.png',
     ],
+    'license': 'LGPL-3',
 }


### PR DESCRIPTION
The license is missing in most enterprise manifest so
the decision was taken to make it explicit in all cases.
When not defined, a warning will be triggered starting from
14.0 when falling back on the default LGPL-3.