### PR TITLE
[FIX] theme_*: fix the activation and deactivation of assets

### DIFF
--- a/theme_artists/models/theme_artists.py
+++ b/theme_artists/models/theme_artists.py
@@ -15,5 +15,5 @@ class ThemeArtists(models.AbstractModel):
         self.disable_view('website.footer_custom')
         self.enable_view('website.template_footer_centered')
 
-        self.enable_asset('website.ripple_effect_scss')
-        self.enable_asset('website.ripple_effect_js')
+        self.enable_asset('Ripple effect SCSS')
+        self.enable_asset('Ripple effect JS')

--- a/theme_aviato/models/theme_aviato.py
+++ b/theme_aviato/models/theme_aviato.py
@@ -8,3 +8,6 @@ class ThemeAviato(models.AbstractModel):
         self.disable_view('website.footer_custom')
         self.enable_view('website.template_footer_contact')
         self.enable_view('website.template_footer_slideout')
+
+        self.enable_asset('Ripple effect SCSS')
+        self.enable_asset('Ripple effect JS')

--- a/theme_bewise/models/theme_bewise.py
+++ b/theme_bewise/models/theme_bewise.py
@@ -11,5 +11,5 @@ class ThemeBewise(models.AbstractModel):
         self.disable_view('website.footer_custom')
         self.enable_view('website.template_footer_headline')
 
-        self.enable_asset('website.ripple_effect_scss')
-        self.enable_asset('website.ripple_effect_js')
+        self.enable_asset('Ripple effect SCSS')
+        self.enable_asset('Ripple effect JS')

--- a/theme_bewise/static/src/scss/primary_variables.scss
+++ b/theme_bewise/static/src/scss/primary_variables.scss
@@ -117,6 +117,7 @@ $o-website-values-palettes: (
         'btn-font-size-lg': 1.65rem,
         'btn-padding-y-lg': .5rem,
         'btn-padding-x-lg': 2.5rem,
+        'btn-ripple': true,
     ),
 );
 

--- a/theme_bistro/models/theme_bistro.py
+++ b/theme_bistro/models/theme_bistro.py
@@ -17,5 +17,5 @@ class ThemeBistro(models.AbstractModel):
         self.enable_view('website.template_footer_slideout')
         self.enable_view('website.option_footer_scrolltop')
 
-        self.enable_asset('website.ripple_effect_scss')
-        self.enable_asset('website.ripple_effect_js')
+        self.enable_asset('Ripple effect SCSS')
+        self.enable_asset('Ripple effect JS')

--- a/theme_buzzy/models/theme_buzzy.py
+++ b/theme_buzzy/models/theme_buzzy.py
@@ -7,3 +7,6 @@ class ThemeBuzzy(models.AbstractModel):
     def _theme_buzzy_post_copy(self, mod):
         self.disable_view('website.footer_custom')
         self.enable_view('website.template_footer_minimalist')
+
+        self.enable_asset('Ripple effect SCSS')
+        self.enable_asset('Ripple effect JS')

--- a/theme_cobalt/models/theme_cobalt.py
+++ b/theme_cobalt/models/theme_cobalt.py
@@ -8,6 +8,6 @@ class ThemeCobalt(models.AbstractModel):
         # For compatibility
         # self.enable_asset('theme_common.compatibility_saas_10_2')
 
-        self.enable_asset('website.ripple_effect_scss')
-        self.enable_asset('website.ripple_effect_js')
+        self.enable_asset('Ripple effect SCSS')
+        self.enable_asset('Ripple effect JS')
         self.enable_header_off_canvas()

--- a/theme_common/models/theme_common.py
+++ b/theme_common/models/theme_common.py
@@ -6,13 +6,13 @@ class ThemeCommon(models.AbstractModel):
 
     def _theme_common_post_copy(self, mod):
         # Reset all default color when switching themes
-        self.disable_asset('theme_common.option_colors_02_variables')
-        self.disable_asset('theme_common.option_colors_03_variables')
-        self.disable_asset('theme_common.option_colors_04_variables')
-        self.disable_asset('theme_common.option_colors_05_variables')
-        self.disable_asset('theme_common.option_colors_06_variables')
-        self.disable_asset('theme_common.option_colors_07_variables')
-        self.disable_asset('theme_common.option_colors_08_variables')
+        self.disable_asset('Option colors 02 variables SCSS')
+        self.disable_asset('Option colors 03 variables SCSS')
+        self.disable_asset('Option colors 04 variables SCSS')
+        self.disable_asset('Option colors 05 variables SCSS')
+        self.disable_asset('Option colors 06 variables SCSS')
+        self.disable_asset('Option colors 07 variables SCSS')
+        self.disable_asset('Option colors 08 variables SCSS')
 
         # For compatibility
         # self.enable_asset('theme_common.compatibility_saas_11_4_variables')

--- a/theme_graphene/models/theme_graphene.py
+++ b/theme_graphene/models/theme_graphene.py
@@ -15,5 +15,5 @@ class ThemeGraphene(models.AbstractModel):
         self.disable_view('website.footer_custom')
         self.enable_view('website.template_footer_centered')
 
-        self.enable_asset('website.ripple_effect_scss')
-        self.enable_asset('website.ripple_effect_js')
+        self.enable_asset('Ripple effect SCSS')
+        self.enable_asset('Ripple effect JS')

--- a/theme_nano/models/theme_nano.py
+++ b/theme_nano/models/theme_nano.py
@@ -16,7 +16,7 @@ class ThemeNano(models.AbstractModel):
         self.enable_view('website.template_footer_slideout')
         self.enable_view('website.option_footer_scrolltop')
 
-        self.enable_asset('website.ripple_effect_scss')
-        self.enable_asset('website.ripple_effect_js')
+        self.enable_asset('Ripple effect SCSS')
+        self.enable_asset('Ripple effect JS')
 
         self.disable_view('portal.footer_language_selector')

--- a/theme_paptic/models/theme_paptic.py
+++ b/theme_paptic/models/theme_paptic.py
@@ -8,7 +8,7 @@ class ThemePaptic(models.AbstractModel):
         # For compatibility
         # self.enable_asset('theme_common.compatibility_saas_10_2')
 
-        self.enable_asset('website.ripple_effect_scss')
-        self.enable_asset('website.ripple_effect_js')
+        self.enable_asset('Ripple effect SCSS')
+        self.enable_asset('Ripple effect JS')
         self.enable_view('website.template_footer_centered')
         self.enable_header_off_canvas()

--- a/theme_real_estate/models/theme_real_estate.py
+++ b/theme_real_estate/models/theme_real_estate.py
@@ -8,5 +8,5 @@ class ThemeRealEstate(models.AbstractModel):
         # For compatibility
         # self.enable_asset('theme_common.compatibility_saas_10_2')
 
-        self.enable_asset('website.ripple_effect_scss')
-        self.enable_asset('website.ripple_effect_js')
+        self.enable_asset('Ripple effect SCSS')
+        self.enable_asset('Ripple effect JS')

--- a/theme_real_estate/static/src/scss/primary_variables.scss
+++ b/theme_real_estate/static/src/scss/primary_variables.scss
@@ -98,6 +98,7 @@ $o-website-values-palettes: (
         'btn-border-radius': 0px,
         'btn-border-radius-sm': 0px,
         'btn-border-radius-lg': 0px,
+        'btn-ripple': true,
     ),
 );
 

--- a/theme_treehouse/models/theme_treehouse.py
+++ b/theme_treehouse/models/theme_treehouse.py
@@ -13,5 +13,5 @@ class ThemeTreehouse(models.AbstractModel):
         self.enable_view('website.template_footer_slideout')
         self.enable_view('website.option_footer_scrolltop')
 
-        self.enable_asset('website.ripple_effect_scss')
-        self.enable_asset('website.ripple_effect_js')
+        self.enable_asset('Ripple effect SCSS')
+        self.enable_asset('Ripple effect JS')

--- a/theme_yes/models/theme_yes.py
+++ b/theme_yes/models/theme_yes.py
@@ -7,3 +7,6 @@ class ThemeYes(models.AbstractModel):
     def _theme_yes_post_copy(self, mod):
         self.disable_view('website.footer_custom')
         self.enable_view('website.template_footer_descriptive')
+
+        self.enable_asset('Ripple effect SCSS')
+        self.enable_asset('Ripple effect JS')

--- a/theme_zap/models/theme_zap.py
+++ b/theme_zap/models/theme_zap.py
@@ -12,5 +12,5 @@ class ThemeZap(models.AbstractModel):
         self.disable_view('website.footer_custom')
         self.enable_view('website.template_footer_links')
 
-        self.enable_asset('website.ripple_effect_scss')
-        self.enable_asset('website.ripple_effect_js')
+        self.enable_asset('Ripple effect SCSS')
+        self.enable_asset('Ripple effect JS')


### PR DESCRIPTION
Before this commit:

- The assets were not enabled or disabled when installing themes because
we searched for assets with the "key" field instead of the "name" field.

- The "Ripple Effect" was not correctly installed on several themes.
Because the variable and the assets were not both activated. Even if the
variable is not used, it is still necessary for the proper functioning
of the option (e.g. computeWidgetState).

task-2686370