### PR TITLE
[FIX] test_themes: force request's website before _frontend_pre_dispatch

### DIFF
--- a/test_themes/models/ir_http.py
+++ b/test_themes/models/ir_http.py
@@ -10,9 +10,9 @@ class Http(models.AbstractModel):
 
     @classmethod
     def _pre_dispatch(cls, rule, args):
-        super()._pre_dispatch(rule, args)
-
         # Allow public user to use `fw` query string in test mode to ease tests
         force_website_id = request.httprequest.args.get('fw')
         if (request.registry.in_test_mode() or tools.config.options['test_enable']) and force_website_id:
             request.env['website']._force_website(force_website_id)
+
+        super()._pre_dispatch(rule, args)


### PR DESCRIPTION
The callstack is:
- _pre_dispatch() (http_routing)
  - super()
  - _frontend_pre_dispatch()
    - super()
      - _frontend_pre_dispatch() (website) -> Set the website on request

But in `test_themes` we were forcing the website in a `_pre_dispatch()`
override, after calling `super()`.
It means that the call to `_frontend_pre_dispatch()` was actually done
without having yet forced the website in session. get_current_website()
would then not consider the `fw` param as not yet in session, and the
request.website would be set to 1, the default one.
Later in the business code, there would be a mismatch between
`request.website` and `get_current_website()`.