### PR TITLE
[FIX] theme_bistro, theme_zap: remove misleading 'hambuger' variable

### DIFF
--- a/theme_bistro/static/src/scss/primary_variables.scss
+++ b/theme_bistro/static/src/scss/primary_variables.scss
@@ -6,7 +6,6 @@ $o-website-values-palettes: (
     (
         // Header
         'header-template':                  'vertical',
-        'hambuger-type':                    'off-canvas',
         'hamburger-position':               'right',
         'logo-height':                      3rem,
         'fixed-logo-height':                2rem,

--- a/theme_zap/static/src/scss/primary_variables.scss
+++ b/theme_zap/static/src/scss/primary_variables.scss
@@ -12,7 +12,6 @@ $o-website-values-palettes: (
 
         'header-font-size':                 (14 / 16) * 1rem,
         'font-size-base':                   (14 / 16) * 1rem,
-        'hambuger-type':                    'off-canvas',
         'hamburger-position':               'right',
 
         // Font


### PR DESCRIPTION
Those two themes were defining a 'hambuger-type' variable to
'off-canvas', probably a typo of 'hamburger-type'... but the themes
do not even activate the views related to 'off-canvas', so this had
simply no effect and did not create any bug.