### PR TITLE
[FIX] *: increase text contrast for cover snippet

### DIFF
--- a/theme_kea/views/snippets/s_cover.xml
+++ b/theme_kea/views/snippets/s_cover.xml
@@ -4,14 +4,13 @@
 <template id="s_cover" inherit_id="website.s_cover">
     <!-- Section -->
     <xpath expr="//section" position="attributes">
-        <attribute name="class" add="oe_img_bg o_full_screen_height" remove="parallax s_parallax_is_fixed bg-black-50" separator=" "/>
+        <attribute name="class" add="oe_img_bg o_full_screen_height" remove="parallax s_parallax_is_fixed" separator=" "/>
         <attribute name="data-scroll-background-ratio">0</attribute>
         <attribute name="data-oe-shape-data">{"shape":"web_editor/Floats/02","flip":[]}</attribute>
         <attribute name="style">background-image: url('/web/image/website.s_cover_default_image'); background-position: 50% 0;</attribute>
     </xpath>
     <!-- Update Filter & Add Shape -->
-    <xpath expr="//div[hasclass('o_we_bg_filter')]" position="replace">
-        <div class="o_we_bg_filter" style="background-color: rgba(0, 0, 0, 0.10)"/>
+    <xpath expr="//div[hasclass('o_we_bg_filter')]" position="after">
         <div class="o_we_shape o_web_editor_Floats_02"/>
     </xpath>
     <!-- Disable Parallax -->

--- a/theme_nano/views/snippets/s_cover.xml
+++ b/theme_nano/views/snippets/s_cover.xml
@@ -12,7 +12,6 @@
     <xpath expr="//*[hasclass('container')]" position="before">
         <div class="o_we_shape o_web_editor_Bold_12_001 o_we_flip_x"/>
     </xpath>
-    <xpath expr="//*[hasclass('o_we_bg_filter')]" position="replace"/>
     <xpath expr="//*[hasclass('s_parallax_bg')]" position="replace"/>
     <!-- Title & Text -->
     <xpath expr="//h1//font" position="replace" mode="inner">
@@ -24,4 +23,3 @@
 </template>
 
 </odoo>
-

--- a/theme_orchid/views/snippets/s_cover.xml
+++ b/theme_orchid/views/snippets/s_cover.xml
@@ -11,10 +11,6 @@
     <xpath expr="//div[hasclass('container')]" position="before">
         <div class="o_we_shape o_web_editor_Wavy_01_001"/>
     </xpath>
-    <!-- Filter -->
-    <xpath expr="//div[hasclass('o_we_bg_filter')]" position="attributes">
-        <attribute name="class" add="bg-black-25" remove="bg-black-50" separator=" "/>
-    </xpath>
     <!-- Title -->
     <xpath expr="//h1" position="replace" mode="inner">
         Live life in full bloom


### PR DESCRIPTION
\*: theme_kea, theme_orchid, theme_nano

The theme customization of the cover snippet was not perfect for those
themes. In particular for the Kea theme where the text was not forced to
white anymore (leaving the default black) and the background filter was
pratically removed, leaving the snippet's text properly contrast with
light brackgrounds but be barely visible with dark backgrounds.

Unfortunately, the Kea theme is the most used currently, alongside the
"Software company" industry... which uses a dark background for the
cover image.