### PR TITLE
[IMP] theme_kiddo, theme_vehicule: add images_peview_theme in manifest

### DIFF
--- a/theme_kiddo/__manifest__.py
+++ b/theme_kiddo/__manifest__.py
@@ -17,11 +17,24 @@
         'views/snippets/s_three_columns.xml',
         'views/snippets/s_call_to_action.xml',
 
-        ],
+    ],
     'images': [
         'static/description/Kiddo_description.png',
         'static/description/kiddo_screenshot.jpg',
     ],
+    'images_preview_theme': {
+        'website.s_banner_default_image': '/theme_kiddo/static/src/img/library/bg11.jpg',
+        'website.s_image_text_default_image': '/theme_kiddo/static/src/img/content/content_img_14.jpg',
+        'website.s_product_list_default_image_1': '/theme_kiddo/static/src/img/content/content_img_30.jpg',
+        'website.s_product_list_default_image_2': '/theme_kiddo/static/src/img/content/content_img_31.jpg',
+        'website.s_product_list_default_image_3': '/theme_kiddo/static/src/img/content/content_img_32.jpg',
+        'website.s_product_list_default_image_4': '/theme_kiddo/static/src/img/content/content_img_33.jpg',
+        'website.s_product_list_default_image_5': '/theme_kiddo/static/src/img/content/content_img_34.jpg',
+        'website.s_product_list_default_image_6': '/theme_kiddo/static/src/img/content/content_img_35.jpg',
+        's_three_columns_default_image_1': '/theme_kiddo/static/src/img/content/content_img_16.jpg',
+        's_three_columns_default_image_2': '/theme_kiddo/static/src/img/content/content_img_17.jpg',
+        's_three_columns_default_image_3': '/theme_kiddo/static/src/img/content/content_img_18.jpg',
+    },
     'license': 'LGPL-3',
     'live_test_url': 'https://theme-kiddo.odoo.com',
     'assets': {

--- a/theme_vehicle/__manifest__.py
+++ b/theme_vehicle/__manifest__.py
@@ -16,6 +16,12 @@
         'static/description/vehicle_description.png',
         'static/description/vehicle_screenshot.jpeg',
     ],
+    'images_preview_theme': {
+        'website.s_cover_default_image': '/theme_vehicle/static/src/img/snippets/s_cover.jpg',
+        'website.s_text_image_default_image': '/theme_vehicle/static/src/img/snippets/s_text_image.jpg',
+        'website.s_masonry_block_default_image_1': '/theme_vehicle/static/src/img/snippets/s_masonry_block.jpg',
+        'website.s_image_text_default_image': '/theme_vehicle/static/src/img/snippets/s_image_text.jpg',
+    },
     'license': 'LGPL-3',
     'live_test_url': 'https://theme-vehicle.odoo.com',
     'assets': {


### PR DESCRIPTION
Example of how to communicate image to be used by IAP in preview when use_theme_image is checked on iap.
//cc @Cocographique 