### PR TITLE
[REF] *: remove owl from linter's accepted global variables

### DIFF
--- a/test_themes/static/src/systray_items/website_switcher.js
+++ b/test_themes/static/src/systray_items/website_switcher.js
@@ -3,8 +3,7 @@
 import { patch } from "@web/core/utils/patch";
 import { useService } from '@web/core/utils/hooks';
 import { WebsiteSwitcherSystray } from '@website/systray_items/website_switcher';
-
-const { onMounted, useState } = owl;
+import { onMounted, useState } from "@odoo/owl";
 
 patch(WebsiteSwitcherSystray.prototype, {
     setup() {


### PR DESCRIPTION
Before this commit, owl was in the linter's accepted global variables. This allowed  direct access to owl global object.

For instance, to use xml from owl, you could do :
`const { xml } = owl;`
or you could use it directly:
`owl.xml`

Now, owl is not accepted on linter's global variables anymore, so to import xml, now you need to use a proper import:

`import { xml } from "@odoo/owl";`

task-id 3498859