### PR TITLE
[IMP] theme_*: prevent abuse of h1 and use font size classes

### DIFF
--- a/theme_artists/views/snippets/s_title.xml
+++ b/theme_artists/views/snippets/s_title.xml
@@ -13,7 +13,7 @@
         <div class="o_we_bg_filter" style="background-color: rgba(17, 13, 22, 0.85) !important;"/>
     </xpath>
     <!-- Title -->
-    <xpath expr="//h1" position="replace" mode="inner">
+    <xpath expr="//h2" position="replace" mode="inner">
         It's all about perception
     </xpath>
 </template>

--- a/theme_avantgarde/views/customizations.xml
+++ b/theme_avantgarde/views/customizations.xml
@@ -9,10 +9,10 @@
     <xpath expr="//span[hasclass('s_parallax_bg')]" position="attributes">
         <attribute name="style" remove="background-position: 50% 0;" add="background-position: 50% 80%;" separator=";"/>
     </xpath>
-    <xpath expr="//font" position="attributes">
+    <xpath expr="//h1" position="attributes">
         <attribute name="class" add="text-o-color-1 text-break" separator=" "/>
     </xpath>
-    <xpath expr="//font" position="replace" mode="inner">
+    <xpath expr="//h1" position="replace" mode="inner">
         We are Avantgarde.
     </xpath>
     <xpath expr="//p" position="replace" mode="inner">
@@ -40,12 +40,9 @@
     </xpath>
     <xpath expr="//h2" position="attributes">
         <attribute name="style" remove="text-align: center;" separator=" "/>
-    </xpath>
-    <xpath expr="//font" position="attributes">
         <attribute name="class" add="text-break" separator=" "/>
-        <attribute name="style" add="font-weight: bolder;" separator=" "/>
     </xpath>
-    <xpath expr="//font" position="replace" mode="inner">
+    <xpath expr="//h2" position="replace" mode="inner">
         Design Methodology
     </xpath>
     <xpath expr="//p" position="attributes">

--- a/theme_aviato/views/snippets/s_title.xml
+++ b/theme_aviato/views/snippets/s_title.xml
@@ -3,7 +3,7 @@
 
 <template id="s_title" inherit_id="website.s_title">
     <!-- Title -->
-    <xpath expr="//h1" position="replace" mode="inner">
+    <xpath expr="//h2" position="replace" mode="inner">
         Top Destinations
     </xpath>
     <xpath expr="//section" position="attributes">

--- a/theme_beauty/views/snippets/s_title.xml
+++ b/theme_beauty/views/snippets/s_title.xml
@@ -7,7 +7,7 @@
         <attribute name="class" add="o_cc o_cc4 pt80" remove="pt40" separator=" "/>
     </xpath>
     <!-- Title -->
-    <xpath expr="//h1" position="replace" mode="inner">
+    <xpath expr="//h2" position="replace" mode="inner">
         Close your eyes and let yourself go in the expert hands of our beauticians.
     </xpath>
 </template>

--- a/theme_bistro/views/snippets/s_cover.xml
+++ b/theme_bistro/views/snippets/s_cover.xml
@@ -7,7 +7,7 @@
         <attribute name="style" add="background-position: 50% 100%;" remove="background-position: 50% 0;" separator=" "/>
     </xpath>
     <!-- Title -->
-    <xpath expr="//h1//font" position="replace" mode="inner">
+    <xpath expr="//h1" position="replace" mode="inner">
         Seasonal<br/> Flavors
     </xpath>
     <xpath expr="//h1" position="before">

--- a/theme_bookstore/views/snippets/s_title.xml
+++ b/theme_bookstore/views/snippets/s_title.xml
@@ -12,7 +12,7 @@
         <div class="o_we_bg_filter bg-black-50"/>
     </xpath>
     <!-- Title -->
-    <xpath expr="//h1" position="replace" mode="inner">
+    <xpath expr="//h2" position="replace" mode="inner">
         Reading means borrowing
     </xpath>
 </template>

--- a/theme_buzzy/views/snippets/s_title.xml
+++ b/theme_buzzy/views/snippets/s_title.xml
@@ -7,7 +7,7 @@
         <attribute name="class" add="o_cc o_cc4 pt152 pb152 oe_img_bg o_bg_img_center" remove="pb40 pt40" separator=" "/>
     </xpath>
     <!-- Title -->
-    <xpath expr="//h1" position="replace" mode="inner">
+    <xpath expr="//h2" position="replace" mode="inner">
         Increase your productivity
     </xpath>
 </template>

--- a/theme_clean/views/snippets/s_title.xml
+++ b/theme_clean/views/snippets/s_title.xml
@@ -13,7 +13,7 @@
         <div class="o_we_bg_filter bg-black-50"/>
     </xpath>
     <!-- Title -->
-    <xpath expr="//h1" position="replace" mode="inner">
+    <xpath expr="//h2" position="replace" mode="inner">
         <b>We create the perfect <br/>tailored solution for you</b>
     </xpath>
 </template>

--- a/theme_cobalt/views/customizations.xml
+++ b/theme_cobalt/views/customizations.xml
@@ -125,7 +125,7 @@
     <xpath expr="//section" position="attributes">
         <attribute name="class" add="pt56" remove="pt40" separator=" "/>
     </xpath>
-    <xpath expr="//h1" position="replace" mode="inner">
+    <xpath expr="//h2" position="replace" mode="inner">
         Projects
     </xpath>
 </template>

--- a/theme_enark/views/snippets/s_parallax.xml
+++ b/theme_enark/views/snippets/s_parallax.xml
@@ -10,7 +10,7 @@
     <xpath expr="//div[hasclass('oe_empty')]" position="after">
         <div class="container">
             <div class="row d-flex justify-content-start">
-                <h1><i>“One of the great beauties of architecture is that each time, it is like life starting all over again.”</i></h1>
+                <h2><i>“One of the great beauties of architecture is that each time, it is like life starting all over again.”</i></h2>
             </div>
         </div>
     </xpath>

--- a/theme_kiddo/views/snippets/s_cover.xml
+++ b/theme_kiddo/views/snippets/s_cover.xml
@@ -13,7 +13,7 @@
     </xpath>
 
     <!-- Heading -->
-    <xpath expr="//font" position="replace" mode="inner">
+    <xpath expr="//h1" position="replace" mode="inner">
         Kiddo Nursery
     </xpath>
 

--- a/theme_kiddo/views/snippets/s_picture.xml
+++ b/theme_kiddo/views/snippets/s_picture.xml
@@ -8,7 +8,7 @@
     </xpath>
 
     <!-- Heading -->
-    <xpath expr="//font" position="replace" mode="inner">
+    <xpath expr="//h2" position="replace" mode="inner">
         Letting each child explore and grow at their own pace
     </xpath>
 

--- a/theme_loftspace/views/snippets/s_title.xml
+++ b/theme_loftspace/views/snippets/s_title.xml
@@ -13,7 +13,7 @@
         <div class="o_we_bg_filter bg-black-50"/>
     </xpath>
     <!-- Title -->
-    <xpath expr="//h1" position="replace" mode="inner">
+    <xpath expr="//h2" position="replace" mode="inner">
         <b>Everything is designed.<br/> Few things are designed well.</b>
     </xpath>
 </template>

--- a/theme_monglia/views/customizations.xml
+++ b/theme_monglia/views/customizations.xml
@@ -6,8 +6,8 @@
     <xpath expr="//section" position="attributes">
         <attribute name="class" add="o_cc o_cc5" separator=" "/>
     </xpath>
-    <xpath expr="//h1" position="replace">
-        <h1> <font style="background-image: linear-gradient(135deg, var(--o-color-4) 25%, var(--o-color-1) 100%);" class="text-gradient">MAIN LINE UP</font></h1>
+    <xpath expr="//h2" position="replace">
+        <h2><font style="background-image: linear-gradient(135deg, var(--o-color-4) 25%, var(--o-color-1) 100%);" class="text-gradient">MAIN LINE UP</font></h2>
     </xpath>
 </template>
 

--- a/theme_nano/views/snippets/s_cover.xml
+++ b/theme_nano/views/snippets/s_cover.xml
@@ -10,7 +10,7 @@
     </xpath>
     <xpath expr="//*[hasclass('s_parallax_bg')]" position="replace"/>
     <!-- Title & Text -->
-    <xpath expr="//h1//font" position="replace" mode="inner">
+    <xpath expr="//h1" position="replace" mode="inner">
         Creative Studio
     </xpath>
     <xpath expr="//p" position="replace" mode="inner">

--- a/theme_notes/views/snippets/s_carousel.xml
+++ b/theme_notes/views/snippets/s_carousel.xml
@@ -8,7 +8,7 @@
     </xpath>
     <xpath expr="//div[hasclass('carousel-content')]" position="replace">
         <div class="carousel-content col-lg-6">
-            <h1>Miraillet Festival</h1>
+            <h2>Miraillet Festival</h2>
             <p class="lead">From the 12th to the 17th of August, come and enjoy the atmosphere at the Miraillet Festival. Discover the line up below.</p>
             <p><br/></p>
             <p><a href="/contactus" class="btn btn-primary btn-lg">More Info</a></p>
@@ -20,7 +20,7 @@
     </xpath>
     <xpath expr="(//div[hasclass('carousel-content')])[2]" position="replace">
         <div class="carousel-content col-lg-6">
-            <h1>6 Days Pass</h1>
+            <h2>6 Days Pass</h2>
             <p class="lead">Tickets will be on sale soon. Do not miss our 6 Days Pass. Free camping!</p>
             <p><br/></p>
             <p><a href="/" class="btn btn-primary btn-lg">More Info</a></p>
@@ -32,7 +32,7 @@
     </xpath>
     <xpath expr="(//div[hasclass('carousel-content')])[3]" position="replace">
         <div class="carousel-content col-lg-6">
-            <h1>Recent Editions</h1>
+            <h2>Recent Editions</h2>
             <p class="lead">Discover what makes the reputation of the Miraillet festival through these after-movies.</p>
             <p><br/></p>
             <p><a href="/" class="btn btn-primary btn-lg">More Info</a></p>

--- a/theme_odoo_experts/views/snippets/s_title.xml
+++ b/theme_odoo_experts/views/snippets/s_title.xml
@@ -3,7 +3,7 @@
 
 <template id="s_title" inherit_id="website.s_title">
     <!-- Section -->
-    <xpath expr="//h1/font" position="replace" mode="inner">
+    <xpath expr="//h2" position="replace" mode="inner">
         Pricing to suit<br/> all sizes of business
     </xpath>
 </template>

--- a/theme_paptic/views/customizations.xml
+++ b/theme_paptic/views/customizations.xml
@@ -163,7 +163,7 @@
     <xpath expr="//section" position="attributes">
         <attribute name="class" add="pt96 pb80" remove="pt40 pb40" separator=" "/>
     </xpath>
-     <xpath expr="//h1" position="replace" mode="inner">
+     <xpath expr="//h2" position="replace" mode="inner">
         Unique experiences.
     </xpath>
 </template>

--- a/theme_treehouse/views/snippets/s_title.xml
+++ b/theme_treehouse/views/snippets/s_title.xml
@@ -12,7 +12,7 @@
         <div class="o_we_bg_filter bg-black-50"/>
     </xpath>
     <!-- Title -->
-    <xpath expr="//h1" position="replace" mode="inner">
+    <xpath expr="//h2" position="replace" mode="inner">
         Changing the world is possible.<br/> We’ve done it before.
     </xpath>
 </template>

--- a/theme_yes/views/snippets/s_cover.xml
+++ b/theme_yes/views/snippets/s_cover.xml
@@ -11,8 +11,11 @@
         <div class="o_we_bg_filter" style="background-color: rgba(25, 41, 37, 0.55) !important;"/>
     </xpath>
     <!-- Title -->
+    <xpath expr="//h1" position="attributes">
+        <attribute name="class" add="display-1-fs" remove="display-3-fs" separator=" "/>
+    </xpath>
     <xpath expr="//h1" position="replace" mode="inner">
-        <font style="font-size: 92px; font-weight: bold;">Once in a lifetime moments</font>
+        Once in a lifetime moments
     </xpath>
     <!-- Paragraph -->
     <xpath expr="//p" position="replace" mode="inner">

--- a/theme_yes/views/snippets/s_picture.xml
+++ b/theme_yes/views/snippets/s_picture.xml
@@ -7,7 +7,7 @@
         <attribute name="class" add="o_cc5" remove="o_cc2" separator=" "/>
     </xpath>
     <!-- Title -->
-    <xpath expr="//h2//font" position="replace" mode="inner">
+    <xpath expr="//h2" position="replace" mode="inner">
         Love is in the air
     </xpath>
     <!-- Paragraphs -->

--- a/theme_yes/views/snippets/s_title.xml
+++ b/theme_yes/views/snippets/s_title.xml
@@ -7,7 +7,7 @@
         <attribute name="class" add="o_cc o_cc2" separator=" "/>
     </xpath>
     <!-- Title -->
-    <xpath expr="//h1//font" position="replace" mode="inner">
+    <xpath expr="//h2" position="replace" mode="inner">
         Meet our team
     </xpath>
 </template>


### PR DESCRIPTION
This commit permit to reduce the risk to have a wrong h1 tag or multiple h1 tags on the same page. This commit replaces some h1 tags by a h2. In addition, this commit removed some font size written in the style attribute and replace them by a font size class.

Community PR: https://github.com/odoo/odoo/pull/129791

task-1958098