### PR TITLE
[FIX] website_animate: fix start of animations

### DIFF
--- a/website_animate/static/src/js/o_animate.frontend.js
+++ b/website_animate/static/src/js/o_animate.frontend.js
@@ -55,7 +55,7 @@ var WebsiteAnimate = {
 
                 // We need to offset for the change in position from some animation
                 // So we get the top value by not taking CSS transforms into calculations
-                var elTop = self.getElementOffsetTop($el[0]);
+                var elTop = self.getElementOffsetTop($el[0]) - $().getScrollingElement().scrollTop();
 
                 var visible = windowBottom > (elTop + elOffset) && windowTop < (elTop + elHeight - elOffset);
 


### PR DESCRIPTION
Before this commit, the calculation of the top position of the
animated elements did not take into account the fact that the
scrollable element is no longer the body. And therefore the animations
never started.

task-2215118