### PR TITLE
[FIX] theme_clean: remove the `content` class from the Carousel rows

### DIFF
--- a/theme_clean/views/snippets/s_carousel.xml
+++ b/theme_clean/views/snippets/s_carousel.xml
@@ -2,6 +2,9 @@
 <odoo>
     <template id="s_carousel" inherit_id="website.s_carousel">
         <!-- Container -->
+        <!-- TODO in master: remove the `content` classes in the div with the
+            class `row`, to avoid having unwanted dropzones when dragging inner
+            content. -->
         <xpath expr="//div[hasclass('carousel-inner')]" position="replace">
             <div class="carousel-inner">
                 <!-- Slide 1 -->


### PR DESCRIPTION
In [1], in master, the `content` class is removed from the elements with the `row` class in the Carousel snippet. This commit does the same for the extension of Carousel in the "Clean" theme, to be consistent with these changes.

[1]: https://github.com/odoo/odoo/pull/102696

task-3011192