### PR TITLE
[FIX] website_animate: fix animation in mega menu

### DIFF
--- a/website_animate/static/src/js/o_animate.frontend.js
+++ b/website_animate/static/src/js/o_animate.frontend.js
@@ -13,7 +13,7 @@ var WebsiteAnimate = {
     // Retrieve animable elements and attach handlers.
     start: function () {
         var self   = this;
-        self.items = $(".o_animate");
+        self.items = $(".o_animate").not(".dropdown .o_animate");
         self.items.each(function () {
             var $el = $(this);
             // Set all monitored elements to initial state
@@ -45,7 +45,7 @@ var WebsiteAnimate = {
             var direction = (windowTop < lastScroll) ? -1 : 1;
             lastScroll = windowTop;
 
-            $(".o_animate").each(function () {
+            $(".o_animate").not(".dropdown .o_animate").each(function () {
                 var $el       = $(this);
                 var elHeight  = $el.height();
                 var elOffset  = direction * Math.max((elHeight * self.offsetRatio), self.offsetMin);

--- a/website_animate/views/options.xml
+++ b/website_animate/views/options.xml
@@ -132,7 +132,7 @@
             </div>
             <div data-js="o_animate_options"
                 t-att-data-selector="o_animate_selector"
-                data-exclude=".o_not-animable">
+                data-exclude=".o_not-animable, .dropdown *">
                 <we-collapse-area class="d-none"> <!-- Visible only if an animation is active (js) -->
                     <we-toggler><i class="fa fa-fw fa-cogs"/> Animation Options</we-toggler>
                     <we-collapse class="o_anim_ul_options">


### PR DESCRIPTION
Before this commit, the animations were never launched in a mega menu.

Indeed the animations are launched when the element to be animated
appears in the viewport according to the scroll. But in the case of a
mega menu we just want the animation to start when the mega menu is
opened. For that we don't need all the code that checks the scroll, etc.
The animation starts by itself when the element inside the mega menu is
made visible in CSS.

This commit also removes the "Each time it becomes visible" option for
an element animated in a mega menu because in this case this option does
not make sense.

opw-2764895