### PR TITLE
[FIX] theme_bookstore: correct JSON value

### DIFF
--- a/theme_bookstore/views/snippets/s_product_catalog.xml
+++ b/theme_bookstore/views/snippets/s_product_catalog.xml
@@ -5,7 +5,7 @@
     <!-- Section -->
     <xpath expr="//section" position="attributes">
         <attribute name="class" add="o_cc o_cc5 pb112 pt112" remove="pb32 pt48" separator=" "/>
-        <attribute name="data-oe-shape-data">data-oe-shape-data="{"shape":"web_editor/Origins/17","flip":["y"]}"</attribute>
+        <attribute name="data-oe-shape-data">{"shape":"web_editor/Origins/17","flip":["y"]}</attribute>
     </xpath>
     <!-- Shape and filter -->
     <xpath expr="//section/*" position="before">


### PR DESCRIPTION
Description of the issue/feature this PR addresses:
---
Broken Pricelist snippet for `theme_bookstore`, as soon as drag and drop

Current behavior before PR:
---
As JSON is invalid, it can not [parse](https://github.com/odoo/odoo/blob/15.0/addons/web_editor/static/src/js/editor/snippets.options.js#L6412) and throws an error `not valid JSON`

Desired behavior after PR is merged:
---
An error occurred due to an incorrect way of passing JSON to the snippet arch, need to correct it in a proper format to achieve the desired result

PR: [605](https://github.com/odoo/design-themes/pull/605)
TaskID: 3002630