### PR TITLE
[FIX] theme_*: adapt svg shapes paths

### DIFF
--- a/theme_anelusia/views/snippets/s_company_team.xml
+++ b/theme_anelusia/views/snippets/s_company_team.xml
@@ -22,8 +22,8 @@
     </xpath>
     <!-- Team #01 - Img -->
     <xpath expr="//img" position="attributes">
-        <attribute name="src">/web_editor/image_shape/website.s_company_team_image_1/web_editor/basic/bsc_square_1.svg</attribute>
-        <attribute name="data-shape">web_editor/basic/bsc_square_1</attribute>
+        <attribute name="src">/web_editor/image_shape/website.s_company_team_image_1/web_editor/geometric/geo_square_1.svg</attribute>
+        <attribute name="data-shape">web_editor/geometric/geo_square_1</attribute>
         <attribute name="data-original-mimetype">image/jpeg</attribute>
         <attribute name="data-file-name">uiface_1.svg</attribute>
         <attribute name="data-shape-colors">;;;;</attribute>
@@ -44,8 +44,8 @@
     </xpath>
     <!-- Team #02 - Img -->
     <xpath expr="(//img)[2]" position="attributes">
-        <attribute name="src">/web_editor/image_shape/website.s_company_team_image_2/web_editor/basic/bsc_square_2.svg</attribute>
-        <attribute name="data-shape">web_editor/basic/bsc_square_2</attribute>
+        <attribute name="src">/web_editor/image_shape/website.s_company_team_image_2/web_editor/geometric/geo_square_2.svg</attribute>
+        <attribute name="data-shape">web_editor/geometric/geo_square_2</attribute>
         <attribute name="data-original-mimetype">image/jpeg</attribute>
         <attribute name="data-file-name">uiface_2.svg</attribute>
         <attribute name="data-shape-colors">;;;;</attribute>
@@ -66,8 +66,8 @@
     </xpath>
     <!-- Team #03 - Img -->
     <xpath expr="(//img)[3]" position="attributes">
-        <attribute name="src">/web_editor/image_shape/website.s_company_team_image_3/web_editor/basic/bsc_square_3.svg</attribute>
-        <attribute name="data-shape">web_editor/basic/bsc_square_3</attribute>
+        <attribute name="src">/web_editor/image_shape/website.s_company_team_image_3/web_editor/geometric/geo_square_3.svg</attribute>
+        <attribute name="data-shape">web_editor/geometric/geo_square_3</attribute>
         <attribute name="data-original-mimetype">image/jpeg</attribute>
         <attribute name="data-file-name">uiface_3.svg</attribute>
         <attribute name="data-shape-colors">;;;;</attribute>
@@ -88,8 +88,8 @@
     </xpath>
     <!-- Team #04 - Img -->
     <xpath expr="(//img)[4]" position="attributes">
-        <attribute name="src">/web_editor/image_shape/website.s_company_team_image_4/web_editor/basic/bsc_square_1.svg</attribute>
-        <attribute name="data-shape">web_editor/basic/bsc_square_1</attribute>
+        <attribute name="src">/web_editor/image_shape/website.s_company_team_image_4/web_editor/geometric/geo_square_1.svg</attribute>
+        <attribute name="data-shape">web_editor/geometric/geo_square_1</attribute>
         <attribute name="data-original-mimetype">image/jpeg</attribute>
         <attribute name="data-file-name">uiface_4.svg</attribute>
         <attribute name="data-shape-colors">;;;;</attribute>

--- a/theme_anelusia/views/snippets/s_image_text.xml
+++ b/theme_anelusia/views/snippets/s_image_text.xml
@@ -4,8 +4,8 @@
 <template id="s_image_text" inherit_id="website.s_image_text">
     <!-- Img -->
     <xpath expr="//img" position="attributes">
-        <attribute name="src">/web_editor/image_shape/website.s_image_text_default_image/web_editor/float/flt_square_1.svg?c1=o-color-1&amp;c2=o-color-3</attribute>
-        <attribute name="data-shape">web_editor/float/flt_square_1</attribute>
+        <attribute name="src">/web_editor/image_shape/website.s_image_text_default_image/web_editor/composition/composition_square_1.svg?c1=o-color-1&amp;c2=o-color-3</attribute>
+        <attribute name="data-shape">web_editor/composition/composition_square_1</attribute>
         <attribute name="data-original-mimetype">image/jpeg</attribute>
         <attribute name="data-file-name">s_image_text.svg</attribute>
         <attribute name="data-shape-colors">o-color-1;o-color-3;;;</attribute>

--- a/theme_anelusia/views/snippets/s_media_list.xml
+++ b/theme_anelusia/views/snippets/s_media_list.xml
@@ -17,8 +17,8 @@
     </xpath>
     <!-- Media #01 - Img -->
     <xpath expr="//div[hasclass('s_media_list_img_wrapper')]//img" position="attributes">
-        <attribute name="src">/web_editor/image_shape/website.s_media_list_default_image_1/web_editor/float/flt_square_1.svg?c1=o-color-4&amp;c2=o-color-2</attribute>
-        <attribute name="data-shape">web_editor/float/flt_square_1</attribute>
+        <attribute name="src">/web_editor/image_shape/website.s_media_list_default_image_1/web_editor/composition/composition_square_1.svg?c1=o-color-4&amp;c2=o-color-2</attribute>
+        <attribute name="data-shape">web_editor/composition/composition_square_1</attribute>
         <attribute name="data-original-mimetype">image/jpeg</attribute>
         <attribute name="data-file-name">s_media_list_1.svg</attribute>
         <attribute name="data-shape-colors">o-color-4;o-color-2;;;</attribute>
@@ -46,8 +46,8 @@
     </xpath>
     <!-- Media #02 - Img -->
     <xpath expr="(//div[hasclass('s_media_list_img_wrapper')])[2]//img" position="attributes">
-        <attribute name="src">/web_editor/image_shape/website.s_media_list_default_image_2/web_editor/float/flt_square_3.svg?c1=o-color-1&amp;c5=o-color-2</attribute>
-        <attribute name="data-shape">web_editor/float/flt_square_3</attribute>
+        <attribute name="src">/web_editor/image_shape/website.s_media_list_default_image_2/web_editor/composition/composition_square_3.svg?c1=o-color-1&amp;c5=o-color-2</attribute>
+        <attribute name="data-shape">web_editor/composition/composition_square_3</attribute>
         <attribute name="data-original-mimetype">image/jpeg</attribute>
         <attribute name="data-file-name">s_media_list_2.svg</attribute>
         <attribute name="data-shape-colors">o-color-1;;;;o-color-2</attribute>

--- a/theme_anelusia/views/snippets/s_product_list.xml
+++ b/theme_anelusia/views/snippets/s_product_list.xml
@@ -12,48 +12,48 @@
     </xpath>
     <!-- Item #1 - Img -->
     <xpath expr="//img" position="attributes">
-        <attribute name="src">/web_editor/image_shape/website.s_product_list_default_image_1/web_editor/basic/bsc_square_1.svg</attribute>
-        <attribute name="data-shape">web_editor/basic/bsc_square_1</attribute>
+        <attribute name="src">/web_editor/image_shape/website.s_product_list_default_image_1/web_editor/geometric/geo_square_1.svg</attribute>
+        <attribute name="data-shape">web_editor/geometric/geo_square_1</attribute>
         <attribute name="data-original-mimetype">image/jpeg</attribute>
         <attribute name="data-file-name">s_product_1.svg</attribute>
         <attribute name="data-shape-colors">;;;;</attribute>
     </xpath>
     <!-- Item #2 - Img -->
     <xpath expr="(//img)[2]" position="attributes">
-        <attribute name="src">/web_editor/image_shape/website.s_product_list_default_image_2/web_editor/basic/bsc_square_3.svg</attribute>
-        <attribute name="data-shape">web_editor/basic/bsc_square_3</attribute>
+        <attribute name="src">/web_editor/image_shape/website.s_product_list_default_image_2/web_editor/geometric/geo_square_3.svg</attribute>
+        <attribute name="data-shape">web_editor/geometric/geo_square_3</attribute>
         <attribute name="data-original-mimetype">image/jpeg</attribute>
         <attribute name="data-file-name">s_product_2.svg</attribute>
         <attribute name="data-shape-colors">;;;;</attribute>
     </xpath>
     <!-- Item #3 - Img -->
     <xpath expr="(//img)[3]" position="attributes">
-        <attribute name="src">/web_editor/image_shape/website.s_product_list_default_image_3/web_editor/basic/bsc_square_2.svg</attribute>
-        <attribute name="data-shape">web_editor/basic/bsc_square_2</attribute>
+        <attribute name="src">/web_editor/image_shape/website.s_product_list_default_image_3/web_editor/geometric/geo_square_2.svg</attribute>
+        <attribute name="data-shape">web_editor/geometric/geo_square_2</attribute>
         <attribute name="data-original-mimetype">image/jpeg</attribute>
         <attribute name="data-file-name">s_product_3.svg</attribute>
         <attribute name="data-shape-colors">;;;;</attribute>
     </xpath>
     <!-- Item #4 - Img -->
     <xpath expr="(//img)[4]" position="attributes">
-        <attribute name="src">/web_editor/image_shape/website.s_product_list_default_image_4/web_editor/basic/bsc_square_1.svg</attribute>
-        <attribute name="data-shape">web_editor/basic/bsc_square_1</attribute>
+        <attribute name="src">/web_editor/image_shape/website.s_product_list_default_image_4/web_editor/geometric/geo_square_1g</attribute>
+        <attribute name="data-shape">web_editor/geometric/geo_square_1</attribute>
         <attribute name="data-original-mimetype">image/jpeg</attribute>
         <attribute name="data-file-name">s_product_4.svg</attribute>
         <attribute name="data-shape-colors">;;;;</attribute>
     </xpath>
     <!-- Item #5 - Img -->
     <xpath expr="(//img)[5]" position="attributes">
-        <attribute name="src">/web_editor/image_shape/website.s_product_list_default_image_5/web_editor/basic/bsc_square_2.svg</attribute>
-        <attribute name="data-shape">web_editor/basic/bsc_square_2</attribute>
+        <attribute name="src">/web_editor/image_shape/website.s_product_list_default_image_5/web_editor/geometric/geo_square_2.svg</attribute>
+        <attribute name="data-shape">web_editor/geometric/geo_square_2</attribute>
         <attribute name="data-original-mimetype">image/jpeg</attribute>
         <attribute name="data-file-name">s_product_5.svg</attribute>
         <attribute name="data-shape-colors">;;;;</attribute>
     </xpath>
     <!-- Item #6 - Img -->
     <xpath expr="(//img)[6]" position="attributes">
-        <attribute name="src">/web_editor/image_shape/website.s_product_list_default_image_6/web_editor/basic/bsc_square_3.svg</attribute>
-        <attribute name="data-shape">web_editor/basic/bsc_square_3</attribute>
+        <attribute name="src">/web_editor/image_shape/website.s_product_list_default_image_6/web_editor/geometric/geo_square_3.svg</attribute>
+        <attribute name="data-shape">web_editor/geometric/geo_square_3</attribute>
         <attribute name="data-original-mimetype">image/jpeg</attribute>
         <attribute name="data-file-name">s_product_6.svg</attribute>
         <attribute name="data-shape-colors">;;;;</attribute>

--- a/theme_anelusia/views/snippets/s_text_image.xml
+++ b/theme_anelusia/views/snippets/s_text_image.xml
@@ -8,8 +8,8 @@
     </xpath>
     <!-- Img -->
     <xpath expr="//img" position="attributes">
-        <attribute name="src">/web_editor/image_shape/website.s_text_image_default_image/web_editor/float/flt_square_3.svg?c1=o-color-2&amp;c5=o-color-1</attribute>
-        <attribute name="data-shape">web_editor/float/flt_square_3</attribute>
+        <attribute name="src">/web_editor/image_shape/website.s_text_image_default_image/web_editor/composition/composition_square_3.svg?c1=o-color-2&amp;c5=o-color-1</attribute>
+        <attribute name="data-shape">web_editor/composition/composition_square_3</attribute>
         <attribute name="data-original-mimetype">image/jpeg</attribute>
         <attribute name="data-file-name">s_text_image.svg</attribute>
         <attribute name="data-shape-colors">o-color-2;;;;o-color-1</attribute>

--- a/theme_artists/views/snippets/s_image_text.xml
+++ b/theme_artists/views/snippets/s_image_text.xml
@@ -24,8 +24,8 @@
     </xpath>
     <!-- Picture -->
     <xpath expr="//img" position="attributes">
-        <attribute name="src">/web_editor/image_shape/website.s_image_text_default_image/web_editor/basic/bsc_square_3.svg</attribute>
-        <attribute name="data-shape">web_editor/basic/bsc_square_3</attribute>
+        <attribute name="src">/web_editor/image_shape/website.s_image_text_default_image/web_editor/geometric/geo_square_3.svg</attribute>
+        <attribute name="data-shape">web_editor/geometric/geo_square_3</attribute>
         <attribute name="data-original-mimetype">image/jpeg</attribute>
         <attribute name="data-file-name">s_image_text.svg</attribute>
         <attribute name="data-shape-colors">;;;;</attribute>

--- a/theme_artists/views/snippets/s_text_image.xml
+++ b/theme_artists/views/snippets/s_text_image.xml
@@ -27,8 +27,8 @@
         <attribute name="class" add="col-lg-5 offset-lg-1" remove="col-lg-6" separator=" "/>
     </xpath>
     <xpath expr="//img" position="attributes">
-        <attribute name="src">/web_editor/image_shape/website.s_text_image_default_image/web_editor/basic/bsc_square_2.svg</attribute>
-        <attribute name="data-shape">web_editor/basic/bsc_square_2</attribute>
+        <attribute name="src">/web_editor/image_shape/website.s_text_image_default_image/web_editor/geometric/geo_square_2.svg</attribute>
+        <attribute name="data-shape">web_editor/geometric/geo_square_2</attribute>
         <attribute name="data-original-mimetype">image/jpeg</attribute>
         <attribute name="data-file-name">s_text_image.svg</attribute>
         <attribute name="data-shape-colors">;;;;</attribute>

--- a/theme_avantgarde/views/customizations.xml
+++ b/theme_avantgarde/views/customizations.xml
@@ -52,8 +52,8 @@
     </xpath>
     <xpath expr="//img" position="attributes">
         <attribute name="class" add="img-fluid" remove="img-thumbnail" separator=" "/>
-        <attribute name="src">/web_editor/image_shape/website.s_picture_default_image/web_editor/line/oval_2_line.svg?c2=o-color-2</attribute>
-        <attribute name="data-shape">web_editor/line/oval_2_line</attribute>
+        <attribute name="src">/web_editor/image_shape/website.s_picture_default_image/web_editor/composition/composition_organic_line.svg?c2=o-color-2</attribute>
+        <attribute name="data-shape">web_editor/composition/composition_organic_line</attribute>
         <attribute name="data-original-mimetype">image/jpeg</attribute>
         <attribute name="data-file-name">bg_image_14.svg</attribute>
         <attribute name="data-shape-colors">;o-color-2;;;</attribute>
@@ -137,8 +137,8 @@
     </xpath>
     <xpath expr="//img" position="attributes">
         <attribute name="class" remove="img-thumbnail" separator=" "/>
-        <attribute name="src">/web_editor/image_shape/website.s_text_image_default_image/web_editor/line/line_triangle.svg?c1=o-color-1</attribute>
-        <attribute name="data-shape">web_editor/line/line_triangle</attribute>
+        <attribute name="src">/web_editor/image_shape/website.s_text_image_default_image/web_editor/composition/composition_triangle_line.svg?c1=o-color-1</attribute>
+        <attribute name="data-shape">web_editor/composition/composition_triangle_line</attribute>
         <attribute name="data-original-mimetype">image/jpeg</attribute>
         <attribute name="data-file-name">bg_image_13.svg</attribute>
         <attribute name="data-shape-colors">;o-color-1;;;</attribute>

--- a/theme_beauty/views/snippets/s_image_text.xml
+++ b/theme_beauty/views/snippets/s_image_text.xml
@@ -4,8 +4,8 @@
 <template id="s_image_text" inherit_id="website.s_image_text">
     <!-- Img -->
     <xpath expr="//img" position="attributes">
-        <attribute name="src">/web_editor/image_shape/website.s_image_text_default_image/web_editor/pattern/pattern_waves_4.svg?c1=o-color-1&amp;c3=o-color-4</attribute>
-        <attribute name="data-shape">web_editor/pattern/pattern_waves_4</attribute>
+        <attribute name="src">/web_editor/image_shape/website.s_image_text_default_image/web_editor/pattern/pattern_wave_3.svg?c1=o-color-1&amp;c3=o-color-4</attribute>
+        <attribute name="data-shape">web_editor/pattern/pattern_wave_3</attribute>
         <attribute name="data-original-mimetype">image/jpeg</attribute>
         <attribute name="data-file-name">s_image_text.svg</attribute>
         <attribute name="data-shape-colors">o-color-1;;o-color-4;;</attribute>

--- a/theme_beauty/views/snippets/s_media_list.xml
+++ b/theme_beauty/views/snippets/s_media_list.xml
@@ -8,24 +8,24 @@
     </xpath>
     <!-- Item #1 - img -->
     <xpath expr="//img" position="attributes">
-        <attribute name="src">/web_editor/image_shape/website.s_media_list_default_image_1/web_editor/line/little_lines_1.svg?c1=o-color-1</attribute>
-        <attribute name="data-shape">web_editor/line/little_lines_1</attribute>
+        <attribute name="src">/web_editor/image_shape/website.s_media_list_default_image_1/web_editor/composition/composition_line_2.svg?c1=o-color-1</attribute>
+        <attribute name="data-shape">web_editor/composition/composition_line_2</attribute>
         <attribute name="data-original-mimetype">image/jpeg</attribute>
         <attribute name="data-file-name">s_media_list_1.svg</attribute>
         <attribute name="data-shape-colors">o-color-1;;;;</attribute>
     </xpath>
     <!-- Item #2 - img -->
     <xpath expr="(//img)[2]" position="attributes">
-        <attribute name="src">/web_editor/image_shape/website.s_media_list_default_image_2/web_editor/line/little_lines_3.svg?c1=o-color-1&amp;c2=o-color-2&amp;c5=o-color-3</attribute>
-        <attribute name="data-shape">web_editor/line/little_lines_3</attribute>
+        <attribute name="src">/web_editor/image_shape/website.s_media_list_default_image_2/web_editor/composition/composition_line_3.svg?c1=o-color-1&amp;c2=o-color-2&amp;c5=o-color-3</attribute>
+        <attribute name="data-shape">web_editor/composition/composition_line_3</attribute>
         <attribute name="data-original-mimetype">image/jpeg</attribute>
         <attribute name="data-file-name">s_media_list_2.svg</attribute>
         <attribute name="data-shape-colors">o-color-1;o-color-2;;;o-color-3</attribute>
     </xpath>
     <!-- Item #3 - img -->
     <xpath expr="(//img)[3]" position="attributes">
-        <attribute name="src">/web_editor/image_shape/website.s_media_list_default_image_3/web_editor/line/little_lines_2.svg?c2=o-color-2</attribute>
-        <attribute name="data-shape">web_editor/line/little_lines_2</attribute>
+        <attribute name="src">/web_editor/image_shape/website.s_media_list_default_image_3/web_editor/composition/composition_line_2.svg?c2=o-color-2</attribute>
+        <attribute name="data-shape">web_editor/composition/composition_line_2</attribute>
         <attribute name="data-original-mimetype">image/jpeg</attribute>
         <attribute name="data-file-name">s_media_list_3.svg</attribute>
         <attribute name="data-shape-colors">;o-color-2;;;</attribute>

--- a/theme_beauty/views/snippets/s_text_image.xml
+++ b/theme_beauty/views/snippets/s_text_image.xml
@@ -18,8 +18,8 @@
     <xpath expr="//p[2]" position="replace"/>
     <!-- Img -->
     <xpath expr="//img" position="attributes">
-        <attribute name="src">/web_editor/image_shape/website.s_text_image_default_image/web_editor/pattern/pattern_waves_3.svg?c1=o-color-1&amp;c2=o-color-2&amp;c3=o-color-3&amp;c5=o-color-1</attribute>
-        <attribute name="data-shape">web_editor/pattern/pattern_waves_3</attribute>
+        <attribute name="src">/web_editor/image_shape/website.s_text_image_default_image/web_editor/pattern/pattern_wave_4.svg?c1=o-color-1&amp;c2=o-color-2&amp;c3=o-color-3&amp;c5=o-color-1</attribute>
+        <attribute name="data-shape">web_editor/pattern/pattern_wave_4</attribute>
         <attribute name="data-original-mimetype">image/jpeg</attribute>
         <attribute name="data-file-name">s_text_image.svg</attribute>
         <attribute name="data-shape-colors">o-color-1;o-color-2;o-color-3;;o-color-1</attribute>

--- a/theme_bistro/views/snippets/s_text_image.xml
+++ b/theme_bistro/views/snippets/s_text_image.xml
@@ -8,9 +8,9 @@
     </xpath>
     <!-- Image -->
     <xpath expr="//img" position="attributes">
-        <attribute name="src">/web_editor/image_shape/website.s_text_image_default_image/web_editor/basic/bsc_square_rounded_2.svg</attribute>
+        <attribute name="src">/web_editor/image_shape/website.s_text_image_default_image/web_editor/geometric_round/geo_round_square_2.svg</attribute>
         <attribute name="data-file-name">text_image.svg</attribute>
-        <attribute name="data-shape">web_editor/basic/bsc_square_rounded_2</attribute>
+        <attribute name="data-shape">web_editor/geometric_round/geo_round_square_2</attribute>
         <attribute name="data-shape-colors">;;;;</attribute>
     </xpath>
 </template>

--- a/theme_clean/views/snippets/s_text_image.xml
+++ b/theme_clean/views/snippets/s_text_image.xml
@@ -18,8 +18,8 @@
     </xpath>
     <!-- Image -->
     <xpath expr="//img" position="attributes">
-        <attribute name="src">/web_editor/image_shape/website.s_text_image_default_image/web_editor/pattern/pattern_points_1.svg?c1=o-color-1</attribute>
-        <attribute name="data-shape">web_editor/pattern/pattern_points_1</attribute>
+        <attribute name="src">/web_editor/image_shape/website.s_text_image_default_image/web_editor/pattern/pattern_point.svg?c1=o-color-1</attribute>
+        <attribute name="data-shape">web_editor/pattern/pattern_point</attribute>
         <attribute name="data-original-mimetype">image/jpeg</attribute>
         <attribute name="data-file-name">image_content_19.svg</attribute>
         <attribute name="data-shape-colors">o-color-1;;;;</attribute>

--- a/theme_kea/views/snippets/s_media_list.xml
+++ b/theme_kea/views/snippets/s_media_list.xml
@@ -22,8 +22,8 @@
         <attribute name="class" add="col-lg-6" remove="col-lg-8" separator=" "/>
     </xpath>
     <xpath expr="(//img)" position="attributes">
-        <attribute name="src">/web_editor/image_shape/website.s_media_list_default_image_3/web_editor/basic/bsc_organic_2.svg</attribute>
-        <attribute name="data-shape">web_editor/basic/bsc_organic_2</attribute>
+        <attribute name="src">/web_editor/image_shape/website.s_media_list_default_image_3/web_editor/geometric_round/geo_round_blob_medium.svg</attribute>
+        <attribute name="data-shape">web_editor/geometric_round/geo_round_blob_medium</attribute>
         <attribute name="data-original-mimetype">image/jpeg</attribute>
         <attribute name="data-file-name">s_media_list_3.svg</attribute>
         <attribute name="data-shape-colors">;;;;</attribute>
@@ -39,8 +39,8 @@
         <attribute name="class" add="col-lg-6" remove="col-lg-8" separator=" "/>
     </xpath>
     <xpath expr="(//img)[2]" position="attributes">
-        <attribute name="src">/web_editor/image_shape/website.s_media_list_default_image_2/web_editor/basic/bsc_organic_2.svg</attribute>
-        <attribute name="data-shape">web_editor/basic/bsc_organic_2</attribute>
+        <attribute name="src">/web_editor/image_shape/website.s_media_list_default_image_2/web_editor/geometric_round/geo_round_blob_medium.svg</attribute>
+        <attribute name="data-shape">web_editor/geometric_round/geo_round_blob_medium</attribute>
         <attribute name="data-original-mimetype">image/jpeg</attribute>
         <attribute name="data-file-name">s_media_list_2.svg</attribute>
         <attribute name="data-shape-colors">;;;;</attribute>
@@ -56,8 +56,8 @@
         <attribute name="class" add="col-lg-6" remove="col-lg-8" separator=" "/>
     </xpath>
     <xpath expr="(//img)[3]" position="attributes">
-        <attribute name="src">/web_editor/image_shape/website.s_media_list_default_image_1/web_editor/basic/bsc_organic_2.svg</attribute>
-        <attribute name="data-shape">web_editor/basic/bsc_organic_2</attribute>
+        <attribute name="src">/web_editor/image_shape/website.s_media_list_default_image_1/web_editor/geometric_round/geo_round_blob_medium.svg</attribute>
+        <attribute name="data-shape">web_editor/geometric_round/geo_round_blob_medium</attribute>
         <attribute name="data-original-mimetype">image/jpeg</attribute>
         <attribute name="data-file-name">s_media_list_1.svg</attribute>
         <attribute name="data-shape-colors">;;;;</attribute>

--- a/theme_kea/views/snippets/s_picture.xml
+++ b/theme_kea/views/snippets/s_picture.xml
@@ -19,8 +19,8 @@
     <xpath expr="//img" position="attributes">
         <attribute name="class" remove="img-thumbnail" separator=" "/>
         <attribute name="style">width: 100%;</attribute>
-        <attribute name="src">/web_editor/image_shape/website.s_media_list_default_image_1/web_editor/basic/bsc_organic_2.svg</attribute>
-        <attribute name="data-shape">web_editor/basic/bsc_organic_2</attribute>
+        <attribute name="src">/web_editor/image_shape/website.s_media_list_default_image_1/web_editor/geometric_round/geo_round_blob_medium.svg</attribute>
+        <attribute name="data-shape">web_editor/geometric_round/geo_round_blob_medium</attribute>
         <attribute name="data-shape-colors">;;;;</attribute>
     </xpath>
     <!-- Paragraphs -->

--- a/theme_kiddo/views/snippets/s_image_text.xml
+++ b/theme_kiddo/views/snippets/s_image_text.xml
@@ -36,11 +36,11 @@
     <xpath expr="//p[2]" position="after">
         <p><br/></p>
     </xpath>
-    
+
     <!-- Img -->
     <xpath expr="//img" position="attributes">
-        <attribute name="src">/web_editor/image_shape/website.s_image_text_default_image/web_editor/basic/bsc_square_rounded_2.svg</attribute>
-        <attribute name="data-shape">web_editor/basic/bsc_square_rounded_2</attribute>
+        <attribute name="src">/web_editor/image_shape/website.s_image_text_default_image/web_editor/geometric_round/geo_round_square_2.svg</attribute>
+        <attribute name="data-shape">web_editor/geometric_round/geo_round_square_2</attribute>
         <attribute name="data-original-mimetype">image/jpeg</attribute>
         <attribute name="data-file-name">s_image_text.svg</attribute>
         <attribute name="data-shape-colors">;;;;</attribute>

--- a/theme_kiddo/views/snippets/s_text_image.xml
+++ b/theme_kiddo/views/snippets/s_text_image.xml
@@ -24,11 +24,11 @@
             <hr class="w-50 me-auto" style="border-top: 4px dotted var(--o-color-1) !important;"/>
         </div>
     </xpath>
-    
+
     <!-- Img -->
     <xpath expr="//img" position="attributes">
-        <attribute name="src">/web_editor/image_shape/website.s_text_image_default_image/web_editor/basic/bsc_square_rounded_1.svg</attribute>
-        <attribute name="data-shape">web_editor/basic/bsc_square_rounded_1</attribute>
+        <attribute name="src">/web_editor/image_shape/website.s_text_image_default_image/web_editor/geometric_round/geo_round_square_1.svg</attribute>
+        <attribute name="data-shape">web_editor/geometric_round/geo_round_square_1</attribute>
         <attribute name="data-original-mimetype">image/jpeg</attribute>
         <attribute name="data-file-name">content_img_13.svg</attribute>
         <attribute name="data-shape-colors">;;;;</attribute>

--- a/theme_kiddo/views/snippets/s_three_columns.xml
+++ b/theme_kiddo/views/snippets/s_three_columns.xml
@@ -18,8 +18,8 @@
         <attribute name="style">border-width: 0px !important;</attribute>
     </xpath>
     <xpath expr="//img" position="attributes">
-        <attribute name="src">/web_editor/image_shape/website.s_three_columns_default_image_1/web_editor/solid/blob_1_solid_rd.svg?c2=o-color-1</attribute>
-        <attribute name="data-shape">web_editor/solid/blob_1_solid_rd</attribute>
+        <attribute name="src">/web_editor/image_shape/website.s_three_columns_default_image_1/web_editor/solid/solid_blob_1.svg?c2=o-color-1</attribute>
+        <attribute name="data-shape">web_editor/solid/solid_blob_1</attribute>
         <attribute name="data-original-mimetype">image/jpeg</attribute>
         <attribute name="data-file-name">s_three_columns_default_image_1.svg</attribute>
         <attribute name="data-shape-colors">;o-color-1;;;</attribute>
@@ -44,14 +44,14 @@
     <xpath expr="//p" position="replace" mode="inner">
         Our aim is to make the early years of your child’s life as enjoyable, rewarding and positive as possible.
     </xpath>
-    
+
     <!-- Column n°2 -->
     <xpath expr="(//div[hasclass('card')])[2]" position="attributes">
         <attribute name="style">border-width: 0px !important;</attribute>
     </xpath>
     <xpath expr="(//img)[2]" position="attributes">
-        <attribute name="src">/web_editor/image_shape/website.s_three_columns_default_image_2/web_editor/line/oval_2_line.svg?c2=o-color-3</attribute>
-        <attribute name="data-shape">web_editor/line/oval_2_line</attribute>
+        <attribute name="src">/web_editor/image_shape/website.s_three_columns_default_image_2/web_editor/composition/composition_organic_line.svg?c2=o-color-3</attribute>
+        <attribute name="data-shape">web_editor/composition/composition_organic_line</attribute>
         <attribute name="data-original-mimetype">image/jpeg</attribute>
         <attribute name="data-file-name">s_three_columns_default_image_2.svg</attribute>
         <attribute name="data-shape-colors">;o-color-3;;;</attribute>
@@ -76,14 +76,14 @@
     <xpath expr="(//p)[2]" position="replace" mode="inner">
         All activities are planned to meet each child’s individual needs. This approach will help your child to develop to the best of their ability.
     </xpath>
-    
+
     <!-- Column n°3 -->
     <xpath expr="(//div[hasclass('card')])[3]" position="attributes">
         <attribute name="style">border-width: 0px !important;</attribute>
     </xpath>
     <xpath expr="(//img)[3]" position="attributes">
-        <attribute name="src">/web_editor/image_shape/website.s_three_columns_default_image_3/web_editor/solid/blob_3_solid_rd.svg?c5=o-color-2</attribute>
-        <attribute name="data-shape">web_editor/solid/blob_3_solid_rd</attribute>
+        <attribute name="src">/web_editor/image_shape/website.s_three_columns_default_image_3/web_editor/solid/solid_blob_3.svg?c5=o-color-2</attribute>
+        <attribute name="data-shape">web_editor/solid/solid_blob_3</attribute>
         <attribute name="data-original-mimetype">image/jpeg</attribute>
         <attribute name="data-file-name">s_three_columns_default_image_3.svg</attribute>
         <attribute name="data-shape-colors">;;;;o-color-2</attribute>

--- a/theme_monglia/views/customizations.xml
+++ b/theme_monglia/views/customizations.xml
@@ -105,8 +105,8 @@
         <attribute name="class" remove="col-lg-6" add="col-lg-5 offset-lg-1" separator=" "/>
     </xpath>
     <xpath expr="//img" position="attributes">
-        <attribute name="src">/web_editor/image_shape/website.s_text_image_default_image/web_editor/basic/bsc_square_3.svg</attribute>
-        <attribute name="data-shape">web_editor/basic/bsc_square_3</attribute>
+        <attribute name="src">/web_editor/image_shape/website.s_text_image_default_image/web_editor/geometric/geo_square_3.svg</attribute>
+        <attribute name="data-shape">web_editor/geometric/geo_square_3</attribute>
         <attribute name="data-original-mimetype">image/jpeg</attribute>
         <attribute name="data-file-name">s_text_image.svg</attribute>
         <attribute name="data-shape-colors">;;;;</attribute>
@@ -139,8 +139,8 @@
     </xpath>
     <xpath expr="//p[2]" position="replace"/>
     <xpath expr="//img" position="attributes">
-        <attribute name="src">/web_editor/image_shape/website.s_image_text_default_image/web_editor/basic/bsc_square_6.svg</attribute>
-        <attribute name="data-shape">web_editor/basic/bsc_square_6</attribute>
+        <attribute name="src">/web_editor/image_shape/website.s_image_text_default_image/web_editor/geometric/geo_square_6.svg</attribute>
+        <attribute name="data-shape">web_editor/geometric/geo_square_6</attribute>
         <attribute name="data-original-mimetype">image/jpeg</attribute>
         <attribute name="data-file-name">s_image_text.svg</attribute>
         <attribute name="data-shape-colors">;;;;</attribute>

--- a/theme_nano/views/snippets/s_image_text.xml
+++ b/theme_nano/views/snippets/s_image_text.xml
@@ -11,9 +11,9 @@
     </xpath>
     <!-- Image + Shape -->
     <xpath expr="//img" position="attributes">
-        <attribute name="src">/web_editor/image_shape/website.s_image_text_default_image/web_editor/float/flt_planets_2.svg</attribute>
+        <attribute name="src">/web_editor/image_shape/website.s_image_text_default_image/web_editor/composition/composition_planet_2.svg</attribute>
         <attribute name="data-file-name">s_image_text.svg</attribute>
-        <attribute name="data-shape">web_editor/float/flt_planets_2</attribute>
+        <attribute name="data-shape">web_editor/composition/composition_planet_2</attribute>
         <attribute name="data-shape-colors">;;;;</attribute>
     </xpath>
     <!-- Column #02 -->

--- a/theme_nano/views/snippets/s_text_image.xml
+++ b/theme_nano/views/snippets/s_text_image.xml
@@ -11,9 +11,9 @@
     </xpath>
     <!-- Image + Shape -->
     <xpath expr="//img" position="attributes">
-        <attribute name="src">/web_editor/image_shape/website.s_text_image_default_image/web_editor/pattern/pattern_points_1.svg</attribute>
+        <attribute name="src">/web_editor/image_shape/website.s_text_image_default_image/web_editor/pattern/pattern_point.svg</attribute>
             <attribute name="data-file-name">s_text_image.svg</attribute>
-        <attribute name="data-shape">web_editor/pattern/pattern_points_1</attribute>
+        <attribute name="data-shape">web_editor/pattern/pattern_point</attribute>
         <attribute name="data-shape-colors">;;;;</attribute>
     </xpath>
 </template>

--- a/theme_orchid/views/snippets/s_image_text.xml
+++ b/theme_orchid/views/snippets/s_image_text.xml
@@ -28,8 +28,8 @@
     </xpath>
     <!-- Img -->
     <xpath expr="//img" position="attributes">
-        <attribute name="src">/web_editor/image_shape/website.s_image_text_default_image/web_editor/float/flt_primary_1.svg?c1=o-color-2&amp;c2=o-color-2&amp;c5=o-color-5</attribute>
-        <attribute name="data-shape">web_editor/float/flt_primary_1</attribute>
+        <attribute name="src">/web_editor/image_shape/website.s_image_text_default_image/web_editor/composition/composition_mixed_1.svg?c1=o-color-2&amp;c2=o-color-2&amp;c5=o-color-5</attribute>
+        <attribute name="data-shape">web_editor/composition/composition_mixed_1</attribute>
         <attribute name="data-original-mimetype">image/jpeg</attribute>
         <attribute name="data-file-name">s_carousel_2.svg</attribute>
         <attribute name="data-shape-colors">o-color-2;o-color-2;;;o-color-5</attribute>

--- a/theme_orchid/views/snippets/s_text_image.xml
+++ b/theme_orchid/views/snippets/s_text_image.xml
@@ -37,8 +37,8 @@
     </xpath>
     <!-- Img -->
     <xpath expr="//img" position="attributes">
-        <attribute name="src">/web_editor/image_shape/website.s_text_image_default_image/web_editor/solid/sld_blob_shadow_2.svg?c2=o-color-2</attribute>
-        <attribute name="data-shape">web_editor/solid/sld_blob_shadow_2</attribute>
+        <attribute name="src">/web_editor/image_shape/website.s_text_image_default_image/web_editor/solid/solid_blob_shadow_2.svg?c2=o-color-2</attribute>
+        <attribute name="data-shape">web_editor/solid/solid_blob_shadow_2</attribute>
         <attribute name="data-original-mimetype">image/jpeg</attribute>
         <attribute name="data-file-name">s_media_list_3.svg</attribute>
         <attribute name="data-shape-colors">;o-color-2;;;</attribute>

--- a/theme_orchid/views/snippets/s_three_columns.xml
+++ b/theme_orchid/views/snippets/s_three_columns.xml
@@ -30,8 +30,8 @@
     </xpath>
     <!-- Column 1 - Img -->
     <xpath expr="//img" position="attributes">
-        <attribute name="src">/web_editor/image_shape/website.s_three_columns_default_image_1/web_editor/float/flt_square_1.svg?c1=o-color-1&amp;c2=o-color-2</attribute>
-        <attribute name="data-shape">web_editor/float/flt_square_1</attribute>
+        <attribute name="src">/web_editor/image_shape/website.s_three_columns_default_image_1/web_editor/composition/composition_square_1.svg?c1=o-color-1&amp;c2=o-color-2</attribute>
+        <attribute name="data-shape">web_editor/composition/composition_square_1</attribute>
         <attribute name="data-original-mimetype">image/jpeg</attribute>
         <attribute name="data-file-name">library_image_11.svg</attribute>
         <attribute name="data-shape-colors">o-color-1;o-color-2;;;</attribute>
@@ -51,8 +51,8 @@
     </xpath>
     <!-- Column 2 - Img -->
     <xpath expr="(//img)[2]" position="attributes">
-        <attribute name="src">/web_editor/image_shape/website.s_three_columns_default_image_2/web_editor/float/flt_square_3.svg?c1=o-color-1&amp;c5=o-color-5</attribute>
-        <attribute name="data-shape">web_editor/float/flt_square_3</attribute>
+        <attribute name="src">/web_editor/image_shape/website.s_three_columns_default_image_2/web_editor/composition/composition_square_3.svg?c1=o-color-1&amp;c5=o-color-5</attribute>
+        <attribute name="data-shape">web_editor/composition/composition_square_3</attribute>
         <attribute name="data-original-mimetype">image/jpeg</attribute>
         <attribute name="data-file-name">library_image_13.svg</attribute>
         <attribute name="data-shape-colors">o-color-1;;;;o-color-5</attribute>
@@ -72,8 +72,8 @@
     </xpath>
     <!-- Column 3 - Img -->
     <xpath expr="(//img)[3]" position="attributes">
-        <attribute name="src">/web_editor/image_shape/website.s_three_columns_default_image_3/web_editor/float/flt_square_2.svg?c2=o-color-1&amp;c5=o-color-2</attribute>
-        <attribute name="data-shape">web_editor/float/flt_square_2</attribute>
+        <attribute name="src">/web_editor/image_shape/website.s_three_columns_default_image_3/web_editor/composition/composition_square_2.svg?c2=o-color-1&amp;c5=o-color-2</attribute>
+        <attribute name="data-shape">web_editor/composition/composition_square_2</attribute>
         <attribute name="data-original-mimetype">image/jpeg</attribute>
         <attribute name="data-file-name">library_image_07.svg</attribute>
         <attribute name="data-shape-colors">;o-color-1;;;o-color-2</attribute>

--- a/theme_real_estate/views/snippets/s_image_text.xml
+++ b/theme_real_estate/views/snippets/s_image_text.xml
@@ -25,8 +25,8 @@
 
     <!-- Image -->
     <xpath expr="//img" position="attributes">
-        <attribute name="src">/web_editor/image_shape/website.s_image_text_default_image/web_editor/solid/sld_square_2.svg?c1=o-color-3</attribute>
-        <attribute name="data-shape">web_editor/solid/sld_square_2</attribute>
+        <attribute name="src">/web_editor/image_shape/website.s_image_text_default_image/web_editor/solid/solid_square_2.svg?c1=o-color-3</attribute>
+        <attribute name="data-shape">web_editor/solid/solid_square_2</attribute>
         <attribute name="data-original-mimetype">image/jpeg</attribute>
         <attribute name="data-file-name">s_image_text.svg</attribute>
         <attribute name="data-shape-colors">o-color-3;;;;</attribute>

--- a/theme_real_estate/views/snippets/s_text_image.xml
+++ b/theme_real_estate/views/snippets/s_text_image.xml
@@ -19,8 +19,8 @@
     <xpath expr="//p[2]" position="replace" />
     <!-- Image -->
     <xpath expr="//img" position="attributes">
-        <attribute name="src">/web_editor/image_shape/website.s_text_image_default_image/web_editor/solid/sld_square_1.svg?c2=o-color-3</attribute>
-        <attribute name="data-shape">web_editor/solid/sld_square_1</attribute>
+        <attribute name="src">/web_editor/image_shape/website.s_text_image_default_image/web_editor/solid/solid_square_1.svg?c2=o-color-3</attribute>
+        <attribute name="data-shape">web_editor/solid/solid_square_1</attribute>
         <attribute name="data-original-mimetype">image/jpeg</attribute>
         <attribute name="data-file-name">s_text_image.svg</attribute>
         <attribute name="data-shape-colors">;o-color-3;;;</attribute>

--- a/theme_treehouse/views/snippets/s_picture.xml
+++ b/theme_treehouse/views/snippets/s_picture.xml
@@ -13,9 +13,9 @@
     <!-- Image + Shape -->
     <xpath expr="//img" position="attributes">
         <attribute name="class" add="img-fluid" remove="img-thumbnail padding-large" separator=" "/>
-        <attribute name="src">/web_editor/image_shape/website.s_picture_default_image/web_editor/special/spl_filter_1.svg</attribute>
+        <attribute name="src">/web_editor/image_shape/website.s_picture_default_image/web_editor/special/special_filter.svg</attribute>
         <attribute name="data-file-name">01.svg</attribute>
-        <attribute name="data-shape">web_editor/special/spl_filter_1</attribute>
+        <attribute name="data-shape">web_editor/special/special_filter</attribute>
         <attribute name="data-shape-colors">;#046380;;;</attribute>
     </xpath>
 </template>

--- a/theme_treehouse/views/snippets/s_text_image.xml
+++ b/theme_treehouse/views/snippets/s_text_image.xml
@@ -20,9 +20,9 @@
     </xpath>
     <!-- Image + Shape -->
     <xpath expr="//img" position="attributes">
-        <attribute name="src">/web_editor/image_shape/website.s_text_image_default_image/web_editor/basic/bsc_organic_2.svg</attribute>
+        <attribute name="src">/web_editor/image_shape/website.s_text_image_default_image/web_editor/geometric_round/geo_round_blob_medium.svg</attribute>
         <attribute name="data-file-name">text_image.svg</attribute>
-        <attribute name="data-shape">web_editor/basic/bsc_organic_2</attribute>
+        <attribute name="data-shape">web_editor/geometric_round/geo_round_blob_medium</attribute>
         <attribute name="data-shape-colors">;;;;</attribute>
     </xpath>
     <!-- Subtitle -->

--- a/theme_vehicle/views/customizations.xml
+++ b/theme_vehicle/views/customizations.xml
@@ -36,8 +36,8 @@
         <attribute name="class" add="pb24 pt56 o_cc o_cc1" remove="pt32 pb32" separator=" "/>
     </xpath>
     <xpath expr="//img" position="attributes">
-        <attribute name="src">/web_editor/image_shape/website.s_text_image_default_image/web_editor/float/flt_square_3.svg?c1=o-color-1&amp;c5=o-color-5</attribute>
-        <attribute name="data-shape">web_editor/float/flt_square_3</attribute>
+        <attribute name="src">/web_editor/image_shape/website.s_text_image_default_image/web_editor/composition/composition_square_3.svg?c1=o-color-1&amp;c5=o-color-5</attribute>
+        <attribute name="data-shape">web_editor/composition/composition_square_3</attribute>
         <attribute name="data-original-mimetype">image/jpeg</attribute>
         <attribute name="data-file-name">s_text_image.svg</attribute>
         <attribute name="data-shape-colors">o-color-1;;;;o-color-5</attribute>
@@ -65,8 +65,8 @@
         <attribute name="class" add="pb56 pt24 o_cc o_cc1" remove="pt32 pb32" separator=" "/>
     </xpath>
     <xpath expr="//img" position="attributes">
-        <attribute name="src">/web_editor/image_shape/website.s_image_text_default_image/web_editor/float/flt_square_2.svg?c2=o-color-1&amp;c5=o-color-5</attribute>
-        <attribute name="data-shape">web_editor/float/flt_square_2</attribute>
+        <attribute name="src">/web_editor/image_shape/website.s_image_text_default_image/web_editor/composition/composition_square_2.svg?c2=o-color-1&amp;c5=o-color-5</attribute>
+        <attribute name="data-shape">web_editor/composition/composition_square_2</attribute>
         <attribute name="data-original-mimetype">image/jpeg</attribute>
         <attribute name="data-file-name">s_image_text.svg</attribute>
         <attribute name="data-shape-colors">;o-color-1;;;o-color-5</attribute>


### PR DESCRIPTION
In commit https://github.com/odoo/odoo/pull/110673/commits/d82b2f6b8f9f5a56c470aa9c467b0fbb5ff7961a some of the shapes have been moved to new folder or have been renamed.

This commit adapt the paths of the previous shapes to their new location in various themes.

task-3266705