### PR TITLE
[FIX] theme_(vehicle|yes|zap): fix masonry xpath

### DIFF
--- a/theme_vehicle/views/customizations.xml
+++ b/theme_vehicle/views/customizations.xml
@@ -70,7 +70,7 @@
 </template>
 
 <!-- ======== MASONERY BLOCK ======== -->
-<template id="s_masonry_block" inherit_id="website.s_masonry_block" name="Vehicle s_masonry_block">
+<template id="s_masonry_block_default_template" inherit_id="website.s_masonry_block_default_template" name="Vehicle s_masonry_block">
     <xpath expr="//p" position="replace"/>
 
     <xpath expr="//div[hasclass('h-100')]/div//h3" position="replace">

--- a/theme_yes/views/snippets/s_masonry_block.xml
+++ b/theme_yes/views/snippets/s_masonry_block.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <odoo>
-    <template id="s_masonry_block" inherit_id="website.s_masonry_block">
+    <template id="s_masonry_block_default_template" inherit_id="website.s_masonry_block_default_template">
         <!-- Column 1 -->
         <xpath expr="(//div[hasclass('col-lg-6')])[3]" position="replace">
             <div class="col-lg-6 o_cc o_cc4 text-center">

--- a/theme_zap/views/snippets/s_masonry_block.xml
+++ b/theme_zap/views/snippets/s_masonry_block.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <odoo>
-    <template id="s_masonry_block" inherit_id="website.s_masonry_block">
+    <template id="s_masonry_block_default_template" inherit_id="website.s_masonry_block_default_template">
         <!-- Block #01 -->
         <xpath expr="//div[hasclass('col-lg-6')][2]//div[hasclass('col-lg-6')]/*" position="before">
             <i class="fa fa-star fa-1x text-secondary rounded shadow-sm mx-auto mb-3"/>


### PR DESCRIPTION
The PR odoo/odoo#67361 modifies the website.s_masonry_block template
and make it call website.s_masonry_block_default_template The xpaths
should now be done in a template inheriting from website.s_masonry_
block_default_template instead.