### PR TITLE
[FIX] theme_test_custo: add bigger timeout to the new test

### DIFF
--- a/theme_test_custo/static/tests/tours/theme_menu_hierarchies.js
+++ b/theme_test_custo/static/tests/tours/theme_menu_hierarchies.js
@@ -9,6 +9,7 @@ wTourUtils.registerEditionTour('theme_menu_hierarchies', {
     {
         content: 'Check Mega Menu is correctly created',
         trigger: 'iframe #top_menu a.o_mega_menu_toggle',
+        timeout: 20000,
     }, {
         content: 'Check Mega Menu content',
         trigger: 'iframe #top_menu div.o_mega_menu.show .fa-cube',


### PR DESCRIPTION
New test was introduced with [1] but it actually sometimes lead to timeout errors.
That's a common issue since we merged the frontend in the backend and some tour (like this one) now have to start both the backend and the frontend (in the iframe).

10 seconds is not enough to load both, it often miss just half a second.

[1]: https://github.com/odoo/design-themes/commit/0e2497b8e84eab8957028f4d63ff0899a9fe6ab3

runbot-4684