### PR TITLE
[IMP] base, *: change the API of init hooks to pass env

### DIFF
--- a/test_themes/__init__.py
+++ b/test_themes/__init__.py
@@ -3,12 +3,9 @@
 
 from . import models
 
-from odoo import api, SUPERUSER_ID
 
-
-def post_init_hook(cr, registry):
+def post_init_hook(env):
     ''' Create a new website for each theme and install the theme on it. '''
-    env = api.Environment(cr, SUPERUSER_ID, {})
     IrModule = env['ir.module.module']
     themes = IrModule.search(IrModule.get_themes_domain(), order='name')
     assert len(themes) == len(env.ref('base.module_test_themes').dependencies_id)


### PR DESCRIPTION
This is mostly a cleaning/refactoring change.

The current API for init hooks (pre, post, uninstall) is to pass `cr, registry`.
But the first thing which was done by most
post init and uninstall hooks was to create an env using the cr passed
e.g.
`env = api.Environment(cr, SUPERUSER_ID, {})`
and the `registry` argument was unused in all these hooks, completely.

By changing the API of hooks to pass `env` instead of `cr, registry`, we gain in average two lines in every hooks:
- the line creating the env `env = api.Environment(cr, SUPERUSER_ID, {})`
- the line importing `api` and `SUPERUSER_ID`

Therefore removing ~250 lines of repeated code lines accross odoo/odoo and odoo/enterprise.
In addition to these lines removed,
it also ease the API of init hooks for Odoo developers, who are used to that `env` and not so much how to create an `env` from a cursor.