### PR TITLE
[FIX] test_themes: call post_copy again on test_themes' themes

### DIFF
--- a/test_themes/__init__.py
+++ b/test_themes/__init__.py
@@ -29,5 +29,5 @@ def post_init_hook(cr, registry):
             'record': website,
             'noupdate': True,  # Avoid unlink on -u
         })
-        theme._theme_get_stream_themes()._theme_load(website)
+        theme.with_context(apply_new_theme=True)._theme_get_stream_themes()._theme_load(website)
     env['ir.model.data']._update_xmlids(xmlids)


### PR DESCRIPTION
Since [1], the themes installed in the `_post_init` hook of test_themes would not go through the `_post_copy()` anymore.
It is not a big deal as this module purpose is to ease our tests and quickly being able to navigate through themes when we need to, but still this is something that need to be fixed as otherwise the themes would not really reflect how they look like.

Typically, go to the Odoo Experts theme, which is supposed to have the "Contact" header template, it will not have that header layout.

[1]: https://github.com/odoo/odoo/commit/b8a24efa71daea1f96465b780f4f0e384ce74703