### PR TITLE
[IMP] test_themes: adapt to website_preview client action 

### DIFF
--- a/test_themes/models/ir_http.py
+++ b/test_themes/models/ir_http.py
@@ -9,10 +9,10 @@ class Http(models.AbstractModel):
     _inherit = 'ir.http'
 
     @classmethod
-    def _frontend_pre_dispatch(cls):
+    def _pre_dispatch(cls, rule, args):
+        super()._pre_dispatch(rule, args)
+
         # Allow public user to use `fw` query string in test mode to ease tests
         force_website_id = request.httprequest.args.get('fw')
         if (request.registry.in_test_mode() or tools.config.options['test_enable']) and force_website_id:
             request.env['website']._force_website(force_website_id)
-
-        super(Http, cls)._frontend_pre_dispatch()

--- a/test_themes/static/src/js/navbar.js
+++ b/test_themes/static/src/js/navbar.js
@@ -1,30 +1,33 @@
-odoo.define('test_themes.website_selector', function (require) {
-'use strict';
+// TODO: This will be reimplemented following the frontend UI being moved to
+// the backend
 
-const websiteNavbarData = require('website.navbar');
-const { registry } = require("@web/core/registry");
+// odoo.define('test_themes.website_selector', function (require) {
+// 'use strict';
 
-const TestThemesWebsiteSelector = websiteNavbarData.WebsiteNavbarActionWidget.extend({
-    /**
-     * @override
-     */
-    start: function () {
-        this.$('.js_multi_website_switch[data-toggle]').tooltip({
-            html: true,
-            placement: 'left',
-            delay: {show: 100, hide: 0},
-        });
-        return this._super(...arguments);
-    },
+// const websiteNavbarData = require('website.navbar');
+// const { registry } = require("@web/core/registry");
 
-});
+// const TestThemesWebsiteSelector = websiteNavbarData.WebsiteNavbarActionWidget.extend({
+//     /**
+//      * @override
+//      */
+//     start: function () {
+//         this.$('.js_multi_website_switch[data-toggle]').tooltip({
+//             html: true,
+//             placement: 'left',
+//             delay: {show: 100, hide: 0},
+//         });
+//         return this._super(...arguments);
+//     },
 
-registry.category("website_navbar_widgets").add("TestThemesWebsiteSelector", {
-    Widget: TestThemesWebsiteSelector,
-    selector: '#website_switcher',
-});
+// });
 
-return {
-    TestThemesWebsiteSelector: TestThemesWebsiteSelector,
-};
-});
+// registry.category("website_navbar_widgets").add("TestThemesWebsiteSelector", {
+//     Widget: TestThemesWebsiteSelector,
+//     selector: '#website_switcher',
+// });
+
+// return {
+//     TestThemesWebsiteSelector: TestThemesWebsiteSelector,
+// };
+// });

--- a/test_themes/tests/test_crawl.py
+++ b/test_themes/tests/test_crawl.py
@@ -51,4 +51,4 @@ class Crawler(HttpCase):
         Website = self.env['website']
         websites_themes = Website.get_test_themes_websites()
         for website in websites_themes:
-            self.start_tour(f"/?fw={website.id}", 'homepage', login='admin')
+            self.start_tour(f"/web?fw={website.id}", 'homepage', login='admin')

--- a/test_themes/views/website_navbar_templates.xml
+++ b/test_themes/views/website_navbar_templates.xml
@@ -1,11 +1,11 @@
 <?xml version="1.0" encoding="utf-8"?>
 <odoo>
-
-<template id="user_navbar" inherit_id="website.user_navbar" name="User Navbar Themes">
+<!-- TODO: This will be reimplemented following the frontend UI being moved to the backend -->
+<!-- <template id="user_navbar" inherit_id="website.user_navbar" name="User Navbar Themes">
     <xpath expr="//a[hasclass('js_multi_website_switch')]" position="attributes">
         <attribute name="t-att-title">multi_website_website['theme_img']</attribute>
         <attribute name="data-toggle">tooltip</attribute>
     </xpath>
-</template>
+</template> -->
 
 </odoo>


### PR DESCRIPTION
This commit removes the tooltips shown when hovering over a theme in
the website switcher dropdown. This feature will be reimplemented later,
patching the WebsiteSwitcherSystray component.

It also adapts the ?fw= url parameter to force a website id during the
tours.

task-2687506