### PR TITLE
[IMP] website: warn users when a website has no domain

### DIFF
--- a/test_themes/static/src/systray_items/website_switcher.js
+++ b/test_themes/static/src/systray_items/website_switcher.js
@@ -12,6 +12,8 @@ patch(WebsiteSwitcherSystray.prototype, 'test_themes_website_switcher_systray', 
 
         this.orm = useService('orm');
         this.tooltips = useState({});
+        // Disable the notification service to avoid having a notification for each theme.
+        this.notificationService = { add: () => () => null };
 
         onMounted(async () => {
             const themesWebsites = await this.orm.call('website', 'get_test_themes_websites_theme_preview');

--- a/test_themes/static/src/systray_items/website_switcher.xml
+++ b/test_themes/static/src/systray_items/website_switcher.xml
@@ -8,5 +8,8 @@
     <xpath expr="//DropdownItem" position="attributes">
         <attribute name="dataset">this.tooltips[element.id]</attribute>
     </xpath>
+    <!-- With this module installed, disable the warning -->
+    <xpath expr="//DropdownItem/t[@t-if='!element.domain']" position="replace">
+    </xpath>
 </t>
 </templates>


### PR DESCRIPTION
This commit disables the warning (introduced by the community commit) when test-themes is installed, as a lot of websites are created and are not necessary when testing the different themes.

-- ORIGINAL COMMIT MESSAGE --

Prior to this commit, if a website does not have a domain, nothing tells the user that this is a misconfiguration that can lead to broken behaviours. For example, here are the steps to reproduce:

- Have two website (X and Y)
- Website Y does not have a domain
- Tab 1 has Website X selected
- User opens a new tab
- Tab 2 has Website X selected as well
- User switches tab 2 to Website Y
- No redirection happens
- User switches back to tab 1
- User opens the HTML editor for Website X
- Website X content is displayed
- User saves
- Content is saved on Website Y

This is pretty hard to fix as a lot of the python flow for Website uses `get_current_website` which will uses the session's "force_website_id" in priority.

In any case, we consider having multiple websites sharing the same domain (or having no domains at all) a misconfiguration. Therefore, we should warn the user of so.

This commit adds a tooltip on the website switcher for websites that do not have a domain set. It also adds a notification recommending users close other tabs if they switch website.

opw-3374214