### PR TITLE
[FIX] theme_test_custo: do not inherit from we options but website ones

### DIFF
--- a/theme_test_custo/data/shapes.xml
+++ b/theme_test_custo/data/shapes.xml
@@ -22,7 +22,7 @@
 </record>
 
 <!-- Image Shape -->
-<template id="snippet_options" inherit_id="web_editor.snippet_options" name="Image Shape Custom Option">
+<template id="snippet_options" inherit_id="website.snippet_options" name="Image Shape Custom Option">
     <xpath expr="//we-select-pager[@data-name='shape_img_opt']/we-select-page[last()]" position="after">
         <we-select-page string="Custom Shapes">
             <we-button data-set-img-shape="theme_test_custo/blob/01" data-select-label="Blob 01"/>


### PR DESCRIPTION
(Otherwise you could impact other apps like mass mailing). In fact this
should have been part of [1] as before you were *required* to inherit
from web_editor.snippet_options as it was t-called inside the website
snippet_options template.

Note: this new test theme was only recently introduced with [2].

[1]: https://github.com/odoo/design-themes/commit/0ce8547d34f08eb5a27329c66e53828e7b039ef1
[2]: https://github.com/odoo/design-themes/commit/0e2497b8e84eab8957028f4d63ff0899a9fe6ab3