### PR TITLE
[FIX] theme_kiddo: fix typo in default font name

### DIFF
--- a/theme_kiddo/static/src/scss/primary_variables.scss
+++ b/theme_kiddo/static/src/scss/primary_variables.scss
@@ -181,7 +181,7 @@ $o-website-values-palettes: (
         'logo-height': 3rem,
         'fixed-logo-height': 3rem,
         'btn-border-radius': 2rem,
-        'font': 'MontSerrat',
+        'font': 'Montserrat',
         'headings-font': 'Bubblegum Sans',
         'navbar-font': 'Bubblegum Sans',
         'buttons-font': 'Bubblegum Sans',


### PR DESCRIPTION
Because of a typo, the theme used "sans-serif" as font, thus with a
random look according to OS and browser.

opw-2559735