### PR TITLE
[FIX] theme_zap: remove `contentenditable` property from Masonry image

### DIFF
--- a/theme_zap/views/snippets/s_masonry_block.xml
+++ b/theme_zap/views/snippets/s_masonry_block.xml
@@ -29,7 +29,6 @@
     <!-- Block #04 -->
     <xpath expr="//*[hasclass('col-lg-3')][4]" position="attributes">
         <attribute name="class" add="o_grid_item_image" remove="o_cc o_cc2" separator=" "/>
-        <attribute name="contenteditable" add="false" separator=" "/>
     </xpath>
     <xpath expr="//*[hasclass('col-lg-3')][4]" position="replace" mode="inner">
         <img src="/web/image/website.s_masonry_block_default_image_2" class="img img-fluid mx-auto" alt=""/>


### PR DESCRIPTION
In [1], in order to allow back the edition of the images of the columns in grid mode containing only an image, the `contenteditable` property is removed from these columns.

This commit removes the `contenteditable` property that was set on an image column of the Masonry snippet in the Zap theme.

[1]: https://github.com/odoo/odoo/pull/103767

opw-3028116