### PR TITLE
[IMP] theme_*: ease defining only one font family to use in a theme

### DIFF
--- a/theme_anelusia/static/src/scss/primary_variables.scss
+++ b/theme_anelusia/static/src/scss/primary_variables.scss
@@ -13,8 +13,6 @@ $o-website-values-palettes: (
         // Font
         'font':                             'Source Sans Pro',
         'headings-font':                    'Spartan',
-        'navbar-font':                      'Source Sans Pro',
-        'buttons-font':                     'Source Sans Pro',
 
         // Links
         'link-underline':                   'never',

--- a/theme_artists/static/src/scss/primary_variables.scss
+++ b/theme_artists/static/src/scss/primary_variables.scss
@@ -97,8 +97,6 @@ $o-website-values-palettes: (
         'header-font-size': (13 / 16) * 1rem,
         'font': 'Montserrat',
         'headings-font': 'Oxygen',
-        'navbar-font': 'Montserrat',
-        'buttons-font': 'Montserrat',
         'btn-ripple': true,
         'header-template': 'hamburger',
         'hamburger-type': 'off-canvas',

--- a/theme_avantgarde/static/src/scss/primary_variables.scss
+++ b/theme_avantgarde/static/src/scss/primary_variables.scss
@@ -181,9 +181,6 @@ $o-website-values-palettes: (
 
         'font-size-base': 1rem,
         'font': 'Syne',
-        'headings-font': 'Syne',
-        'navbar-font': 'Syne',
-        'buttons-font': 'Syne',
 
         'header-template': 'hamburger',
         'hamburger-type': 'default',

--- a/theme_aviato/static/src/scss/primary_variables.scss
+++ b/theme_aviato/static/src/scss/primary_variables.scss
@@ -24,8 +24,6 @@ $o-website-values-palettes: (
         // Font
         'font': 'Open Sans',
         'headings-font': 'Libre Baskerville',
-        'navbar-font': 'Open Sans',
-        'buttons-font': 'Open Sans',
 
         // Buttons
         'btn-padding-y': .45rem,

--- a/theme_beauty/static/src/scss/primary_variables.scss
+++ b/theme_beauty/static/src/scss/primary_variables.scss
@@ -61,10 +61,10 @@ $o-website-values-palettes: (
         'color-palettes-name': 'beauty-1',
 
         'header-font-size': (18 / 16) * 1rem,
+
         'font': 'Questrial',
         'headings-font': 'DM Serif Display',
-        'navbar-font': 'Questrial',
-        'buttons-font': 'Questrial',
+
         'header-template': 'Contact',
         'footer-template': 'default',
         'header-links-style': 'outline',

--- a/theme_bewise/static/src/scss/primary_variables.scss
+++ b/theme_bewise/static/src/scss/primary_variables.scss
@@ -104,11 +104,11 @@ $o-website-values-palettes: (
         'color-palettes-name': 'bewise-1',
 
         'header-font-size': (20 / 16) * 1rem,
-        'font': 'Darker Grotesque',
         'font-size-base': 1.3125rem,
+
+        'font': 'Darker Grotesque',
         'headings-font': 'Raleway',
-        'navbar-font': 'Darker Grotesque',
-        'buttons-font': 'Darker Grotesque',
+
         'layout': 'full',
         'header-template': 'default',
         'menu-box-shadow': false,

--- a/theme_bistro/static/src/scss/primary_variables.scss
+++ b/theme_bistro/static/src/scss/primary_variables.scss
@@ -16,9 +16,6 @@ $o-website-values-palettes: (
 
         // Font
         'font':                             'Poppins',
-        'headings-font':                    'Poppins',
-        'navbar-font':                      'Poppins',
-        'buttons-font':                     'Poppins',
 
         // Buttons
         'btn-padding-y':                    .5rem,

--- a/theme_bookstore/static/src/scss/primary_variables.scss
+++ b/theme_bookstore/static/src/scss/primary_variables.scss
@@ -69,8 +69,6 @@ $o-website-values-palettes: (
         'btn-border-radius-lg': 0px,
         'font': 'Source Sans Pro',
         'headings-font': 'DM Serif Display',
-        'navbar-font': 'Source Sans Pro',
-        'buttons-font': 'Source Sans Pro',
         'header-template': 'Contact',
         'footer-template': 'links',
         'header-links-style': 'border-bottom',

--- a/theme_buzzy/static/src/scss/primary_variables.scss
+++ b/theme_buzzy/static/src/scss/primary_variables.scss
@@ -13,9 +13,6 @@ $o-website-values-palettes: (
 
         // Font
         'font':                             'Montserrat',
-        'headings-font':                    'Montserrat',
-        'navbar-font':                      'Montserrat',
-        'buttons-font':                     'Montserrat',
 
         // Buttons
         'btn-padding-y':                    .45rem,
@@ -52,7 +49,7 @@ $o-selected-color-palettes-names: append($o-selected-color-palettes-names, 'kidd
 
 
 $o-theme-font-configs: (
-    
+
     'Abel': (
         'family': ('Abel', sans-serif),
         'url': 'Abel:300,300i,400,400i,700,700i',

--- a/theme_cobalt/static/src/scss/primary_variables.scss
+++ b/theme_cobalt/static/src/scss/primary_variables.scss
@@ -31,9 +31,6 @@ $o-website-values-palettes: (
         'color-palettes-name': 'cobalt-1',
 
         'font': 'Inter',
-        'headings-font': 'Inter',
-        'navbar-font': 'Inter',
-        'buttons-font': 'Inter',
 
         'hamburger-type': 'off-canvas',
         'menu-box-shadow': false,

--- a/theme_graphene/static/src/scss/primary_variables.scss
+++ b/theme_graphene/static/src/scss/primary_variables.scss
@@ -96,11 +96,9 @@ $o-website-values-palettes: (
         'color-palettes-name': 'graphene-1',
 
         'font-size-base': 1rem,
-        
+
         'font': 'Source Sans Pro',
         'headings-font': 'Assistant',
-        'navbar-font': 'Source Sans Pro',
-        'buttons-font': 'Source Sans Pro',
 
         'btn-ripple': true,
         'layout': 'boxed',
@@ -148,4 +146,3 @@ $o-bg-shapes: change-shape-colors-mapping('web_editor', 'Origins/02_001', (4: 2,
 $o-bg-shapes: add-extra-shape-colors-mapping('web_editor', 'Origins/02_001', 'second', (4: 2, 5: rgba(0, 0, 0, 0)));
 $o-bg-shapes: change-shape-colors-mapping('web_editor', 'Origins/06_001', (3: 2));
 $o-bg-shapes: change-shape-colors-mapping('web_editor', 'Zigs/01_001', (2: 4));
-

--- a/theme_nano/static/src/scss/bootstrap_overridden.scss
+++ b/theme_nano/static/src/scss/bootstrap_overridden.scss
@@ -3,16 +3,16 @@
 //------------------------------------------------------------------------------//
 
 // Headings
-@if o-website-value('headings-font') == 'Roboto' {
+@if nth($o-theme-headings-font, 1) == 'Roboto' {
     $o-theme-headings-font-weight:          500;
 }
-@if o-website-value('headings-font') == 'Dosis' {
+@if nth($o-theme-headings-font, 1) == 'Dosis' {
     $o-theme-headings-font-weight:          400;
 }
-@else if o-website-value('headings-font') == 'Lato' {
+@else if nth($o-theme-headings-font, 1) == 'Lato' {
     $o-theme-headings-font-weight:          300;
 }
-@else if o-website-value('headings-font') == 'Advent Pro' {
+@else if nth($o-theme-headings-font, 1) == 'Advent Pro' {
     $o-theme-headings-font-weight:          600;
 }
 
@@ -43,19 +43,19 @@
 }
 
 // Buttons
-@if o-website-value('buttons-font') == 'Roboto' {
+@if nth($o-theme-buttons-font, 1) == 'Roboto' {
     $o-theme-btn-font-weight:               500;
 }
-@else if o-website-value('buttons-font') == 'Advent Pro' {
+@else if nth($o-theme-buttons-font, 1) == 'Advent Pro' {
     $o-theme-btn-font-weight:               600;
 }
-@else if o-website-value('buttons-font') == 'Oswald' {
+@else if nth($o-theme-buttons-font, 1) == 'Oswald' {
     $o-theme-btn-font-weight:               200;
 }
-@else if o-website-value('buttons-font') == 'Open Sans' {
+@else if nth($o-theme-buttons-font, 1) == 'Open Sans' {
     $o-theme-btn-font-weight:               600;
 }
-@else if o-website-value('buttons-font') == 'Montserrat Alternates' {
+@else if nth($o-theme-buttons-font, 1) == 'Montserrat Alternates' {
     $o-theme-btn-font-weight:               600;
 }
 

--- a/theme_nano/static/src/scss/primary_variables.scss
+++ b/theme_nano/static/src/scss/primary_variables.scss
@@ -18,7 +18,6 @@ $o-website-values-palettes: (
         // Font
         'font':                             'Oxygen',
         'headings-font':                    'Nunito',
-        'navbar-font':                      'Oxygen',
         'buttons-font':                     'Nunito',
 
         // Body

--- a/theme_odoo_experts/static/src/scss/primary_variables.scss
+++ b/theme_odoo_experts/static/src/scss/primary_variables.scss
@@ -88,7 +88,6 @@ $o-website-values-palettes: (
         'font': 'Lato',
         'headings-font': 'Work Sans',
         'navbar-font': 'Work Sans',
-        'buttons-font': 'Lato',
         'header-template': 'Contact',
         'footer-template': 'contact',
         'link-underline': 'never',

--- a/theme_orchid/static/src/scss/primary_variables.scss
+++ b/theme_orchid/static/src/scss/primary_variables.scss
@@ -63,8 +63,6 @@ $o-website-values-palettes: (
         'color-palettes-name': 'orchid-7',
         'font': 'Questrial',
         'headings-font': 'Cormorant Garamond',
-        'navbar-font': 'Questrial',
-        'buttons-font': 'Questrial',
         'header-template': 'default',
         'footer-template': 'descriptive',
     ),

--- a/theme_real_estate/static/src/scss/primary_variables.scss
+++ b/theme_real_estate/static/src/scss/primary_variables.scss
@@ -90,9 +90,6 @@ $o-website-values-palettes: (
 
         // Font
         'font': 'Roboto',
-        'headings-font': 'Roboto',
-        'navbar-font': 'Roboto',
-        'buttons-font': 'Roboto',
 
         // Buttons
         'btn-border-radius': 0px,

--- a/theme_test_custo/static/src/scss/primary_variables.scss
+++ b/theme_test_custo/static/src/scss/primary_variables.scss
@@ -10,8 +10,6 @@ $o-website-values-palettes: (
         // Fonts
         'font': 'Source Sans Pro',
         'headings-font': 'Poppins',
-        'navbar-font': 'Source Sans Pro',
-        'buttons-font': 'Source Sans Pro',
 
         // Header
         'header-template': 'custom-theme',

--- a/theme_treehouse/static/src/scss/primary_variables.scss
+++ b/theme_treehouse/static/src/scss/primary_variables.scss
@@ -12,9 +12,6 @@ $o-website-values-palettes: (
 
         // Font
         'font':                             'Poppins',
-        'headings-font':                    'Poppins',
-        'navbar-font':                      'Poppins',
-        'buttons-font':                     'Poppins',
 
         // Buttons
         'btn-padding-y':                    .45rem,

--- a/theme_yes/static/src/scss/primary_variables.scss
+++ b/theme_yes/static/src/scss/primary_variables.scss
@@ -58,8 +58,6 @@ $o-website-values-palettes: (
         'color-palettes-name':              'yes-3',
         'font':                             'Quicksand',
         'headings-font':                    'Playfair Display',
-        'navbar-font':                      'Quicksand',
-        'buttons-font':                     'Quicksand',
         'footer-template':                  'descriptive',
         'btn-border-radius':                10rem,
         'btn-border-radius-sm':             10rem,

--- a/theme_zap/static/src/scss/bootstrap_overridden.scss
+++ b/theme_zap/static/src/scss/bootstrap_overridden.scss
@@ -3,13 +3,13 @@
 //------------------------------------------------------------------------------//
 
 // Headings
-@if o-website-value('headings-font') == 'Roboto' {
+@if nth($o-theme-headings-font, 1) == 'Roboto' {
     $o-theme-headings-font-weight:          500;
 }
-@else if o-website-value('headings-font') == 'Nunito' {
+@else if nth($o-theme-headings-font, 1) == 'Nunito' {
     $o-theme-headings-font-weight:          600;
 }
-@else if o-website-value('headings-font') == 'Advent Pro' {
+@else if nth($o-theme-headings-font, 1) == 'Advent Pro' {
     $o-theme-headings-font-weight:          600;
 }
 
@@ -37,19 +37,19 @@
 }
 
 // Buttons
-@if o-website-value('buttons-font') == 'Roboto' {
+@if nth($o-theme-buttons-font, 1) == 'Roboto' {
     $o-theme-btn-font-weight:               500;
 }
-@else if o-website-value('buttons-font') == 'Advent Pro' {
+@else if nth($o-theme-buttons-font, 1) == 'Advent Pro' {
     $o-theme-btn-font-weight:               600;
 }
-@else if o-website-value('buttons-font') == 'Oswald' {
+@else if nth($o-theme-buttons-font, 1) == 'Oswald' {
     $o-theme-btn-font-weight:               200;
 }
-@else if o-website-value('buttons-font') == 'Open Sans' {
+@else if nth($o-theme-buttons-font, 1) == 'Open Sans' {
     $o-theme-btn-font-weight:               600;
 }
-@else if o-website-value('buttons-font') == 'Montserrat Alternates' {
+@else if nth($o-theme-buttons-font, 1) == 'Montserrat Alternates' {
     $o-theme-btn-font-weight:               600;
 }
 

--- a/theme_zap/static/src/scss/primary_variables.scss
+++ b/theme_zap/static/src/scss/primary_variables.scss
@@ -14,9 +14,6 @@ $o-website-values-palettes: (
 
         // Font
         'font':                             'Lato',
-        'headings-font':                    'Lato',
-        'navbar-font':                      'Lato',
-        'buttons-font':                     'Lato',
 
         // Buttons
         'btn-padding-y':                    .625rem,


### PR DESCRIPTION
Before this commit, if a theme wanted to define a main font for their
theme and let the "headings", "navbar" and "buttons" ones use the same
they had to add this in their map:

```
'font': XXX,
'headings-font': null,
'navbar-font': null,
'button-font': null,
```

Indeed, without setting the "null" values, those font would use YYY
which is the first font defined in the theme config, which might be
different from XXX. And if forcing XXX 4 times, like most themes do at
the moment, if the user wanted to change them all, he had to change the
4 ones instead of the main one.

Now, only the 'font' value use the first font defined in the theme
config if not explicitly set. So forcing the null values is not
necessary, it will be the default behavior.
The advantage is thus also functional, as most theme forced all their 4
fonts so changing the main one did not change the others.