### PR TITLE
[FIX] test_themes: fix theme_upgrade standalone test

### DIFF
--- a/test_themes/tests/test_theme_upgrade.py
+++ b/test_themes/tests/test_theme_upgrade.py
@@ -25,13 +25,13 @@ def test_01_theme_upgrade_post_copy(env):
         except Exception:
             pass
 
-    ripple_specific_view = Website.viewref('website.option_ripple_effect')
+    ofs_specific_view = Website.viewref('website.option_footer_scrolltop')
     fls_specific_view = Website.viewref('portal.footer_language_selector')
     theme_nano_module = env.ref('base.module_theme_nano')
 
     def _simulate_user_manual_change():
         # Change some website options that will be changed by Theme Nano
-        ripple_specific_view.active = False
+        ofs_specific_view.active = False
         fls_specific_view.active = True
 
     # 2. Simulate some website option change made by the user
@@ -41,7 +41,7 @@ def test_01_theme_upgrade_post_copy(env):
     with MockRequest(env, website=website):
         theme_nano_module.with_context(website_id=website.id).button_choose_theme()
 
-    assert Website.viewref('website.option_ripple_effect').active is True, \
+    assert Website.viewref('website.option_footer_scrolltop').active is True, \
         "Theme Nano custo should be applied"
     assert Website.viewref('portal.footer_language_selector').active is False, \
         "Theme Nano custo should be applied (2)"
@@ -54,7 +54,7 @@ def test_01_theme_upgrade_post_copy(env):
     env.reset()  # clear the set of environments
     env = env()  # get an environment that refers to the new registry
 
-    assert Website.viewref('website.option_ripple_effect').active is False, \
+    assert Website.viewref('website.option_footer_scrolltop').active is False, \
         "Theme Nano custo should NOT be applied"
     assert Website.viewref('portal.footer_language_selector').active is True, \
         "Theme Nano custo should NOT be applied (2)"


### PR DESCRIPTION
Ripple option is now an ir.asset, not an ir.ui.view anymore, see [1].

[1]: https://github.com/odoo/odoo/commit/9f56357cc1f4a7b8606ef4d5fd431fc396bdf1e8