### PR TITLE
[FIX] theme_nano: remove breaking container padding removals

### DIFF
--- a/theme_nano/views/snippets/s_image_text.xml
+++ b/theme_nano/views/snippets/s_image_text.xml
@@ -7,7 +7,7 @@
         <attribute name="class" add="o_cc o_cc5 pt48 pb48" remove="pt32 pb32" separator=" "/>
     </xpath>
     <xpath expr="//*[hasclass('container')]" position="attributes">
-        <attribute name="class" add="container-fluid px-0" remove="container" separator=" "/>
+        <attribute name="class" add="container-fluid" remove="container" separator=" "/>
     </xpath>
     <!-- Image + Shape -->
     <xpath expr="//img" position="attributes">

--- a/theme_nano/views/snippets/s_images_wall.xml
+++ b/theme_nano/views/snippets/s_images_wall.xml
@@ -8,7 +8,7 @@
     </xpath>
     <!-- Content -->
     <xpath expr="//*[hasclass('container')]" position="attributes">
-        <attribute name="class" add="container-fluid px-0" remove="container" separator=" "/>
+        <attribute name="class" add="container-fluid" remove="container" separator=" "/>
     </xpath>
 </template>
 

--- a/theme_nano/views/snippets/s_text_image.xml
+++ b/theme_nano/views/snippets/s_text_image.xml
@@ -7,7 +7,7 @@
         <attribute name="class" add="o_cc o_cc5 pt48 pb48" remove="pt32 pb32" separator=" "/>
     </xpath>
     <xpath expr="//*[hasclass('container')]" position="attributes">
-        <attribute name="class" add="container-fluid px-0" remove="container" separator=" "/>
+        <attribute name="class" add="container-fluid" remove="container" separator=" "/>
     </xpath>
     <!-- Image + Shape -->
     <xpath expr="//img" position="attributes">

--- a/theme_nano/views/snippets/s_three_columns.xml
+++ b/theme_nano/views/snippets/s_three_columns.xml
@@ -7,7 +7,7 @@
         <attribute name="class" add="o_cc5 pt64 pb64" remove="o_cc2 pt32 pb32" separator=" "/>
     </xpath>
     <xpath expr="//*[hasclass('container')]" position="attributes">
-        <attribute name="class" add="container-fluid px-0" remove="container" separator=" "/>
+        <attribute name="class" add="container-fluid" remove="container" separator=" "/>
     </xpath>
     <!-- Column #01 -->
     <xpath expr="//*[hasclass('card-title')]" position="replace" mode="inner">


### PR DESCRIPTION
Removing the container padding in some cases may be fine but cannot
be done because would create horizontal scrollbars in full-width mode
or simply on mobile devices.

To further improve with task-2241779