### PR TITLE
[FIX] theme_kea: fix faulty shape on s_picture

### DIFF
--- a/theme_kea/views/snippets/s_picture.xml
+++ b/theme_kea/views/snippets/s_picture.xml
@@ -5,6 +5,7 @@
     <!-- Section -->
     <xpath expr="//section" position="attributes">
         <attribute name="class" add="o_cc3" remove="o_cc2" separator=" "/>
+        <!-- TODO: adapt in master, this was fixed in JS -->
         <attribute name="data-oe-shape-data">{"shape":"web_editor/Origins/Wavy_03","flip":["y"]}</attribute>
     </xpath>
     <!-- Shape -->


### PR DESCRIPTION
Related community PR: https://github.com/odoo/odoo/pull/107224

Commit [1] refreshed the design of the KEA theme but unfortunately introduced the wrong path to a shape on the s_picture snippet.

This causes a traceback when the bg_shape option is toggle on a block inserted directly under that snippet.

This commit fixes the path to the shape.

[1]: https://github.com/odoo/design-themes/commit/88b81d41dadbfaad5d0b36ba2f1c595e309438ba

opw-3082292