### PR TITLE
Master fix text bold bvr

### DIFF
--- a/theme_artists/views/snippets/s_call_to_action.xml
+++ b/theme_artists/views/snippets/s_call_to_action.xml
@@ -13,7 +13,7 @@
     </xpath>
     <!-- Title & Paragraph -->
     <xpath expr="//h3" position="replace" mode="inner">
-        <b>Want to discover more?</b>
+        <span style="font-weight: bold;">Want to discover more?</span>
     </xpath>
     <xpath expr="//p" position="replace" mode="inner">
         Contact me for a visit of my studio.

--- a/theme_artists/views/snippets/s_carousel.xml
+++ b/theme_artists/views/snippets/s_carousel.xml
@@ -16,7 +16,7 @@
     <xpath expr="//div[hasclass('carousel-item')]//div[hasclass('carousel-content')]" position="replace">
         <div class="carousel-content col-lg-12 pb112 pt112">
             <h2 style="text-align: center;">Aquitani</h2>
-            <p class="lead" style="text-align: center;"><b>Photoshoot / June 2021</b></p>
+            <p class="lead" style="text-align: center;"><span style="font-weight: bold;">Photoshoot / June 2021</span></p>
             <p style="text-align: center;">
                 <a href="#" class="btn btn-primary btn-lg mb-2">Discover</a>
             </p>
@@ -37,7 +37,7 @@
     <xpath expr="//div[hasclass('carousel-item')][2]//div[hasclass('carousel-content')]" position="replace">
         <div class="carousel-content col-lg-12 pb112 pt112">
             <h2 style="text-align: center;">Immemorabili</h2>
-            <p class="lead" style="text-align: center;"><b>Painting concept / April 2021</b></p>
+            <p class="lead" style="text-align: center;"><span style="font-weight: bold;">Painting concept / April 2021</span></p>
             <p style="text-align: center;">
                 <a href="#" class="btn btn-primary btn-lg mb-2">Discover</a>
             </p>
@@ -58,7 +58,7 @@
     <xpath expr="//div[hasclass('carousel-item')][3]//div[hasclass('carousel-content')]" position="replace">
         <div class="carousel-content col-lg-12 pb112 pt112">
             <h2 style="text-align: center;">Vincam</h2>
-            <p class="lead" style="text-align: center;"><b>Typographic collection / March 2021</b></p>
+            <p class="lead" style="text-align: center;"><span style="font-weight: bold;">Typographic collection / March 2021</span></p>
             <p style="text-align: center;">
                 <a href="#" class="btn btn-primary btn-lg mb-2">Discover</a>
             </p>

--- a/theme_avantgarde/views/customizations.xml
+++ b/theme_avantgarde/views/customizations.xml
@@ -38,7 +38,7 @@
     </xpath>
     <xpath expr="//font" position="attributes">
         <attribute name="class" add="text-break" separator=" "/>
-        <attribute name="style" add="font-weight: bolder;" separator=" "/>
+        <attribute name="style" add="font-weight: bold;" separator=" "/>
     </xpath>
     <xpath expr="//font" position="replace" mode="inner">
         Design Methodology
@@ -80,7 +80,7 @@
         <attribute name="style">border-color: rgb(11, 13, 99) !important; box-shadow: rgb(11, 13, 99) -25px -25px 0px 0px !important; border-width: 8px !important;</attribute>
     </xpath>
     <xpath expr="//h3" position="replace" mode="inner">
-        <span style="font-weight: bolder;">Excellence</span>
+        <span style="font-weight: bold;">Excellence</span>
     </xpath>
     <xpath expr="(//p[hasclass('card-text')])[1]" position="replace" mode="inner">
         We conduct state-of-the-art research and development to solve complex design challenges, taking the latest advances out of the lab and into the hands of architects and engineers.</xpath>
@@ -89,7 +89,7 @@
         <attribute name="style">border-color: rgb(255, 255, 255) !important; border-width: 8px !important; box-shadow: rgb(78, 77, 77) 0px 0px 100px -40px !important;</attribute>
     </xpath>
     <xpath expr="(//h3)[2]" position="replace" mode="inner">
-        <span style="font-weight: bolder;">Collaboration</span>
+        <span style="font-weight: bold;">Collaboration</span>
     </xpath>
     <xpath expr="(//p[hasclass('card-text')])[2]" position="replace" mode="inner">
         We thrive on rich collaborations to push our thinking. A continuous state of reinvention, driven by our partners in the process, is essential to our work.
@@ -99,7 +99,7 @@
         <attribute name="style">box-shadow: rgb(240, 142, 128) 25px 25px 0px 0px !important; border-color: rgb(240, 142, 128) !important; border-width: 8px !important;</attribute>
     </xpath>
     <xpath expr="(//h3)[3]" position="replace" mode="inner">
-        <span style="font-weight: bolder;">Sustainability</span>
+        <span style="font-weight: bold;">Sustainability</span>
     </xpath>
     <xpath expr="(//p[hasclass('card-text')])[3]" position="replace" mode="inner">
         Sustainability is at the heart of our design approach. We audit projects against global standards as well as our own, more comprehensive, responsibility framework.
@@ -115,7 +115,7 @@
         <attribute name="class" add="col-lg-4 offset-lg-1" remove="col-lg-6" separator=" "/>
     </xpath>
     <xpath expr="//h2" position="replace" mode="inner">
-        <span class="text-break" style="font-size: 62px; font-weight: bolder;">Our R&amp;D Approach</span>
+        <span class="text-break" style="font-size: 62px; font-weight: bold;">Our R&amp;D Approach</span>
     </xpath>
     <xpath expr="//p" position="before">
         <p><br/></p>
@@ -169,7 +169,7 @@
         <div class="o_we_shape o_web_editor_Origins_14_001"/>
     </xpath>
     <xpath expr="//h3" position="replace">
-        <h3 style="text-align: right;"><b>Since 1992</b> creating around the world.</h3>
+        <h3 style="text-align: right;"><span style="font-weight: bold;">Since 1992</span> creating around the world.</h3>
     </xpath>
     <xpath expr="//p" position="replace" mode="inner">
         We partner with ambitious clients. We’d love to hear from you.

--- a/theme_aviato/views/snippets/s_cover.xml
+++ b/theme_aviato/views/snippets/s_cover.xml
@@ -20,7 +20,7 @@
     </xpath>
     <!-- Paragraphs -->
     <xpath expr="//p" position="replace" mode="inner">
-        <b>A travel agent helps you to plan your <br/> trip from start to finish.</b>
+        <span style="font-weight: bold;">A travel agent helps you to plan your <br/> trip from start to finish.</span>
         <br/>
     </xpath>
     <!-- Button -->

--- a/theme_aviato/views/snippets/s_quotes_carousel.xml
+++ b/theme_aviato/views/snippets/s_quotes_carousel.xml
@@ -7,21 +7,21 @@
         It's difficult to describe how awesome the trip was. I feel like my life has changed forever. It would take too long to describe day by day the sights, sounds, architecture, art, food, history, and people that we came across. Ireland was fantastic.
     </xpath>
     <xpath expr="(//span[hasclass('s_blockquote_author')])[1]" position="replace" mode="inner">
-        <b>Linda and Paulo</b> • From Italy
+        <span style="font-weight: bold;">Linda and Paulo</span> • From Italy
     </xpath>
     <!-- Quote 2 -->
     <xpath expr="(//div[hasclass('s_blockquote_content')])[2]/p" position="replace" mode="inner">
         As always, Odoo Travel has delivered a truly wonderful travel experience for us. Norway was a great travel destination. The parts of the country we visited were beautiful, people were friendly, everything we ate was delicious, and there were many fun things to see and do.
     </xpath>
     <xpath expr="(//span[hasclass('s_blockquote_author')])[2]" position="replace" mode="inner">
-        <b>Jacques and Marie</b> • From France
+        <span style="font-weight: bold;">Jacques and Marie</span> • From France
     </xpath>
     <!-- Quote 3 -->
     <xpath expr="(//div[hasclass('s_blockquote_content')])[3]/p" position="replace"  mode="inner">
         We would like to thank Odoo Travel for organising wonderful tour for us in Delhi, Agra and Rajasthan. Everything was very well organised. Thank you very much for everything!
     </xpath>
     <xpath expr="(//span[hasclass('s_blockquote_author')])[3]" position="replace" mode="inner">
-        <b>Rose and Peter</b> • From United Kingdom
+        <span style="font-weight: bold;">Rose and Peter</span> • From United Kingdom
     </xpath>
 </template>
 

--- a/theme_aviato/views/snippets/s_text_image.xml
+++ b/theme_aviato/views/snippets/s_text_image.xml
@@ -8,7 +8,7 @@
     </xpath>
     <!-- Title -->
     <xpath expr="//h2" position="replace" mode="inner">
-        What we can do, <b>for you</b>
+        What we can do, <span style="font-weight: bold;">for you</span>
     </xpath>
     <!-- Paragraph -->
     <xpath expr="//p[1]" position="replace" mode="inner">

--- a/theme_bewise/views/customizations.xml
+++ b/theme_bewise/views/customizations.xml
@@ -181,7 +181,7 @@
         I have learned a lot, and I have realised professional projects thanks to the support of the mentors! The team is always at the top and always looking for solutions to problems, I felt accompanied and supported! It's not easy every day, but it's a great adventure!
     </xpath>
     <xpath expr="//span[hasclass('s_blockquote_author')]" position="replace" mode="inner">
-        <b>Iris DOE</b> • Graduated in 2019
+        <span style="font-weight: bold;">Iris DOE</span> • Graduated in 2019
     </xpath>
     <!-- Slide #2 -->
     <xpath expr="//div[hasclass('carousel-item')][2]" position="attributes">
@@ -200,7 +200,7 @@
         Thanks to its innovative system, the school offers a diplomatic training during which we are followed by a "mentor", a sort of "tutor"!
     </xpath>
     <xpath expr="(//span[hasclass('s_blockquote_author')])[2]" position="replace" mode="inner">
-        <b>Jane DOE</b> • Graduated in 2017
+        <span style="font-weight: bold;">Jane DOE</span> • Graduated in 2017
     </xpath>
     <!-- Slide #3 -->
     <xpath expr="//div[hasclass('carousel-item')][3]" position="attributes">
@@ -219,7 +219,7 @@
         Great support and quality courses! A mentor helps you move forward and can be contacted through flexible schedules. Everything you need to start your career on the web.
     </xpath>
     <xpath expr="(//span[hasclass('s_blockquote_author')])[3]" position="replace" mode="inner">
-        <b>John DOE</b> • Graduated in 2016
+        <span style="font-weight: bold;">John DOE</span> • Graduated in 2016
     </xpath>
 </template>
 
@@ -234,7 +234,7 @@
     </xpath>
     <!-- Title -->
     <xpath expr="//h3" position="replace">
-        <h4><b>3,000 students</b> graduate each year find a job within 2 months</h4>
+        <h4><span style="font-weight: bold;">3,000 students</span> graduate each year find a job within 2 months</h4>
     </xpath>
     <!-- Subtitle -->
     <xpath expr="//div[hasclass('col-lg-9')]/p" position="replace" mode="inner">
@@ -256,28 +256,28 @@
     </xpath>
     <!-- Profile #1 -->
     <xpath expr="//div[hasclass('s_nb_column_fixed')]/div//h4" position="replace" mode="inner">
-        <b>Tony Fred, Faculty Head of IT</b>
+        <span style="font-weight: bold;">Tony Fred, Faculty Head of IT</span>
     </xpath>
     <xpath expr="//div[hasclass('s_nb_column_fixed')]/div//p" position="replace" mode="inner">
         Tony received a degree in Electrical and Mechanical Engineering and a Ph D. degree in 1998 and 2004. After a post-doctoral experience  he joined the school as professor of mechatronics in 2006. In 2010, he became Head of IT.
     </xpath>
     <!-- Profile #2 -->
     <xpath expr="//div[hasclass('s_nb_column_fixed')]/div[2]//h4" position="replace" mode="inner">
-        <b>Mich Stark, IT Officer</b>
+        <span style="font-weight: bold;">Mich Stark, IT Officer</span>
     </xpath>
     <xpath expr="//div[hasclass('s_nb_column_fixed')]/div[2]//p" position="replace" mode="inner">
         He is professor in the Institute of Mechanics, Materials and Civil Engineering since 2000. He lectures in mechanical drawing and mechanical design for undergraduate and graduate students. He is active in Problem and Project based learning. He is the promoter of 8 doctoral theses.
     </xpath>
     <!-- Profile #3 -->
     <xpath expr="//div[hasclass('s_nb_column_fixed')]/div[3]//h4" position="replace" mode="inner">
-        <b>Aline Turner, Law professor</b>
+        <span style="font-weight: bold;">Aline Turner, Law professor</span>
     </xpath>
     <xpath expr="//div[hasclass('s_nb_column_fixed')]/div[3]//p" position="replace" mode="inner">
         She has been practicing law at the French-speaking Brussels Bar since 2006. She has worked in various major law firms based in Brussels, as member and then head of their litigation/arbitration practice groups.
     </xpath>
     <!-- Profile #4 -->
     <xpath expr="//div[hasclass('s_nb_column_fixed')]/div[4]//h4" position="replace" mode="inner">
-        <b>Iris Joe, team leader professor</b>
+        <span style="font-weight: bold;">Iris Joe, team leader professor</span>
     </xpath>
 </template>
 

--- a/theme_bistro/views/snippets/s_features.xml
+++ b/theme_bistro/views/snippets/s_features.xml
@@ -10,7 +10,7 @@
         Breakfast
     </xpath>
     <xpath expr="//p" position="replace" mode="inner">
-        Help you start your morning right.<br/><small>From <b>7:30 pm</b> to <b>10:30 pm</b></small>
+        Help you start your morning right.<br/><small>From <span style="font-weight: bold;">7:30 pm</span> to <span style="font-weight: bold;">10:30 pm</span></small>
     </xpath>
     <!-- Column #02 -->
     <xpath expr="(//i)[2]" position="replace">
@@ -20,7 +20,7 @@
         Lunch
     </xpath>
     <xpath expr="(//p)[2]" position="replace" mode="inner">
-        Take a break from your busy schedule.<br/><small>From <b>11:30 pm</b> to <b>14:30 am</b></small>
+        Take a break from your busy schedule.<br/><small>From <span style="font-weight: bold;">11:30 pm</span> to <span style="font-weight: bold;">14:30 am</span></small>
     </xpath>
     <!-- Column #03 -->
     <xpath expr="(//i)[3]" position="replace">
@@ -30,7 +30,7 @@
         Dinner
     </xpath>
     <xpath expr="(//p)[3]" position="replace" mode="inner">
-        Enjoy tasty food with friends.<br/><small>From <b>6:30 am</b> to <b>10:30 am</b></small>
+        Enjoy tasty food with friends.<br/><small>From <span style="font-weight: bold;">6:30 am</span> to <span style="font-weight: bold;">10:30 am</span></small>
     </xpath>
 </template>
 

--- a/theme_bistro/views/snippets/s_text_block.xml
+++ b/theme_bistro/views/snippets/s_text_block.xml
@@ -12,11 +12,11 @@
     </xpath>
     <!-- Paragraph #01 -->
     <xpath expr="//p" position="replace" mode="inner">
-        A healthy kitchen with local products. We’re constantly looking to propose new products and receipts. <b>While respecting seasons' products and nature.</b>
+        A healthy kitchen with local products. We’re constantly looking to propose new products and receipts. <span style="font-weight: bold;">While respecting seasons' products and nature.</span>
     </xpath>
     <!-- Paragraph #02 -->
     <xpath expr="//p[2]" position="replace" mode="inner">
-        At the Bistro, you can expect a healthy kitchen on a daily basis. <br/>Come and visit us for a Sunday brunch, healthy juices full of nutrition, or delicious cakes that satisfy your sweet tooth. <b>And each day, you’ll discover our Today’s Special.</b>
+        At the Bistro, you can expect a healthy kitchen on a daily basis. <br/>Come and visit us for a Sunday brunch, healthy juices full of nutrition, or delicious cakes that satisfy your sweet tooth. <span style="font-weight: bold;">And each day, you’ll discover our Today’s Special.</span>
     </xpath>
 </template>
 

--- a/theme_buzzy/views/snippets/s_call_to_action.xml
+++ b/theme_buzzy/views/snippets/s_call_to_action.xml
@@ -21,7 +21,7 @@
     </xpath>
     <!-- Title -->
     <xpath expr="//h3" position="replace" mode="inner">
-        <b>Start to build</b> your robust activity with these powerful tools
+        <span style="font-weight: bold;">Start to build</span> your robust activity with these powerful tools
     </xpath>
     <!-- Paragraph -->
     <xpath expr="//div[hasclass('row')]//p" position="replace" mode="inner">

--- a/theme_clean/views/snippets/s_call_to_action.xml
+++ b/theme_clean/views/snippets/s_call_to_action.xml
@@ -16,7 +16,7 @@
         <attribute name="class" add="pt16" remove="pb16" separator=" "/>
     </xpath>
     <xpath expr="//h3" position="replace" mode="inner">
-        <b>50,000 people</b>, run Clean to grow their financial wealth.
+        <span style="font-weight: bold;">50,000 people</span>, run Clean to grow their financial wealth.
     </xpath>
     <xpath expr="//p" position="replace" mode="inner">
         Join them and make the right money move.

--- a/theme_clean/views/snippets/s_cover.xml
+++ b/theme_clean/views/snippets/s_cover.xml
@@ -17,7 +17,7 @@
     </xpath>
     <!-- Title & Paragraph -->
     <xpath expr="//h1" position="replace" mode="inner">
-        <b>Sell from your couch</b>
+        <span style="font-weight: bold;">Sell from your couch</span>
     </xpath>
     <xpath expr="//p[hasclass('lead')]" position="replace" mode="inner">
         Make your finances reach a new level with our online management system. <br/>Track every penny, directly from the confort of your home.

--- a/theme_clean/views/snippets/s_title.xml
+++ b/theme_clean/views/snippets/s_title.xml
@@ -16,7 +16,7 @@
     </xpath>
     <!-- Title -->
     <xpath expr="//h1" position="replace" mode="inner">
-        <b>We create the perfect <br/>tailored solution for you</b>
+        <span style="font-weight: bold;">We create the perfect <br/>tailored solution for you</span>
     </xpath>
 </template>
 

--- a/theme_cobalt/views/customizations.xml
+++ b/theme_cobalt/views/customizations.xml
@@ -74,7 +74,7 @@
     </xpath>
     <!-- Content -->
     <xpath expr="//h2" position="replace" mode="inner">
-        What we can do, <b>for you</b><br/>
+        What we can do, <span style="font-weight: bold;">for you</span><br/>
     </xpath>
     <xpath expr="//img" position="replace">
             <img src="/web_editor/shape/theme_cobalt/s_text_image.svg?c1=o-color-1" style="width: 100%;" alt="Marketing"/>

--- a/theme_enark/views/snippets/s_call_to_action.xml
+++ b/theme_enark/views/snippets/s_call_to_action.xml
@@ -4,7 +4,7 @@
 <template id="s_call_to_action" inherit_id="website.s_call_to_action">
     <!-- Paragraph -->
     <xpath expr="//h3" position="replace" mode="inner">
-        As <b>436 clients</b> before you, let’s work together
+        As <span style="font-weight: bold;">436 clients</span> before you, let’s work together
     </xpath>
     <xpath expr="//p" position="replace"/>
 </template>

--- a/theme_graphene/views/customizations.xml
+++ b/theme_graphene/views/customizations.xml
@@ -17,7 +17,7 @@
         <div class="row">
             <div class="col col-lg-11">
                 <h1 style="text-align: right;">
-                    <b>Making the difference.</b>
+                    <span style="font-weight: bold;">Making the difference.</span>
                 </h1>
                 <p class="lead o_default_snippet_text" style="text-align: right">
                     Our mission is to give customers the best experience.<br/>Extensive documentation &amp; guides, an active community,<br/>24/7 support make it a pleasure to work with us.
@@ -140,25 +140,25 @@
         <div class="o_we_shape o_web_editor_Origins_05"/>
     </xpath>
     <xpath expr="//div[hasclass('s_nb_column_fixed')]/div//h4" position="replace" mode="inner">
-        Tony Fred, <small><b>CEO</b></small>
+        Tony Fred, <small><span style="font-weight: bold;">CEO</span></small>
     </xpath>
     <xpath expr="//div[hasclass('s_nb_column_fixed')]/div//p" position="replace">
         <small>Founder and chief visionary, Tony is the driving force behind the company. He loves to keep his hands full by participating in the development of the software, marketing, and customer experience strategies.</small>
     </xpath>
     <xpath expr="//div[hasclass('s_nb_column_fixed')]/div[2]//h4" position="replace" mode="inner">
-        Mich Stark, <small><b>COO</b></small>
+        Mich Stark, <small><span style="font-weight: bold;">COO</span></small>
     </xpath>
     <xpath expr="//div[hasclass('s_nb_column_fixed')]/div[2]//p" position="replace" mode="inner">
         <small>Mich loves taking on challenges. With his multi-year experience as Commercial Director in the software industry, Mich has helped the company to get where it is today. Mich is among the best minds.</small>
     </xpath>
     <xpath expr="//div[hasclass('s_nb_column_fixed')]/div[3]//h4" position="replace" mode="inner">
-        Aline Turner, <small><b>CTO</b></small>
+        Aline Turner, <small><span style="font-weight: bold;">CTO</span></small>
     </xpath>
     <xpath expr="//div[hasclass('s_nb_column_fixed')]/div[3]//p" position="replace" mode="inner">
         <small>Aline is one of the iconic people in life who can say they love what they do. She mentors 100+ in-house developers and looks after the community of thousands of developers.</small>
     </xpath>
     <xpath expr="//div[hasclass('s_nb_column_fixed')]/div[4]//h4" position="replace" mode="inner">
-        Iris Joe, <small><b>CFO</b></small>
+        Iris Joe, <small><span style="font-weight: bold;">CFO</span></small>
     </xpath>
     <xpath expr="//div[hasclass('s_nb_column_fixed')]/div[4]//p" position="replace" mode="inner">
         <small>Iris, with her international experience, helps us easily understand the numbers and improves them. She is determined to drive success and delivers her professional acumen to bring the company to the next level.</small>
@@ -202,7 +202,7 @@
         <attribute name="class" add="o_cc5" remove="o_cc3" separator=" "/>
     </xpath>
     <xpath expr="//h3" position="replace">
-        <h3 style="text-align: right;"><b>50,000+ companies</b> run our software.</h3>
+        <h3 style="text-align: right;"><span style="font-weight: bold;">50,000+ companies</span> run our software.</h3>
     </xpath>
     <xpath expr="//div[hasclass('col-lg-9')]" position="attributes">
         <attribute name="class" add="col-lg-8" remove="col-lg-9" separator=" "/>

--- a/theme_kea/views/snippets/s_features.xml
+++ b/theme_kea/views/snippets/s_features.xml
@@ -14,7 +14,7 @@
         <i class="fa fa-2x fa-image bg-o-color-1 m-3 rounded-circle"/>
     </xpath>
     <xpath expr="//div[hasclass('row')]/div[1]/h3" position="replace" mode="inner">
-        <b>Stunning visuals</b>
+        <span style="font-weight: bold;">Stunning visuals</span>
     </xpath>
     <xpath expr="//div[hasclass('row')]/div[1]/p" position="replace" mode="inner">
         Tell what's the value for the customer for this feature.
@@ -27,7 +27,7 @@
         <i class="fa fa-2x fa-eye bg-o-color-5 m-3 rounded-circle"/>
     </xpath>
     <xpath expr="//div[hasclass('row')]/div[2]/h3" position="replace" mode="inner">
-        <b>360-degree vision</b>
+        <span style="font-weight: bold;">360-degree vision</span>
     </xpath>
     <xpath expr="//div[hasclass('row')]/div[2]/p" position="replace" mode="inner">
         Write what the customer would like to know, not what you want to show.
@@ -40,7 +40,7 @@
         <attribute name="class" add="fa-2x fa-microphone rounded-circle" remove="fa-3x fa-leaf rounded" separator=" "/>
     </xpath>
     <xpath expr="//div[hasclass('row')]/div[3]/h3" position="replace" mode="inner">
-        <b>Built in mic</b>
+        <span style="font-weight: bold;">Built in mic</span>
     </xpath>
     <xpath expr="//div[hasclass('row')]/div[3]/p" position="replace" mode="inner">
         A small explanation of this great feature, in clear words.

--- a/theme_loftspace/views/snippets/s_banner.xml
+++ b/theme_loftspace/views/snippets/s_banner.xml
@@ -22,7 +22,7 @@
     </xpath>
     <!-- Title -->
     <xpath expr="//h1" position="replace" mode="inner">
-        <b>The art of Design</b>
+        <span style="font-weight: bold;">The art of Design</span>
     </xpath>
     <xpath expr="//h1" position="after">
         <p><br/></p>

--- a/theme_loftspace/views/snippets/s_cover.xml
+++ b/theme_loftspace/views/snippets/s_cover.xml
@@ -8,7 +8,7 @@
     </xpath>
     <!-- Title -->
     <xpath expr="//h1" position="replace" mode="inner">
-        <b>Bringing life to your interior</b>
+        <span style="font-weight: bold;">Bringing life to your interior</span>
     </xpath>
     <!-- Paragraphs -->
     <xpath expr="//p[hasclass('lead')]" position="replace" mode="inner">

--- a/theme_loftspace/views/snippets/s_title.xml
+++ b/theme_loftspace/views/snippets/s_title.xml
@@ -14,7 +14,7 @@
     </xpath>
     <!-- Title -->
     <xpath expr="//h1" position="replace" mode="inner">
-        <b>Everything is designed.<br/> Few things are designed well.</b>
+        <span style="font-weight: bold;">Everything is designed.<br/> Few things are designed well.</span>
     </xpath>
 </template>
 

--- a/theme_monglia/views/customizations.xml
+++ b/theme_monglia/views/customizations.xml
@@ -180,7 +180,7 @@
         <attribute name="class" add="o_cc o_cc4" separator=" "/>
     </xpath>
     <xpath expr="//h3" position="replace">
-        <h3 style="text-align: left;"><b>APPLY FOR OUR V.I.P. CARD</b></h3>
+        <h3 style="text-align: left;"><span style="font-weight: bold;">APPLY FOR OUR V.I.P. CARD</span></h3>
     </xpath>
     <xpath expr="//p" position="replace">
         <p style="text-align: left;">The vip card allows you to benefit from tickets before everyone else.</p>

--- a/theme_notes/views/snippets/s_cover.xml
+++ b/theme_notes/views/snippets/s_cover.xml
@@ -12,7 +12,7 @@
     </xpath>
     <!-- Title -->
     <xpath expr="//h1" position="replace" mode="inner">
-        <b>Discover <br/>the Miraillet Festival</b>
+        <span style="font-weight: bold;">Discover <br/>the Miraillet Festival</span>
     </xpath>
 </template>
 

--- a/theme_odoo_experts/views/snippets/s_numbers.xml
+++ b/theme_odoo_experts/views/snippets/s_numbers.xml
@@ -14,16 +14,16 @@
     </xpath>
     <!-- Numbers -->
     <xpath expr="//span[hasclass('s_number')]" position="replace" mode="inner">
-        <b>12</b>
+        <span style="font-weight: bold;">12</span>
     </xpath>
     <xpath expr="(//span[hasclass('s_number')])[2]" position="replace" mode="inner">
-        <b>45</b>
+        <span style="font-weight: bold;">45</span>
     </xpath>
     <xpath expr="(//span[hasclass('s_number')])[3]" position="replace" mode="inner">
-        <b>8</b>
+        <span style="font-weight: bold;">8</span>
     </xpath>
     <xpath expr="(//span[hasclass('s_number')])[4]" position="replace" mode="inner">
-        <b>37</b>
+        <span style="font-weight: bold;">37</span>
     </xpath>
 </template>
 

--- a/theme_paptic/views/customizations.xml
+++ b/theme_paptic/views/customizations.xml
@@ -307,7 +307,7 @@
     </xpath>
     <!-- Title -->
     <xpath expr="//h3" position="replace" mode="inner">
-        <b>50,000+ companies</b> run Paptic to grow their businesses.
+        <span style="font-weight: bold;">50,000+ companies</span> run Paptic to grow their businesses.
     </xpath>
 </template>
 

--- a/theme_real_estate/views/snippets/s_banner.xml
+++ b/theme_real_estate/views/snippets/s_banner.xml
@@ -18,7 +18,7 @@
         <attribute name="class" add="col-lg-7 h-100 pt160 pb160" remove="col-lg-6 jumbotron rounded o_cc o_cc1 pt32 pb32" separator=" "/>
     </xpath>
     <xpath expr="//h1" position="replace" mode="inner">
-        <b>Real Estate Agency.<br/>Near You.</b>
+        <span style="font-weight: bold;">Real Estate Agency.<br/>Near You.</span>
     </xpath>
     <!-- Paragraph -->
     <xpath expr="//p" position="replace">

--- a/theme_real_estate/views/snippets/s_quotes_carousel.xml
+++ b/theme_real_estate/views/snippets/s_quotes_carousel.xml
@@ -7,21 +7,21 @@
         Amazing team! smiling, always nice to talk with, they always have the best advices for you, adapted to your needs!
     </xpath>
     <xpath expr="(//span[hasclass('s_blockquote_author')])[1]" position="replace" mode="inner">
-        <b>Jane Doe</b> • Customer, bought a house
+        <span style="font-weight: bold;">Jane Doe</span> • Customer, bought a house
     </xpath>
     <!-- Quote 2 -->
     <xpath expr="(//div[hasclass('s_blockquote_content')])[2]/p" position="replace" mode="inner">
         From start to finish, they were extremely professional, friendly, helpful and easy to do business with. Very happy with the experience and the company.
     </xpath>
     <xpath expr="(//span[hasclass('s_blockquote_author')])[2]" position="replace" mode="inner">
-        <b>John Doe</b> • Customer, bought an appartement
+        <span style="font-weight: bold;">John Doe</span> • Customer, bought an appartement
     </xpath>
     <!-- Quote 3 -->
     <xpath expr="(//div[hasclass('s_blockquote_content')])[3]/p" position="replace" mode="inner">
         Positive energy, great team spirit, hard workers and awesome people! I warmly recommend them!
     </xpath>
     <xpath expr="(//span[hasclass('s_blockquote_author')])[3]" position="replace" mode="inner">
-        <b>Iris Doe</b> • Customer, sold an appartement
+        <span style="font-weight: bold;">Iris Doe</span> • Customer, sold an appartement
     </xpath>
 </template>
 

--- a/theme_real_estate/views/snippets/s_text_block.xml
+++ b/theme_real_estate/views/snippets/s_text_block.xml
@@ -7,10 +7,10 @@
         <attribute name="class" add="o_cc o_cc4 pb56 pt56" remove="pt96 pb96" separator=" "/>
     </xpath>
     <xpath expr="//p" position="replace" mode="inner">
-        We are <b>Odoo Travel Agency</b>, dedicated to making your vacation dreams come true! Overwhelmed with too many choices on the internet? We offer you answers, support, advice, and itineraries that will amaze you with their <b>thoroughness and thoughtfulness</b>.
+        We are <span style="font-weight: bold;">Odoo Travel Agency</span>, dedicated to making your vacation dreams come true! Overwhelmed with too many choices on the internet? We offer you answers, support, advice, and itineraries that will amaze you with their <span style="font-weight: bold;">thoroughness and thoughtfulness</span>.
     </xpath>
     <xpath expr="//p[2]" position="replace" mode="inner">
-            At <b>Odoo Travel Agency</b> our agents are more than a consultant, they are fellow <b>travelers with a passion</b> to help you explore the world. With more than 75 years combined experience you can be sure we are devoted to finding the best solutions for your travel plans.
+            At <span style="font-weight: bold;">Odoo Travel Agency</span> our agents are more than a consultant, they are fellow <span style="font-weight: bold;">travelers with a passion</span> to help you explore the world. With more than 75 years combined experience you can be sure we are devoted to finding the best solutions for your travel plans.
     </xpath>
 </template>
 

--- a/theme_treehouse/views/snippets/s_cover.xml
+++ b/theme_treehouse/views/snippets/s_cover.xml
@@ -11,7 +11,7 @@
         <i class="fa fa-2x fa-bug d-block my-3 mx-auto rounded-circle bg-o-color-4 text-o-color-1"/>
     </xpath>
     <xpath expr="//h1" position="replace" mode="inner">
-        <font style="font-size: 62px;"><b>— Life on Earth —</b></font>
+        <font style="font-size: 62px;"><span style="font-weight: bold;">— Life on Earth —</span></font>
     </xpath>
     <!-- Paragraphs -->
     <xpath expr="//p" position="replace" mode="inner">

--- a/theme_treehouse/views/snippets/s_text_image.xml
+++ b/theme_treehouse/views/snippets/s_text_image.xml
@@ -27,7 +27,7 @@
     </xpath>
     <!-- Subtitle -->
     <xpath expr="//h2" position="before">
-        <p style="font-size: 12px;"><b>ABOUT US</b></p>
+        <p style="font-size: 12px;"><span style="font-weight: bold;">ABOUT US</span></p>
     </xpath>
 </template>
 

--- a/theme_vehicle/views/customizations.xml
+++ b/theme_vehicle/views/customizations.xml
@@ -46,7 +46,7 @@
         <attribute name="class" add="col-lg-5 offset-lg-1" remove="col-lg-6" separator=" "/>
     </xpath>
     <xpath expr="//h2" position="before">
-        <h4 class="text-o-color-1"><b>The world is yours</b></h4>
+        <h4 class="text-o-color-1"><span style="font-weight: bold;">The world is yours</span></h4>
     </xpath>
     <xpath expr="//h2" position="replace" mode="inner">
         No compromise
@@ -75,7 +75,7 @@
         <attribute name="class" add="col-lg-5 offset-lg-1" remove="col-lg-6" separator=" "/>
     </xpath>
     <xpath expr="//h2" position="before">
-        <h4 class="text-o-color-1"><b>A greener lifestyle</b></h4>
+        <h4 class="text-o-color-1"><span style="font-weight: bold;">A greener lifestyle</span></h4>
     </xpath>
     <xpath expr="//h2" position="replace" mode="inner">
         Electric Driving
@@ -113,12 +113,12 @@
     </xpath>
     <!-- Block #02 -->
     <xpath expr="//h3" position="replace" mode="inner">
-        Electrifying <b>Performance</b>.
+        Electrifying <span style="font-weight: bold;">Performance</span>.
     </xpath>
     <xpath expr="(//p)[2]" position="replace" mode="inner"/>
     <!-- Block #03 -->
     <xpath expr="(//h3)[2]" position="replace" mode="inner">
-        Smarter <b>Range</b>.
+        Smarter <span style="font-weight: bold;">Range</span>.
     </xpath>
     <xpath expr="(//p)[3]" position="replace" mode="inner"/>
 </template>
@@ -151,7 +151,7 @@
     </xpath>
     <!-- Content -->
     <xpath expr="//h3" position="replace" mode="inner">
-        <b>50,000 pre-orders</b> already registered.
+        <span style="font-weight: bold;">50,000 pre-orders</span> already registered.
     </xpath>
     <xpath expr="//h3" position="attributes">
         <attribute name="style" add="text-align: left;" separator=" "/>
@@ -225,7 +225,7 @@
         <p><a href="#" class="btn btn-primary btn-block mb-0 o_cc o_cc4">Configure</a></p>
     </xpath>
     <xpath expr="//p[hasclass('card-text')]" position="after">
-        <span class="d-inline-block mb-4"><b>From $14,000</b></span>
+        <span class="d-inline-block mb-4"><span style="font-weight: bold;">From $14,000</span></span>
     </xpath>
     <!-- Column 2 -->
     <xpath expr="(//h3)[2]" position="replace" mode="inner">
@@ -238,7 +238,7 @@
         <p><a href="#" class="btn btn-primary btn-block mb-0 o_cc o_cc4">Configure</a></p>
     </xpath>
     <xpath expr="(//p[hasclass('card-text')])[2]" position="after">
-        <span class="d-inline-block mb-4"><b>From $19,000</b></span>
+        <span class="d-inline-block mb-4"><span style="font-weight: bold;">From $19,000</span></span>
     </xpath>
     <!-- Column 3 -->
     <xpath expr="(//h3)[3]" position="replace" mode="inner">
@@ -251,7 +251,7 @@
         <p><a href="#" class="btn btn-primary btn-block mb-0 o_cc o_cc4">Configure</a></p>
     </xpath>
     <xpath expr="(//p[hasclass('card-text')])[3]" position="after">
-        <span class="d-inline-block mb-4"><b>From $25,000</b></span>
+        <span class="d-inline-block mb-4"><span style="font-weight: bold;">From $25,000</span></span>
     </xpath>
 </template>
 

--- a/theme_yes/views/snippets/s_call_to_action.xml
+++ b/theme_yes/views/snippets/s_call_to_action.xml
@@ -4,7 +4,7 @@
 <template id="s_call_to_action" inherit_id="website.s_call_to_action">
     <!-- Title -->
     <xpath expr="//h3" position="replace" mode="inner">
-        <b>345 couples</b> trusted us to organize their wedding.
+        <span style="font-weight: bold;">345 couples</span> trusted us to organize their wedding.
     </xpath>
     <!-- Paragraph -->
     <xpath expr="//p" position="replace" mode="inner">

--- a/theme_yes/views/snippets/s_company_team.xml
+++ b/theme_yes/views/snippets/s_company_team.xml
@@ -15,7 +15,7 @@
         Livia Sailor
     </xpath>
     <xpath expr="//p" position="replace">
-        <p><font style="font-weight: bolder;" class="text-o-color-1">The Founder &amp; Planner</font></p>
+        <p><font style="font-weight: bold;" class="text-o-color-1">The Founder &amp; Planner</font></p>
         <p>Livia is our head wedding coordinator and stylist, she'll turn any of your ideas into reality, making sure your wedding day is smooth and looks better than anything you have ever seen on Pinterest.</p>
     </xpath>
     <!-- Row #1 - Col #2 -->
@@ -23,7 +23,7 @@
         Clair Stark
     </xpath>
     <xpath expr="(//p)[3]" position="replace">
-        <p><font style="font-weight: bolder;" class="text-o-color-1">The Designer</font></p>
+        <p><font style="font-weight: bold;" class="text-o-color-1">The Designer</font></p>
         <p>As a passionate wedding designer with a romantic soul, Clair adores celebrating the special moments in life in magical places and creating an authentic experience for couples. </p>
     </xpath>
     <!-- Row -->

--- a/theme_yes/views/snippets/s_quotes_carousel.xml
+++ b/theme_yes/views/snippets/s_quotes_carousel.xml
@@ -25,7 +25,7 @@
         <p style="font-size: 16px">Thank you so much for being a part of our special day. It was so nice working with you. Without your help the day would not have been as perfect as it was.</p>
     </xpath>
     <xpath expr="(//span[hasclass('s_blockquote_author')])[1]" position="replace">
-        <span class="s_blockquote_author"><b>Linda and Paul</b> • Married in 2020</span>
+        <span class="s_blockquote_author"><span style="font-weight: bold;">Linda and Paul</span> • Married in 2020</span>
     </xpath>
     <!-- Quote 2 -->
     <xpath expr="(//*[hasclass('carousel-item')])[2]" position="attributes">
@@ -46,7 +46,7 @@
         <p style="font-size:16px">Our wedding coordinator made the entire process so much less stressful. She was more than kind, accommodating, and helpful in more ways than one! She always answered my emails within a day and thoroughly. She went above and beyond, I would recommend her to anyone!</p>
     </xpath>
     <xpath expr="(//span[hasclass('s_blockquote_author')])[2]" position="replace">
-        <span class="s_blockquote_author"><b>Jack and Mary</b> • Married in 2019</span>
+        <span class="s_blockquote_author"><span style="font-weight: bold;">Jack and Mary</span> • Married in 2019</span>
     </xpath>
     <!-- Quote 3 -->
     <xpath expr="(//*[hasclass('carousel-item')])[3]" position="attributes">
@@ -67,7 +67,7 @@
         <p style="font-size:16px">From the beginning of our planning process, our planner was incredible! She made us feel heard, gave great suggestions and was always just an email or call away when we had any last minute questions. Couldn't have done it without her!</p>
     </xpath>
     <xpath expr="(//*[hasclass('s_blockquote_author')])[3]" position="replace">
-        <span class="s_blockquote_author"><b>Rose and Peter</b> • Renewed their vows in 2021</span>
+        <span class="s_blockquote_author"><span style="font-weight: bold;">Rose and Peter</span> • Renewed their vows in 2021</span>
     </xpath>
 </template>
 

--- a/theme_zap/views/snippets/s_banner.xml
+++ b/theme_zap/views/snippets/s_banner.xml
@@ -17,7 +17,7 @@
     </xpath>
     <!-- Title -->
     <xpath expr="//h1" position="replace" mode="inner">
-        <b>Software innovation</b><br/> as its best.
+        <span style="font-weight: bold;">Software innovation</span><br/> as its best.
     </xpath>
     <!-- Text -->
     <xpath expr="//p" position="replace">

--- a/theme_zap/views/snippets/s_color_blocks_2.xml
+++ b/theme_zap/views/snippets/s_color_blocks_2.xml
@@ -10,7 +10,7 @@
         <i class="fa fa-2x fa-cloud bg-white text-o-color-1 rounded-circle shadow my-4"/>
     </xpath>
     <xpath expr="//h2" position="replace" mode="inner">
-        Cloud <b>Solution</b>
+        Cloud <span style="font-weight: bold;">Solution</span>
     </xpath>
     <xpath expr="//p" position="replace">
         <p class="lead">Keep your files in one place. <br/>Manage documents online with an easy to use interface. <br/>Rely on an highly secure cloud storage.</p>

--- a/theme_zap/views/snippets/s_masonry_block.xml
+++ b/theme_zap/views/snippets/s_masonry_block.xml
@@ -15,7 +15,7 @@
         <i class="fa fa-2x fa-star text-o-color-2 rounded-circle shadow mx-auto my-3"/>
     </xpath>
     <xpath expr="//h3" position="replace" mode="inner">
-        Super <b>Easy</b>
+        Super <span style="font-weight: bold;">Easy</span>
     </xpath>
     <xpath expr="(//p)[3]" position="replace" mode="inner"/>
     <!-- Block #03 -->
@@ -23,7 +23,7 @@
         <i class="fa fa-2x fa-rocket text-o-color-1 rounded-circle shadow mx-auto my-3"/>
     </xpath>
     <xpath expr="(//h3)[2]" position="replace" mode="inner">
-        Super <b>Fast</b>
+        Super <span style="font-weight: bold;">Fast</span>
     </xpath>
     <xpath expr="(//p)[4]" position="replace" mode="inner"/>
     <!-- Block #04 -->

--- a/theme_zap/views/snippets/s_references.xml
+++ b/theme_zap/views/snippets/s_references.xml
@@ -8,7 +8,7 @@
     </xpath>
     <!-- Title -->
     <xpath expr="//h2" position="replace" mode="inner">
-        Our <b>References</b>
+        Our <span style="font-weight: bold;">References</span>
     </xpath>
     <!-- Paragraph -->
     <xpath expr="//p" position="after">


### PR DESCRIPTION
Since we changed the behavior of the text editor so that it applies
"bold" on the text and no longer "bolder" with the bold option. we have
replaced all the `<b>` tags of the editable content of website themes with
inline style ("font-weight: bold").

Indeed, with Bootstrap, the `<b>` tag applies "font-weight: bolder" to the
texts. What we no longer want and which is no longer possible to do with
the text editor.