### PR TITLE
[REF] *: remove _lt() and core._t usages

### DIFF
--- a/theme_anelusia/static/src/js/tour.js
+++ b/theme_anelusia/static/src/js/tour.js
@@ -33,7 +33,7 @@ const snippets = [
     },
 ];
 
-wTourUtils.registerThemeHomepageTour("anelusia_tour", [
+wTourUtils.registerThemeHomepageTour("anelusia_tour", () => [
     wTourUtils.assertCssVariable('--color-palettes-name', '"generic-17"'),
     wTourUtils.dragNDrop(snippets[0]),
     wTourUtils.clickOnText(snippets[0], 'h1', 'top'),

--- a/theme_artists/static/src/js/tour.js
+++ b/theme_artists/static/src/js/tour.js
@@ -29,7 +29,7 @@ const snippets = [
     },
 ];
 
-wTourUtils.registerThemeHomepageTour("artists_tour", [
+wTourUtils.registerThemeHomepageTour("artists_tour", () => [
     wTourUtils.assertCssVariable('--color-palettes-name', '"artists-1"'),
     wTourUtils.dragNDrop(snippets[0], 'top'),
     wTourUtils.dragNDrop(snippets[1]),

--- a/theme_avantgarde/static/src/js/tour.js
+++ b/theme_avantgarde/static/src/js/tour.js
@@ -24,7 +24,7 @@ const snippets = [
     },
 ];
 
-wTourUtils.registerThemeHomepageTour("avantgarde_tour", [
+wTourUtils.registerThemeHomepageTour("avantgarde_tour", () => [
     wTourUtils.assertCssVariable('--color-palettes-name', '"avantgarde-3"'),
     wTourUtils.dragNDrop(snippets[0], 'top'),
     wTourUtils.clickOnText(snippets[0], 'h1', 'left'),

--- a/theme_aviato/static/src/js/tour.js
+++ b/theme_aviato/static/src/js/tour.js
@@ -1,7 +1,7 @@
 /** @odoo-module */
 
 import wTourUtils from '@website/js/tours/tour_utils';
-import { _t } from '@web/legacy/js/services/core';
+import { _t } from "@web/core/l10n/translation";
 
 const snippets = [
     {
@@ -30,7 +30,7 @@ const snippets = [
     },
 ];
 
-wTourUtils.registerThemeHomepageTour("aviato_tour", [
+wTourUtils.registerThemeHomepageTour("aviato_tour", () => [
     wTourUtils.assertCssVariable('--color-palettes-name', '"treehouse-5"'),
     wTourUtils.dragNDrop(snippets[0]),
     wTourUtils.clickOnText(snippets[0], 'h1', 'top'),

--- a/theme_beauty/static/src/js/tour.js
+++ b/theme_beauty/static/src/js/tour.js
@@ -29,7 +29,7 @@ const snippets = [
     },
 ];
 
-wTourUtils.registerThemeHomepageTour("beauty_tour", [
+wTourUtils.registerThemeHomepageTour("beauty_tour", () => [
     wTourUtils.assertCssVariable('--color-palettes-name', '"beauty-1"'),
     wTourUtils.dragNDrop(snippets[0]),
     wTourUtils.clickOnText(snippets[0], 'h1'),

--- a/theme_bewise/static/src/js/tour.js
+++ b/theme_bewise/static/src/js/tour.js
@@ -1,6 +1,6 @@
 /** @odoo-module */
 import wTourUtils from '@website/js/tours/tour_utils';
-import { _t } from '@web/legacy/js/services/core';
+import { _t } from "@web/core/l10n/translation";
 
 const snippets = [
     {
@@ -33,7 +33,7 @@ const snippets = [
     },
 ];
 
-wTourUtils.registerThemeHomepageTour("bewise_tour", [
+wTourUtils.registerThemeHomepageTour("bewise_tour", () => [
     wTourUtils.assertCssVariable('--color-palettes-name', '"bewise-1"'),
     wTourUtils.dragNDrop(snippets[0], 'top'),
     wTourUtils.clickOnText(snippets[0], 'h1', 'top'),

--- a/theme_bistro/static/src/js/tour.js
+++ b/theme_bistro/static/src/js/tour.js
@@ -29,7 +29,7 @@ const snippets = [
     },
 ];
 
-wTourUtils.registerThemeHomepageTour("bistro_tour", [
+wTourUtils.registerThemeHomepageTour("bistro_tour", () => [
     wTourUtils.assertCssVariable('--color-palettes-name', '"bistro-5"'),
     wTourUtils.dragNDrop(snippets[0]),
     wTourUtils.clickOnText(snippets[0], 'h1', 'top'),

--- a/theme_bookstore/static/src/js/tour.js
+++ b/theme_bookstore/static/src/js/tour.js
@@ -1,7 +1,7 @@
 /** @odoo-module */
 
 import wTourUtils from '@website/js/tours/tour_utils';
-import { _t } from '@web/legacy/js/services/core';
+import { _t } from "@web/core/l10n/translation";
 
 const snippets = [
     {
@@ -30,7 +30,7 @@ const snippets = [
     },
 ];
 
-wTourUtils.registerThemeHomepageTour("bookstore_tour", [
+wTourUtils.registerThemeHomepageTour("bookstore_tour", () => [
     wTourUtils.assertCssVariable('--color-palettes-name', '"generic-8"'),
     wTourUtils.dragNDrop(snippets[0]),
     wTourUtils.clickOnText(snippets[0], 'h1'),

--- a/theme_buzzy/static/src/js/tour.js
+++ b/theme_buzzy/static/src/js/tour.js
@@ -29,7 +29,7 @@ const snippets = [
     },
 ];
 
-wTourUtils.registerThemeHomepageTour("buzzy_tour", [
+wTourUtils.registerThemeHomepageTour("buzzy_tour", () => [
     wTourUtils.assertCssVariable('--color-palettes-name', '"kiddo-2"'),
     wTourUtils.dragNDrop(snippets[0]),
     wTourUtils.clickOnText(snippets[0], 'h1', 'top'),

--- a/theme_clean/static/src/js/tour.js
+++ b/theme_clean/static/src/js/tour.js
@@ -1,7 +1,7 @@
 /** @odoo-module */
 
 import wTourUtils from '@website/js/tours/tour_utils';
-import { _t } from '@web/legacy/js/services/core';
+import { _t } from "@web/core/l10n/translation";
 
 const snippets = [
     {
@@ -38,7 +38,7 @@ const snippets = [
     },
 ];
 
-wTourUtils.registerThemeHomepageTour("clean_tour", [
+wTourUtils.registerThemeHomepageTour("clean_tour", () => [
     wTourUtils.assertCssVariable('--color-palettes-name', '"clean-1"'),
     wTourUtils.dragNDrop(snippets[0]),
     wTourUtils.clickOnText(snippets[0], 'h1'),

--- a/theme_cobalt/static/src/js/tour.js
+++ b/theme_cobalt/static/src/js/tour.js
@@ -30,7 +30,7 @@ const snippets = [
 ];
 
 
-wTourUtils.registerThemeHomepageTour("cobalt_tour", [
+wTourUtils.registerThemeHomepageTour("cobalt_tour", () => [
     wTourUtils.assertCssVariable('--color-palettes-name', '"cobalt-1"'),
     wTourUtils.dragNDrop(snippets[0]),
     wTourUtils.clickOnText(snippets[0], 'h1', 'top'),

--- a/theme_enark/static/src/js/tour.js
+++ b/theme_enark/static/src/js/tour.js
@@ -29,7 +29,7 @@ const snippets = [
     },
 ];
 
-wTourUtils.registerThemeHomepageTour("enark_tour", [
+wTourUtils.registerThemeHomepageTour("enark_tour", () => [
     wTourUtils.assertCssVariable('--color-palettes-name', '"enark-1"'),
     wTourUtils.dragNDrop(snippets[0]),
     wTourUtils.clickOnText(snippets[0], 'h1'),

--- a/theme_graphene/static/src/js/tour.js
+++ b/theme_graphene/static/src/js/tour.js
@@ -26,7 +26,7 @@ const snippets = [
 ];
 
 
-wTourUtils.registerThemeHomepageTour("graphene_tour", [
+wTourUtils.registerThemeHomepageTour("graphene_tour", () => [
     wTourUtils.assertCssVariable('--color-palettes-name', '"graphene-1"'),
     wTourUtils.dragNDrop(snippets[0]),
     wTourUtils.clickOnText(snippets[0], 'h1', 'top'),

--- a/theme_kea/static/src/js/tour.js
+++ b/theme_kea/static/src/js/tour.js
@@ -29,7 +29,7 @@ const snippets = [
     },
 ];
 
-wTourUtils.registerThemeHomepageTour("kea_tour", [
+wTourUtils.registerThemeHomepageTour("kea_tour", () => [
     wTourUtils.assertCssVariable('--color-palettes-name', '"bewise-2"'),
     wTourUtils.dragNDrop(snippets[0]),
     wTourUtils.clickOnText(snippets[0], 'h1'),

--- a/theme_kiddo/static/src/js/tour.js
+++ b/theme_kiddo/static/src/js/tour.js
@@ -1,6 +1,6 @@
 /** @odoo-module */
 import wTourUtils from '@website/js/tours/tour_utils';
-import { _t } from '@web/legacy/js/services/core';
+import { _t } from "@web/core/l10n/translation";
 
 const snippets = [
     {
@@ -25,7 +25,7 @@ const snippets = [
     },
 ];
 
-wTourUtils.registerThemeHomepageTour("kiddo_tour", [
+wTourUtils.registerThemeHomepageTour("kiddo_tour", () => [
     wTourUtils.assertCssVariable('--color-palettes-name', '"default-16"'),
     wTourUtils.dragNDrop(snippets[0]),
     wTourUtils.clickOnText(snippets[0], 'h1'),

--- a/theme_loftspace/static/src/js/tour.js
+++ b/theme_loftspace/static/src/js/tour.js
@@ -25,7 +25,7 @@ const snippets = [
     },
 ];
 
-wTourUtils.registerThemeHomepageTour("loftspace_tour", [
+wTourUtils.registerThemeHomepageTour("loftspace_tour", () => [
     wTourUtils.assertCssVariable('--color-palettes-name', '"graphene-2"'),
     wTourUtils.dragNDrop(snippets[0]),
     wTourUtils.clickOnText(snippets[0], 'h1'),

--- a/theme_monglia/static/src/js/tour.js
+++ b/theme_monglia/static/src/js/tour.js
@@ -37,7 +37,7 @@ const snippets = [
     },
 ];
 
-wTourUtils.registerThemeHomepageTour("monglia_tour", [
+wTourUtils.registerThemeHomepageTour("monglia_tour", () => [
     wTourUtils.assertCssVariable('--color-palettes-name', '"monglia-1"'),
     wTourUtils.dragNDrop(snippets[0]),
     wTourUtils.clickOnText(snippets[0], 'h1', 'top'),

--- a/theme_nano/static/src/js/tour.js
+++ b/theme_nano/static/src/js/tour.js
@@ -29,7 +29,7 @@ const snippets = [
     },
 ];
 
-wTourUtils.registerThemeHomepageTour("nano_tour", [
+wTourUtils.registerThemeHomepageTour("nano_tour", () => [
     wTourUtils.assertCssVariable('--color-palettes-name', '"nano-1"'),
     wTourUtils.dragNDrop(snippets[0]),
     wTourUtils.clickOnText(snippets[0], 'h1', 'top'),

--- a/theme_notes/static/src/js/tour.js
+++ b/theme_notes/static/src/js/tour.js
@@ -1,7 +1,7 @@
 /** @odoo-module */
 
 import wTourUtils from '@website/js/tours/tour_utils';
-import { _t } from '@web/legacy/js/services/core';
+import { _t } from "@web/core/l10n/translation";
 
 const snippets = [
     {
@@ -30,7 +30,7 @@ const snippets = [
     },
 ];
 
-wTourUtils.registerThemeHomepageTour("notes_tour", [
+wTourUtils.registerThemeHomepageTour("notes_tour", () => [
     wTourUtils.assertCssVariable('--color-palettes-name', '"notes-1"'),
     wTourUtils.dragNDrop(snippets[0]),
     wTourUtils.clickOnText(snippets[0], 'h1'),

--- a/theme_odoo_experts/static/src/js/tour.js
+++ b/theme_odoo_experts/static/src/js/tour.js
@@ -1,7 +1,7 @@
 /** @odoo-module */
 
 import wTourUtils from '@website/js/tours/tour_utils';
-import { _t } from '@web/legacy/js/services/core';
+import { _t } from "@web/core/l10n/translation";
 
 const snippets = [
     {
@@ -34,7 +34,7 @@ const snippets = [
     },
 ];
 
-wTourUtils.registerThemeHomepageTour("odoo_experts_tour", [
+wTourUtils.registerThemeHomepageTour("odoo_experts_tour", () => [
     wTourUtils.assertCssVariable('--color-palettes-name', '"odoo-experts-1"'),
     wTourUtils.dragNDrop(snippets[0]),
     wTourUtils.dragNDrop(snippets[1]),

--- a/theme_orchid/static/src/js/tour.js
+++ b/theme_orchid/static/src/js/tour.js
@@ -1,7 +1,7 @@
 /** @odoo-module */
 
 import wTourUtils from '@website/js/tours/tour_utils';
-import { _t } from '@web/legacy/js/services/core';
+import { _t } from "@web/core/l10n/translation";
 
 const snippets = [
     {
@@ -30,7 +30,7 @@ const snippets = [
     },
 ];
 
-wTourUtils.registerThemeHomepageTour("orchid_tour", [
+wTourUtils.registerThemeHomepageTour("orchid_tour", () => [
     wTourUtils.assertCssVariable('--color-palettes-name', '"orchid-7"'),
     wTourUtils.dragNDrop(snippets[0]),
     wTourUtils.clickOnText(snippets[0], 'h1'),

--- a/theme_paptic/static/src/js/tour.js
+++ b/theme_paptic/static/src/js/tour.js
@@ -30,7 +30,7 @@ const snippets = [
 ];
 
 
-wTourUtils.registerThemeHomepageTour("paptic_tour", [
+wTourUtils.registerThemeHomepageTour("paptic_tour", () => [
     wTourUtils.assertCssVariable('--color-palettes-name', '"paptic-1"'),
     wTourUtils.dragNDrop(snippets[0], 'top'),
     wTourUtils.clickOnText(snippets[0], 'h1', 'top'),

--- a/theme_real_estate/static/src/js/tour.js
+++ b/theme_real_estate/static/src/js/tour.js
@@ -45,7 +45,7 @@ const snippets = [
     },
 ];
 
-wTourUtils.registerThemeHomepageTour("real_estate_tour", [
+wTourUtils.registerThemeHomepageTour("real_estate_tour", () => [
     wTourUtils.assertCssVariable('--color-palettes-name', '"real-estate-4"'),
     wTourUtils.dragNDrop(snippets[0]),
     wTourUtils.clickOnText(snippets[0], 'h1'),

--- a/theme_test_custo/static/tests/tours/theme_menu_hierarchies.js
+++ b/theme_test_custo/static/tests/tours/theme_menu_hierarchies.js
@@ -5,7 +5,7 @@ import wTourUtils from '@website/js/tours/tour_utils';
 wTourUtils.registerWebsitePreviewTour('theme_menu_hierarchies', {
     url: '/example',
     test: true,
-}, [
+}, () => [
     {
         content: 'Check Mega Menu is correctly created',
         trigger: 'iframe #top_menu a.o_mega_menu_toggle',

--- a/theme_treehouse/static/src/js/tour.js
+++ b/theme_treehouse/static/src/js/tour.js
@@ -25,7 +25,7 @@ const snippets = [
     },
 ];
 
-wTourUtils.registerThemeHomepageTour("treehouse_tour", [
+wTourUtils.registerThemeHomepageTour("treehouse_tour", () => [
     wTourUtils.assertCssVariable('--color-palettes-name', '"treehouse-1"'),
     wTourUtils.dragNDrop(snippets[0]),
     wTourUtils.clickOnText(snippets[0], 'h1', 'top'),

--- a/theme_vehicle/static/src/js/tour.js
+++ b/theme_vehicle/static/src/js/tour.js
@@ -29,7 +29,7 @@ const snippets = [
     },
 ];
 
-wTourUtils.registerThemeHomepageTour("vehicle_tour", [
+wTourUtils.registerThemeHomepageTour("vehicle_tour", () => [
     wTourUtils.assertCssVariable('--color-palettes-name', '"vehicle-1"'),
     wTourUtils.dragNDrop(snippets[0], 'top'),
     wTourUtils.clickOnText(snippets[0], 'h1', 'top'),

--- a/theme_yes/static/src/js/tour.js
+++ b/theme_yes/static/src/js/tour.js
@@ -29,7 +29,7 @@ const snippets = [
     },
 ];
 
-wTourUtils.registerThemeHomepageTour("yes_tour", [
+wTourUtils.registerThemeHomepageTour("yes_tour", () => [
     wTourUtils.assertCssVariable('--color-palettes-name', '"yes-3"'),
     wTourUtils.dragNDrop(snippets[0]),
     wTourUtils.dragNDrop(snippets[1]),

--- a/theme_zap/static/src/js/tour.js
+++ b/theme_zap/static/src/js/tour.js
@@ -29,7 +29,7 @@ const snippets = [
     },
 ];
 
-wTourUtils.registerThemeHomepageTour("zap_tour", [
+wTourUtils.registerThemeHomepageTour("zap_tour", () => [
     wTourUtils.assertCssVariable('--color-palettes-name', '"zap-1"'),
     wTourUtils.dragNDrop(snippets[0]),
     wTourUtils.clickOnText(snippets[0], 'h1', 'top'),


### PR DESCRIPTION
In a previous commit 8bfa76a842625, _lt() returns _t(). 
So, in this commit, all usages of _lt() are replaced by _t().
core._lt() and core._t() are also replace by _t().

task-3292454