### PR TITLE
[FIX] theme_common: Remove shadow style for small header tags

### DIFF
--- a/theme_common/static/src/scss/mixins.scss
+++ b/theme_common/static/src/scss/mixins.scss
@@ -263,7 +263,7 @@
 }
 
 @mixin o-theme-cfa-header-shadows() {
-    .bg-100, .bg-200, .bg-300, .bg-400, .bg-500, .bg-600, .bg-700, .bg-800, .bg-900 {
+    .bg-500, .bg-600, .bg-700, .bg-800, .bg-900 {
         h1, h2, h3, h4, h5, h6 {
             text-shadow: 0px 2px 0px $black;
         }


### PR DESCRIPTION
Steps to reproduce (in Odoo version >= 13.0):

  - Install eLearning module and at step of selecting a website theme,
    choose Monglia.
    (or install and activate theme manually after eLearning install)
  - Go to eLearning and edit "Basics of Gardening" course
  - Under Options tab, switch `Type` to `Documentation` then save
  - Go to Website and open the course, then lesson "Home Gardening"
    (If in Fullscreen view, switch back to normal view)

Issue :

  On right side of the presentation (Related & Most viewed),
  the lessons titles are blurry.

Solution :

  Remove shadow style for tag h4, h5 & h6.

opw-2627163