### PR TITLE
[IMP] theme_beauty, *: rename the font "Muli" to "Mulish"

### DIFF
--- a/theme_beauty/static/src/scss/primary_variables.scss
+++ b/theme_beauty/static/src/scss/primary_variables.scss
@@ -42,9 +42,9 @@ $o-theme-font-configs: (
         'family': ('Questrial', sans-serif),
         'url': 'Questrial:300,300i,400,400i,700,700i',
     ),
-    'Muli': (
-        'family': ('Muli', sans-serif),
-        'url': 'Muli:300,300i,400,400i,700,700i',
+    'Mulish': (
+        'family': ('Mulish', sans-serif),
+        'url': 'Mulish:300,300i,400,400i,700,700i',
     ),
     'DM Serif Display': (
         'family': ('DM Serif Display', serif),

--- a/theme_bookstore/static/src/scss/primary_variables.scss
+++ b/theme_bookstore/static/src/scss/primary_variables.scss
@@ -42,9 +42,9 @@ $o-theme-font-configs: (
         'family': ('Questrial', sans-serif),
         'url': 'Questrial:300,300i,400,400i,700,700i',
     ),
-    'Muli': (
-        'family': ('Muli', sans-serif),
-        'url': 'Muli:300,300i,400,400i,700,700i',
+    'Mulish': (
+        'family': ('Mulish', sans-serif),
+        'url': 'Mulish:300,300i,400,400i,700,700i',
     ),
     'Cormorant': (
         'family': ('Cormorant', serif),

--- a/theme_clean/static/src/scss/primary_variables.scss
+++ b/theme_clean/static/src/scss/primary_variables.scss
@@ -150,9 +150,9 @@ $o-theme-font-configs: (
         'family': ('Abel', sans-serif),
         'url': 'Abel:300,300i,400,400i,700,700i',
     ),
-    'Muli': (
-        'family': ('Muli', sans-serif),
-        'url': 'Muli:300,300i,400,400i,700,700i',
+    'Mulish': (
+        'family': ('Mulish', sans-serif),
+        'url': 'Mulish:300,300i,400,400i,700,700i',
     ),
     'Libre Baskerville': (
         'family': ('Libre Baskerville', serif),

--- a/theme_enark/static/src/scss/primary_variables.scss
+++ b/theme_enark/static/src/scss/primary_variables.scss
@@ -98,9 +98,9 @@ $o-theme-font-configs: (
         'family': ('Maven Pro', sans-serif),
         'url': 'Maven+Pro:300,300i,400,400i,700,700i',
     ),
-    'Muli': (
-        'family': ('Muli', sans-serif),
-        'url': 'Muli:300,300i,400,400i,700,700i',
+    'Mulish': (
+        'family': ('Mulish', sans-serif),
+        'url': 'Mulish:300,300i,400,400i,700,700i',
     ),
     'Abel': (
         'family': ('Abel', sans-serif),

--- a/theme_kiddo/static/src/scss/primary_variables.scss
+++ b/theme_kiddo/static/src/scss/primary_variables.scss
@@ -106,9 +106,9 @@ $o-theme-font-configs: (
         'family': ('Advent Pro', sans-serif),
         'url': 'Advent+Pro:300,300i,400,400i,700,700i',
     ),
-    'Muli': (
-        'family': ('Muli', sans-serif),
-        'url': 'Muli:300,300i,400,400i,700,700i',
+    'Mulish': (
+        'family': ('Mulish', sans-serif),
+        'url': 'Mulish:300,300i,400,400i,700,700i',
     ),
     'Noto Sans': (
         'family': ('Noto Sans', sans-serif),

--- a/theme_loftspace/static/src/scss/primary_variables.scss
+++ b/theme_loftspace/static/src/scss/primary_variables.scss
@@ -112,9 +112,9 @@ $o-theme-font-configs: (
         'family': ('Questrial', sans-serif),
         'url': 'Questrial:300,300i,400,400i,700,700i',
     ),
-    'Muli': (
-        'family': ('Muli', sans-serif),
-        'url': 'Muli:300,300i,400,400i,700,700i',
+    'Mulish': (
+        'family': ('Mulish', sans-serif),
+        'url': 'Mulish:300,300i,400,400i,700,700i',
     ),
 );
 

--- a/theme_odoo_experts/static/src/scss/primary_variables.scss
+++ b/theme_odoo_experts/static/src/scss/primary_variables.scss
@@ -44,9 +44,9 @@ $o-theme-font-configs: (
         'family': ('Questrial', sans-serif),
         'url': 'Questrial:300,300i,400,400i,700,700i',
     ),
-    'Muli': (
-        'family': ('Muli', sans-serif),
-        'url': 'Muli:300,300i,400,400i,700,700i',
+    'Mulish': (
+        'family': ('Mulish', sans-serif),
+        'url': 'Mulish:300,300i,400,400i,700,700i',
     ),
     'Anton': (
         'family': ('Anton', sans-serif),

--- a/theme_orchid/static/src/scss/primary_variables.scss
+++ b/theme_orchid/static/src/scss/primary_variables.scss
@@ -44,9 +44,9 @@ $o-theme-font-configs: (
         'family': ('Questrial', sans-serif),
         'url': 'Questrial:300,300i,400,400i,700,700i',
     ),
-    'Muli': (
-        'family': ('Muli', sans-serif),
-        'url': 'Muli:300,300i,400,400i,700,700i',
+    'Mulish': (
+        'family': ('Mulish', sans-serif),
+        'url': 'Mulish:300,300i,400,400i,700,700i',
     ),
     'Cormorant Garamond': (
         'family': ('Cormorant Garamond', serif),


### PR DESCRIPTION
* theme_bookstore, theme_clean, theme_enark, theme_kiddo, theme_loftspace, theme_odoo_experts, theme_orchid

This commit will rename the font "Muli" to "Mulish" as it has been renamed in Google Fonts.

Closes https://github.com/odoo/design-themes/issues/574