### PR TITLE
[FIX] test_themes: add a test which goes over all theme tours

### DIFF
--- a/test_themes/tests/test_crawl.py
+++ b/test_themes/tests/test_crawl.py
@@ -26,3 +26,18 @@ class Crawler(HttpCase):
         # 2. Test as admin
         self.authenticate('admin', 'admin')
         test_crawling()
+
+    # Note: this test is also really useful to build the default pages
+    # automatically by adding cr.commit() at the end of the tour
+    def test_02_homepage_tour_every_theme(self):
+        # TODO All the theme tours that are runned during this test should be
+        # improved so that each step properly checks that the previous step
+        # actually had an effect (as those tours are normally made to display to
+        # the user and were not designed for testing). However, this is already
+        # really useful as only checking if *entering* edit mode in each theme
+        # does not crash is already covering most issues that can be created
+        # when designing a theme at the moment.
+        Website = self.env['website']
+        websites_themes = Website.get_test_themes_websites()
+        for website in websites_themes:
+            self.start_tour(f"/?fw={website.id}", 'homepage', login='admin')


### PR DESCRIPTION
This is a backport of [1] which at the same time finally enables the
test to be able to test all theme tours. Notice that the tours should
be improved so that each step properly checks that the previous step
actually had an effect (as those tours are normally made to display to
the user and were not designed for testing). However, this is already
really useful as only checking if *entering* edit mode in each theme
does not crash is already covering most issues that can be created when
designing a theme at the moment.

[1]: https://github.com/odoo/design-themes/commit/52fef46388ec880af78c5a5f3e6152c4510548f4

COMMUNITY PR: https://github.com/odoo/odoo/pull/80936