### PR TITLE
[REF] test_themes: remove owl="1" from the templates

### DIFF
--- a/test_themes/static/src/systray_items/website_switcher.xml
+++ b/test_themes/static/src/systray_items/website_switcher.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <templates xml:space="preserve">
-<t t-name="test_themes.ThemeTooltip" owl="1">
+<t t-name="test_themes.ThemeTooltip">
     <img t-att-src="url" width="150"/>
 </t>
 


### PR DESCRIPTION
As all the templates are now imported in the owl app, there is not need anymore to specify the owl="1" attribute in the templates.

Part of task~3443861