### PR TITLE
[FIX] theme_test_custo: add test for the mobile/desktop theme preview

### DIFF
--- a/theme_test_custo/static/tests/tours/website_theme_preview.js
+++ b/theme_test_custo/static/tests/tours/website_theme_preview.js
@@ -1,0 +1,41 @@
+/** @odoo-module */
+
+import tour from "web_tour.tour";
+
+tour.register("website_theme_preview", {
+    test: true,
+    url: "/web#action=website.action_website_configuration",
+},
+[{
+    content: "Click on create new website",
+    trigger: 'button[name="action_website_create_new"]',
+}, {
+    content: "insert website name",
+    trigger: '[name="name"] input',
+    run: "text Website Test",
+}, {
+    content: "Validate the website creation modal",
+    trigger: "button.btn-primary",
+},
+// Configurator first screen
+{
+    content: "Click Skip and start from scratch",
+    trigger: "button:contains('Skip and start from scratch')",
+}, {
+    content: "Click on the Live preview of a theme",
+    trigger: ".o_theme_preview .o_button_area .btn-secondary:contains('Live Preview')",
+}, {
+    content: "Switch from desktop to mobile preview",
+    trigger: ".btn[for=themeViewerMobile]",
+}, {
+    content: "Check that the mobile view is active",
+    trigger: ".o_view_form_theme_preview_controller .o_field_iframe > div.is_mobile:visible",
+    run: () => null, // it's a check
+}, {
+    content: "Switch back to desktop",
+    trigger: ".btn[for=themeViewerDesktop]",
+}, {
+    content: "Check that the desktop view is active",
+    trigger: ".o_view_form_theme_preview_controller .o_field_iframe > div:not(.is_mobile):visible",
+    run: () => null, // it's a check
+}]);

--- a/theme_test_custo/tests/test_theme_creation.py
+++ b/theme_test_custo/tests/test_theme_creation.py
@@ -2,7 +2,7 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
 from odoo.tests import HttpCase, tagged
-
+from odoo.addons.website.tests.test_configurator import TestConfiguratorCommon
 
 # TODO: `test_themes` tag should not be there, runbot config should be adapted
 #       to test this module too. There is a special config for the theme repo.
@@ -14,3 +14,8 @@ class Crawler(HttpCase):
         website.theme_id = theme_custo.id
         theme_custo.with_context(load_all_views=True, apply_new_theme=True)._theme_load(website)
         self.start_tour('/@/example', "theme_menu_hierarchies", login='admin')
+
+@tagged('post_install', '-at_install')
+class TestThemeConfigurator(TestConfiguratorCommon):
+    def test_website_theme_preview(self):
+        self.start_tour('/web#action=website.action_website_configuration', 'website_theme_preview', login="admin")


### PR DESCRIPTION
With the Milk redesign in [1], the possibility to use the mobile/desktop
switcher on a theme preview to see how it behaves/displays on those
devices didn't work anymore.

It has been fixed in [2], but in order to prevent future breaks, this
commit tests this functionality.

task-3355253

[1]: https://github.com/odoo/odoo/commit/caef16ee4e5351142ef04f02798999ccb38a56bc
[2]: https://github.com/odoo/odoo/commit/9445f61bcaee88bc6ac2fc373d7eca4e4b38c154