### PR TITLE
[FIX] theme_avantgarde: properly define 3rd 3-cols image for previews

### DIFF
--- a/theme_avantgarde/__manifest__.py
+++ b/theme_avantgarde/__manifest__.py
@@ -20,7 +20,7 @@
         'website.s_picture_default_image': '/theme_avantgarde/static/src/img/pictures/bg_image_14.jpg',
         'website.s_three_columns_default_image_1': '/theme_avantgarde/static/src/img/pictures/bg_image_15',
         'website.s_three_columns_default_image_2': '/theme_avantgarde/static/src/img/pictures/bg_image_16.jpg',
-        'website.s_three_columns_default_image_2': '/theme_avantgarde/static/src/img/pictures/bg_image_17.jpg',
+        'website.s_three_columns_default_image_3': '/theme_avantgarde/static/src/img/pictures/bg_image_17.jpg',
         'website.s_text_image_default_image': '/theme_avantgarde/static/src/img/pictures/bg_image_13.jpg',
     },
     'snippet_lists': {


### PR DESCRIPTION
Since [1], the manifest is not well formed: it contains a duplicated key

[1]: https://github.com/odoo/design-themes/commit/08befbeaf5ef90ef7ab2176847269d7eea2ec4c7

Courtesy of @XtremXpert