### PR TITLE
[IMP] theme_cobalt, theme_paptic: adapt to new theme options

### DIFF
--- a/theme_cobalt/static/src/scss/bootstrap_overridden.scss
+++ b/theme_cobalt/static/src/scss/bootstrap_overridden.scss
@@ -4,5 +4,4 @@
 
 // Headings
 
-$headings-line-height: 1.1 !default;
 $headings-font-weight: 600 !default;

--- a/theme_cobalt/static/src/scss/primary_variables.scss
+++ b/theme_cobalt/static/src/scss/primary_variables.scss
@@ -32,6 +32,8 @@ $o-website-values-palettes: (
 
         'font': 'Inter',
 
+        'headings-line-height': 1.1,
+
         'hamburger-type': 'off-canvas',
         'menu-box-shadow': false,
 

--- a/theme_paptic/static/src/scss/bootstrap_overridden.scss
+++ b/theme_paptic/static/src/scss/bootstrap_overridden.scss
@@ -1,6 +1,5 @@
 // Headings
 
-$headings-line-height: 1.1 !default;
 $headings-font-weight: 600 !default;
 
 

--- a/theme_paptic/static/src/scss/primary_variables.scss
+++ b/theme_paptic/static/src/scss/primary_variables.scss
@@ -42,6 +42,7 @@ $o-website-values-palettes: (
 
         'font-size-base': (14 / 16) * 1rem,
         'header-font-size': (14 / 16) * 1rem,
+        'headings-line-height': 1.1,
 
         'hamburger-type': 'off-canvas',
         'menu-box-shadow': false,


### PR DESCRIPTION
theme_*: theme_cobalt, theme_paptic, theme_vehicle

This commit adapt themes to rely on the new theme option
`headings-line-height`.

See https://github.com/odoo/odoo/pull/111621.

task-3140991