### PR TITLE
[FIX] *: add explicit license to all manifest

### DIFF
--- a/test_themes/__manifest__.py
+++ b/test_themes/__manifest__.py
@@ -49,5 +49,6 @@
         'web.assets_frontend': [
             'test_themes/static/src/js/navbar.js',
         ],
-    }
+    },
+    'license': 'LGPL-3',
 }

--- a/theme_common/__manifest__.py
+++ b/theme_common/__manifest__.py
@@ -12,4 +12,5 @@
         'views/old_snippets/s_three_columns_circle.xml',
         ],
     'application': False,
+    'license': 'LGPL-3',
 }

--- a/website_animate/__manifest__.py
+++ b/website_animate/__manifest__.py
@@ -19,5 +19,6 @@
         'website.assets_editor': [
             'website_animate/static/src/js/o_animate.editor.js',
         ],
-    }
+    },
+    'license': 'LGPL-3',
 }


### PR DESCRIPTION
The license is missing in most enterprise manifest so
the decision was taken to make it explicit in all cases.
When not defined, a warning will be triggered starting from
14.0 when falling back on the default LGPL-3.