### PR TITLE
[FIX] theme_test_custo: use new utility to enter in edit mode

### DIFF
--- a/theme_test_custo/static/tests/tours/theme_menu_hierarchies.js
+++ b/theme_test_custo/static/tests/tours/theme_menu_hierarchies.js
@@ -29,11 +29,9 @@ wTourUtils.registerWebsitePreviewTour('theme_menu_hierarchies', {
         trigger: 'iframe footer ul li a[href="/dogs"]',
         run: () => null, // It's a check.
     },
-    wTourUtils.clickOnEdit(),
+    ...wTourUtils.clickOnEditAndWaitEditMode(),
     {
         content: 'Click on footer',
-        // TODO: this extra_trigger should be part of the `clickOnEdit` util
-        extra_trigger: "#oe_snippets.o_loaded",
         trigger: 'iframe footer',
     }, {
         content: 'The theme custom footer template should be listed and selected',


### PR DESCRIPTION
This commit permits to use the new utility to enter in edit mode. This way, we make sure that the edit mode is enabled before testing the next step of the test. This avoids race conditions during tests.

Community PR: https://github.com/odoo/odoo/pull/118849

task-3203820