### PR TITLE
[FIX] test_themes: adapt TestThemesWebsiteSelector to new registry

### DIFF
--- a/test_themes/static/src/js/navbar.js
+++ b/test_themes/static/src/js/navbar.js
@@ -2,6 +2,7 @@ odoo.define('test_themes.website_selector', function (require) {
 'use strict';
 
 const websiteNavbarData = require('website.navbar');
+const { registry } = require("@web/core/registry");
 
 const TestThemesWebsiteSelector = websiteNavbarData.WebsiteNavbarActionWidget.extend({
     /**
@@ -18,7 +19,10 @@ const TestThemesWebsiteSelector = websiteNavbarData.WebsiteNavbarActionWidget.ex
 
 });
 
-websiteNavbarData.websiteNavbarRegistry.add(TestThemesWebsiteSelector, '#website_switcher');
+registry.category("website_navbar_widgets").add("TestThemesWebsiteSelector", {
+    Widget: TestThemesWebsiteSelector,
+    selector: '#website_switcher',
+});
 
 return {
     TestThemesWebsiteSelector: TestThemesWebsiteSelector,


### PR DESCRIPTION
In odoo/odoo#72675 the registry for navbar widgets was changed to use
the new registry class introduced with the wowl webclient, this use site
was not adapted, causing a crash on startup.