### PR TITLE
[FIX] test_theme: clean the filestore after each assets generation

### DIFF
--- a/test_themes/tests/test_crawl.py
+++ b/test_themes/tests/test_crawl.py
@@ -30,6 +30,7 @@ class Crawler(HttpCase):
                 for name in websites_themes_names:
                     if name != website.theme_id.name:
                         self.assertFalse('/%s/static/src' % name in r.text, "Ensure other themes do not pollute current one")
+                self._gc_filestore()
 
         # 1. Test as public user
         test_crawling()


### PR DESCRIPTION
Since https://github.com/odoo/odoo/pull/101626, we can avoid keeping all assets in the filestore.
Testing all themes generates 600M of space. 
By calling the _gc_filestore between each them crawl, we use the filestore of the attachment before the current transaction and garbage collect the assets.