### PR TITLE
[FIX] theme_*: remove mb-2 class on orphan buttons

### DIFF
--- a/theme_anelusia/views/snippets/s_color_blocks_2.xml
+++ b/theme_anelusia/views/snippets/s_color_blocks_2.xml
@@ -50,7 +50,7 @@
             <i class="fa fa-venus-mars fa-5x m-3"/>
             <h2>Fancy for them</h2>
             <p>Are you looking for sustainable clothing for men or women? Discover our exclusive fashion brand for both of you.</p>
-            <a href="#" class="btn btn-primary mb-2 btn-lg">More Details</a>
+            <a href="#" class="btn btn-primary btn-lg">More Details</a>
         </div>
     </xpath>
 </template>

--- a/theme_anelusia/views/snippets/s_media_list.xml
+++ b/theme_anelusia/views/snippets/s_media_list.xml
@@ -66,7 +66,7 @@
     </xpath>
     <!-- Media #02 - Add a button -->
     <xpath expr="//div[hasclass('s_media_list_item')][2]//p" position="after">
-        <a href="#" class="btn btn-primary mb-2">Read more</a>
+        <a href="#" class="btn btn-primary">Read more</a>
     </xpath>
 
     <!-- Remove Media #03 -->

--- a/theme_artists/views/snippets/s_carousel.xml
+++ b/theme_artists/views/snippets/s_carousel.xml
@@ -18,7 +18,7 @@
             <h2 style="text-align: center;">Aquitani</h2>
             <p class="lead" style="text-align: center;"><b>Photoshoot / June 2021</b></p>
             <p style="text-align: center;">
-                <a href="#" class="btn btn-primary btn-lg mb-2">Discover</a>
+                <a href="#" class="btn btn-primary btn-lg">Discover</a>
             </p>
         </div>
     </xpath>
@@ -39,7 +39,7 @@
             <h2 style="text-align: center;">Immemorabili</h2>
             <p class="lead" style="text-align: center;"><b>Painting concept / April 2021</b></p>
             <p style="text-align: center;">
-                <a href="#" class="btn btn-primary btn-lg mb-2">Discover</a>
+                <a href="#" class="btn btn-primary btn-lg">Discover</a>
             </p>
         </div>
     </xpath>
@@ -60,7 +60,7 @@
             <h2 style="text-align: center;">Vincam</h2>
             <p class="lead" style="text-align: center;"><b>Typographic collection / March 2021</b></p>
             <p style="text-align: center;">
-                <a href="#" class="btn btn-primary btn-lg mb-2">Discover</a>
+                <a href="#" class="btn btn-primary btn-lg">Discover</a>
             </p>
         </div>
     </xpath>

--- a/theme_aviato/views/snippets/s_three_columns.xml
+++ b/theme_aviato/views/snippets/s_three_columns.xml
@@ -12,7 +12,7 @@
         <div class="card-wrapper shadow-lg position-relative p-4 bg-white rounded-3 mt-n4" style="z-index:1;">
             <h4 class="card-title mt-4">Paris</h4>
             <p>Paris' monument-lined boulevards, museums, classical bistros and boutiques are enhanced by a new wave of multimedia galleries, creative wine bars..</p>
-            <a href="#" class="btn btn-primary mb-2">Book now</a>
+            <a href="#" class="btn btn-primary">Book now</a>
         </div>
     </xpath>
     <!-- Column #02 -->
@@ -21,8 +21,8 @@
         <div class="card-wrapper shadow-lg position-relative p-4 bg-white rounded-3 mt-n4" style="z-index:1;">
             <h4 class="card-title mt-4">Rome</h4>
             <p>A heady mix of haunting ruins, awe-inspiring art and vibrant street life, Italy’s hot-blooded capital is one of the world’s most romantic and charismatic cities.</p>
-            <a href="#" class="btn btn-primary mb-2">Book now</a>
-        </div> 
+            <a href="#" class="btn btn-primary">Book now</a>
+        </div>
     </xpath>
     <!-- Column #03 -->
     <xpath expr="//div[hasclass('row')]/div[3]/div" position="replace">
@@ -30,7 +30,7 @@
         <div class="card-wrapper shadow-lg position-relative p-4 bg-white rounded-3 mt-n4" style="z-index:1;">
             <h4 class="card-title mt-4">Prague</h4>
             <p>Prague is the equal of Paris in terms of beauty. Its history goes back a millennium. And the beer? The best in Europe. Prague is the perfect city to walk around.</p>
-            <a href="#" class="btn btn-primary mb-2">Book now</a>
+            <a href="#" class="btn btn-primary">Book now</a>
         </div>
     </xpath>
 </template>

--- a/theme_graphene/views/customizations.xml
+++ b/theme_graphene/views/customizations.xml
@@ -23,7 +23,7 @@
                     Our mission is to give customers the best experience.<br/>Extensive documentation &amp; guides, an active community,<br/>24/7 support make it a pleasure to work with us.
                 </p>
                 <p style="text-align: right">
-                    <a t-att-href="cta_btn_href" class="btn btn-primary btn-lg mb-2 o_default_snippet_text"><t t-esc="cta_btn_text">Contact us</t></a>
+                    <a t-att-href="cta_btn_href" class="btn btn-primary btn-lg o_default_snippet_text"><t t-esc="cta_btn_text">Contact us</t></a>
                 </p>
             </div>
         </div>
@@ -222,16 +222,16 @@
         <div class="o_we_shape o_web_editor_Origins_06_001" style="background-image: url('/web_editor/shape/web_editor/Origins/06_001.svg?c3=o-color-3&amp;c4=o-color-4&amp;flip=x'); background-position: 50% 50%;"/>
     </xpath>
     <xpath expr="//div[hasclass('row')]/div//a" position="replace">
-        <a href="/contactus" class="btn btn-primary mb-2">Start Now</a>
+        <a href="/contactus" class="btn btn-primary">Start Now</a>
     </xpath>
     <xpath expr="//div[hasclass('row')]/div[2]//a" position="replace">
-        <a href="/contactus" class="btn btn-primary mb-2">Start Now</a>
+        <a href="/contactus" class="btn btn-primary">Start Now</a>
     </xpath>
     <xpath expr="//div[hasclass('row')]/div[2]//li[2]" position="replace">
         <li class="list-group-item">Access to all modules</li>
     </xpath>
     <xpath expr="//div[hasclass('row')]/div[3]//a" position="replace">
-        <a href="/contactus" class="btn btn-primary mb-2">Start Now</a>
+        <a href="/contactus" class="btn btn-primary">Start Now</a>
     </xpath>
     <xpath expr="//div[hasclass('row')]/div[3]//li[2]" position="replace">
         <li class="list-group-item">Access to all modules and features</li>

--- a/theme_kiddo/views/snippets/s_call_to_action.xml
+++ b/theme_kiddo/views/snippets/s_call_to_action.xml
@@ -19,10 +19,10 @@
             <h3 style="text-align: center;">2,000 parents<br/> brought their kid to our nursery.</h3>
             <p style="text-align: center;">Entrust us with your children and go to work with peace of mind</p>
             <p><br/></p>
-            <p style="text-align: center;"><a t-att-href="cta_btn_href" class="btn btn-primary btn-lg mb-2"><t t-esc="cta_btn_text">Contact us</t></a></p>
+            <p style="text-align: center;"><a t-att-href="cta_btn_href" class="btn btn-primary btn-lg"><t t-esc="cta_btn_text">Contact us</t></a></p>
         </div>
     </xpath>
-    
+
     <!-- Remove last column with button -->
     <xpath expr="//div[hasclass('col-lg-3')]" position="replace"/>
 </template>

--- a/theme_loftspace/views/snippets/s_call_to_action.xml
+++ b/theme_loftspace/views/snippets/s_call_to_action.xml
@@ -27,6 +27,9 @@
     <xpath expr="//div[hasclass('col-lg-12')]/p" position="attributes">
         <attribute name="style" add="text-align: center;" remove="text-align: right;" separator=";"/>
     </xpath>
+    <xpath expr="//a[hasclass('btn')]" position="attributes">
+        <attribute name="class" add="mb-2" separator=" "/>
+    </xpath>
     <!-- Add secondary button -->
     <xpath expr="//a[hasclass('btn')]" position="before">
         <a href="#" class="btn btn-secondary btn-lg me-2 mb-2">Our services</a>

--- a/theme_monglia/views/customizations.xml
+++ b/theme_monglia/views/customizations.xml
@@ -119,7 +119,7 @@
     </xpath>
     <xpath expr="//p[2]" position="replace"/>
     <xpath expr="//a" position="replace">
-        <a href="/contactus" class="btn btn-primary mb-2">Learn more</a>
+        <a href="/contactus" class="btn btn-primary">Learn more</a>
     </xpath>
 </template>
 
@@ -156,7 +156,7 @@
         <p class="lead">This is the first full-length studio release in seven years for the British singer-songwriter.</p>
     </xpath>
     <xpath expr="//a" position="replace">
-        <a href="/contactus" class="btn btn-primary mb-2">Discover</a>
+        <a href="/contactus" class="btn btn-primary">Discover</a>
     </xpath>
 </template>
 

--- a/theme_notes/views/snippets/s_carousel.xml
+++ b/theme_notes/views/snippets/s_carousel.xml
@@ -12,7 +12,7 @@
             <h1>Miraillet Festival</h1>
             <p class="lead">From the 12th to the 17th of August, come and enjoy the atmosphere at the Miraillet Festival. Discover the line up below.</p>
             <p><br/></p>
-            <p><a href="/contactus" class="btn btn-primary btn-lg mb-2">More Info</a></p>
+            <p><a href="/contactus" class="btn btn-primary btn-lg">More Info</a></p>
         </div>
     </xpath>
     <!-- Slide #1 - Shape -->
@@ -29,7 +29,7 @@
             <h1>6 Days Pass</h1>
             <p class="lead">Tickets will be on sale soon. Do not miss our 6 Days Pass. Free camping!</p>
             <p><br/></p>
-            <p><a href="/" class="btn btn-primary btn-lg mb-2">More Info</a></p>
+            <p><a href="/" class="btn btn-primary btn-lg">More Info</a></p>
         </div>
     </xpath>
     <!-- Slide #2 - Shape -->
@@ -46,7 +46,7 @@
             <h1>Recent Editions</h1>
             <p class="lead">Discover what makes the reputation of the Miraillet festival through these after-movies.</p>
             <p><br/></p>
-            <p><a href="/" class="btn btn-primary btn-lg mb-2">More Info</a></p>
+            <p><a href="/" class="btn btn-primary btn-lg">More Info</a></p>
         </div>
     </xpath>
     <!-- Slide #3 - Shape -->

--- a/theme_notes/views/snippets/s_media_list.xml
+++ b/theme_notes/views/snippets/s_media_list.xml
@@ -63,7 +63,7 @@
     </xpath>
     <!-- Row #2 - Add a button -->
     <xpath expr="(//div[hasclass('s_media_list_body')])[2]//p" position="after">
-        <a href="#" class="btn btn-primary mb-2">More info</a>
+        <a href="#" class="btn btn-primary">More info</a>
     </xpath>
 
     <!-- Row #3 -->
@@ -92,7 +92,7 @@
     </xpath>
     <!-- Row #3 - Add a button -->
     <xpath expr="(//div[hasclass('s_media_list_body')])[3]//a" position="replace">
-        <a href="#" class="btn btn-primary mb-2">More info</a>
+        <a href="#" class="btn btn-primary">More info</a>
     </xpath>
 </template>
 

--- a/theme_odoo_experts/views/snippets/s_picture.xml
+++ b/theme_odoo_experts/views/snippets/s_picture.xml
@@ -30,7 +30,7 @@
     <!-- Add a button -->
     <xpath expr="//p[2]" position="after">
         <p style="text-align: center;">
-            <a t-att-href="cta_btn_href" class="btn btn-primary mb-2 rounded-circle btn-lg"><t t-esc="cta_btn_text">Contact Us</t></a>
+            <a t-att-href="cta_btn_href" class="btn btn-primary rounded-circle btn-lg"><t t-esc="cta_btn_text">Contact Us</t></a>
         </p>
     </xpath>
     <!-- Image -->

--- a/theme_paptic/views/customizations.xml
+++ b/theme_paptic/views/customizations.xml
@@ -105,7 +105,7 @@
     </xpath>
 
     <xpath expr="//a[hasclass('btn')]" position="replace">
-        <a href="#" class="btn btn-link mb-2">DISCOVER MORE &#160;<i class="fa fa-chevron-right"/></a>
+        <a href="#" class="btn btn-link">DISCOVER MORE &#160;<i class="fa fa-chevron-right"/></a>
     </xpath>
 
     <xpath expr="//img" position="attributes">

--- a/theme_test_custo/data/pages.xml
+++ b/theme_test_custo/data/pages.xml
@@ -14,7 +14,7 @@
                             <h2>A Section Subtitle</h2>
                             <p>Write one or two paragraphs describing your product or services. To be successful your content needs to be useful to your readers.</p>
                             <p>Start with the customer - find out what they want and give it to them.</p>
-                            <p><a href="#" class="btn btn-primary mb-2">Learn more</a></p>
+                            <p><a href="#" class="btn btn-primary">Learn more</a></p>
                         </div>
                         <div class="col-lg-6 pt16 pb16">
                             <img src="/web_editor/image_shape/website.s_text_image_default_image/theme_test_custo/blob/01.svg" class="img img-fluid mx-auto" alt="" data-original-mimetype="image/jpeg" data-file-name="01.svg" data-shape="theme_test_custo/blob/01" data-shape-colors=";;;;"/>

--- a/theme_yes/views/snippets/s_media_list.xml
+++ b/theme_yes/views/snippets/s_media_list.xml
@@ -42,7 +42,7 @@
         <div class="col-lg-9 s_media_list_body">
             <h3 class="card-title"><span style="font-size: 36px;">Wedding Receptions</span></h3>
             <p class="card-text">As a full service experience, we monitor all aspects of your wedding from planning to execution.</p>
-            <a href="#" class="btn btn-primary mb-2">Start planning your wedding</a>
+            <a href="#" class="btn btn-primary">Start planning your wedding</a>
         </div>
     </xpath>
     <!-- Row #2 - Image -->
@@ -61,7 +61,7 @@
         <div class="col-lg-9 s_media_list_body">
             <h3 class="card-title"><span style="font-size: 36px;">Vow renewals</span></h3>
             <p class="card-text">The heartfelt exchange of wedding vows is often the most memorable part of a marriage ceremony.</p>
-            <a href="#" class="btn btn-outline-primary mb-2">See how others renewed their vows</a>
+            <a href="#" class="btn btn-outline-primary">See how others renewed their vows</a>
         </div>
     </xpath>
     <!-- Row #3 - Image -->


### PR DESCRIPTION
*: anelusia, artists, aviato, graphene, kiddo, loftspace, monglia, notes, odoo_experts, paptic, test_custo, yes

The community PR [126995] introduces an automatic check on buttons to add the `mb-2` class when several buttons follow each other, so that they have space to breathe when split on multiple lines. For consistency, this commit therefore removes most `mb-2` occurrences on buttons within themes as long as they are alone on their line, but keeps or adds the class when several buttons are next to each other.

[126995]: https://github.com/odoo/odoo/pull/126995

task-3369604