### PR TITLE
[FIX] theme_*: remove some snippets hard coded background color

### DIFF
--- a/theme_bistro/views/snippets/s_image_text.xml
+++ b/theme_bistro/views/snippets/s_image_text.xml
@@ -4,7 +4,7 @@
 <template id="s_image_text" inherit_id="website.s_image_text">
     <!-- Section -->
     <xpath expr="//section" position="attributes">
-        <attribute name="class" add="pt64 pb64 bg-200" remove="pt32 pb32" separator=" "/>
+        <attribute name="class" add="pt64 pb64" remove="pt32 pb32" separator=" "/>
     </xpath>
     <!-- Image -->
     <xpath expr="//img" position="attributes">

--- a/theme_bistro/views/snippets/s_text_image.xml
+++ b/theme_bistro/views/snippets/s_text_image.xml
@@ -4,7 +4,7 @@
 <template id="s_text_image" inherit_id="website.s_text_image">
     <!-- Section -->
     <xpath expr="//section" position="attributes">
-        <attribute name="class" add="pt80 pb80 bg-200" remove="o_cc o_cc2 pt32 pb32" separator=" "/>
+        <attribute name="class" add="pt80 pb80" remove="o_cc o_cc2 pt32 pb32" separator=" "/>
     </xpath>
     <!-- Image -->
     <xpath expr="//img" position="attributes">

--- a/theme_buzzy/views/snippets/s_text_highlight.xml
+++ b/theme_buzzy/views/snippets/s_text_highlight.xml
@@ -4,7 +4,7 @@
 <template id="s_text_highlight" inherit_id="website.s_text_highlight">
     <!-- Main div -->
     <xpath expr="//div[hasclass('s_text_highlight')]" position="attributes">
-        <attribute name="class" add="o_cc o_cc4" remove="bg-secondary" separator=" "/>
+        <attribute name="class" add="o_cc4" remove="o_cc3" separator=" "/>
     </xpath>
 </template>
 

--- a/theme_cobalt/views/customizations.xml
+++ b/theme_cobalt/views/customizations.xml
@@ -159,7 +159,7 @@
 <!-- ==== Picture ===== -->
 <template id="s_picture" inherit_id="website.s_picture" name="Cobalt s_picture">
     <xpath expr="//section" position="attributes">
-        <attribute name="class" add="bg-o-color-3 pt72 overflow-hidden" remove="o_cc o_cc2 pt48" separator=" "/>
+        <attribute name="class" add="pt72 overflow-hidden" remove="o_cc o_cc2 pt48" separator=" "/>
         <attribute name="data-oe-shape-data">{"shape":"web_editor/Bold/01","flip":["y"]}</attribute>
     </xpath>
     <xpath expr="//section/div" position="before">

--- a/theme_treehouse/views/snippets/s_image_text.xml
+++ b/theme_treehouse/views/snippets/s_image_text.xml
@@ -4,7 +4,7 @@
 <template id="s_image_text" inherit_id="website.s_image_text">
     <!-- Section -->
     <xpath expr="//section" position="attributes">
-        <attribute name="class" add="pt80 pb80 bg-200" remove="pt32 pb32" separator=" "/>
+        <attribute name="class" add="pt80 pb80" remove="pt32 pb32" separator=" "/>
     </xpath>
     <!-- Image -->
     <xpath expr="//img" position="attributes">

--- a/theme_treehouse/views/snippets/s_three_columns.xml
+++ b/theme_treehouse/views/snippets/s_three_columns.xml
@@ -4,7 +4,7 @@
 <template id="s_three_columns" inherit_id="website.s_three_columns">
     <!-- Section -->
     <xpath expr="//section" position="attributes">
-        <attribute name="class" add="pt80 pb80 bg-200" remove="pt32 pb32 o_cc o_cc2" separator=" "/>
+        <attribute name="class" add="pt80 pb80" remove="pt32 pb32 o_cc o_cc2" separator=" "/>
     </xpath>
     <!-- Column #01 -->
     <xpath expr="(//*[hasclass('card-title')])[1]" position="replace" mode="inner">

--- a/theme_zap/views/snippets/s_image_text.xml
+++ b/theme_zap/views/snippets/s_image_text.xml
@@ -4,7 +4,7 @@
 <template id="s_image_text" inherit_id="website.s_image_text">
     <!-- Section -->
     <xpath expr="//section" position="attributes">
-        <attribute name="class" add="pt80 pb80 bg-200" remove="pt32 pb32" separator=" "/>
+        <attribute name="class" add="pt80 pb80 o_colored_level o_cc o_cc2" remove="pt32 pb32" separator=" "/>
     </xpath>
     <!-- Image -->
     <xpath expr="//img" position="attributes">


### PR DESCRIPTION
This is the direct following of the PR [1].

Some themes "hard code" the background colors of some snippets, which
prevents the user to change it with a preset color without deleting the
current background first.

This commit does two things:
- remove the problematic hard coded background colors;
- replace the colors that are removed by some themes by the ones that
were set in [1] (for the searchbar and text highlight snippets).

[1]: https://github.com/odoo/odoo/pull/90749

task-2824393