### PR TITLE
[IMP] theme_monglia: use BS mixin to have responsive font sizes

### DIFF
--- a/theme_monglia/static/src/snippets/s_numbers/000.scss
+++ b/theme_monglia/static/src/snippets/s_numbers/000.scss
@@ -1,10 +1,4 @@
 .s_numbers {
-    .s_number {
-        font-size: 75px;
-        @include media-breakpoint-down(md) {
-            font-size: 60px;
-        }
-    }
     h6 {
         text-transform: uppercase;
     }


### PR DESCRIPTION
This commit permits to have responsive font sizes on all the Odoo frontend. It is based on the Bootstrap mixin `font-size` which calculates the font size based on the viewport width.

Community PR: odoo/odoo#129469

task-1958098