### PR TITLE
[FIX] theme_bistro, theme_monglia: prevent scroll button editing

### DIFF
--- a/theme_bistro/views/snippets/s_cover.xml
+++ b/theme_bistro/views/snippets/s_cover.xml
@@ -22,7 +22,7 @@
         </xpath>
         <!-- Scroll Down button -->
         <xpath expr="//div[hasclass('container')]" position="after">
-            <a class="o_scroll_button rounded-circle align-items-center justify-content-center mx-auto bg-o-color-5 mb-2" href="#" title="Scroll down to next section">
+            <a class="o_scroll_button rounded-circle align-items-center justify-content-center mx-auto bg-o-color-5 mb-2 o_not_editable" href="#" contenteditable="false" title="Scroll down to next section">
                 <i class="fa fa-angle-down fa-2x"/>
             </a>
         </xpath>

--- a/theme_monglia/views/customizations.xml
+++ b/theme_monglia/views/customizations.xml
@@ -38,7 +38,7 @@
     </xpath>
 
     <xpath expr="//div[hasclass('container')]" position="after">
-        <a class="o_scroll_button rounded-circle align-items-center justify-content-center mx-auto bg-primary text-o-color-4 mb-2" href="#" contenteditable="false" title="Scroll down to next section">
+        <a class="o_scroll_button rounded-circle align-items-center justify-content-center mx-auto bg-primary text-o-color-4 mb-2 o_not_editable" href="#" contenteditable="false" title="Scroll down to next section">
             <i class="fa fa-angle-down fa-3x"/>
         </a>
     </xpath>


### PR DESCRIPTION
Before this commit, it was possible to edit the scroll button of the
cover snippet in Bistro and Monglia themes.

task-2656662