### PR TITLE
[FIX] theme_*: adapt .pot file to recent commit changing wording

### DIFF
--- a/theme_aviato/i18n/theme_aviato.pot
+++ b/theme_aviato/i18n/theme_aviato.pot
@@ -132,7 +132,7 @@ msgstr ""
 #: model_terms:theme.ir.ui.view,arch:theme_aviato.s_three_columns
 msgid ""
 "Paris' monument-lined boulevards, museums, classical bistros and boutiques "
-"are enhanced by a new wave of multimedia galleries, creative wine bars.."
+"are enhanced by a new wave of multimedia galleries, creative wine bars..."
 msgstr ""
 
 #. module: theme_aviato

--- a/theme_bewise/i18n/theme_bewise.pot
+++ b/theme_bewise/i18n/theme_bewise.pot
@@ -22,7 +22,7 @@ msgstr ""
 
 #. module: theme_bewise
 #: model_terms:theme.ir.ui.view,arch:theme_bewise.s_call_to_action
-msgid "<b>3,000 students</b> graduate each year find a job within 2 months"
+msgid "<b>3,000 students</b> graduate each year and find a job within 2 months"
 msgstr ""
 
 #. module: theme_bewise

--- a/theme_bistro/i18n/theme_bistro.pot
+++ b/theme_bistro/i18n/theme_bistro.pot
@@ -71,15 +71,15 @@ msgstr ""
 #. module: theme_bistro
 #: model_terms:theme.ir.ui.view,arch:theme_bistro.s_features
 msgid ""
-"Enjoy tasty food with friends.<br/><small>From <b>6:30 am</b> to <b>10:30 "
-"am</b></small>"
+"Enjoy tasty food with friends.<br/><small>From <b>6:30 pm</b> to <b>10:30 "
+"pm</b></small>"
 msgstr ""
 
 #. module: theme_bistro
 #: model_terms:theme.ir.ui.view,arch:theme_bistro.s_features
 msgid ""
-"Help you start your morning right.<br/><small>From <b>7:30 pm</b> to "
-"<b>10:30 pm</b></small>"
+"Help you start your morning right.<br/><small>From <b>7:30 am</b> to "
+"<b>10:30 am</b></small>"
 msgstr ""
 
 #. module: theme_bistro
@@ -100,16 +100,16 @@ msgstr ""
 #. module: theme_bistro
 #: model_terms:theme.ir.ui.view,arch:theme_bistro.s_features
 msgid ""
-"Take a break from your busy schedule.<br/><small>From <b>11:30 pm</b> to "
-"<b>14:30 am</b></small>"
+"Take a break from your busy schedule.<br/><small>From <b>11:30 am</b> to "
+"<b>2:30 pm</b></small>"
 msgstr ""
 
 #. module: theme_bistro
 #: model_terms:theme.ir.ui.view,arch:theme_bistro.s_picture
 msgid ""
-"Taste our chef special, the macon two shells of almond macaroon<br/> topped "
-"with a creamy orange blossom scent."
-msgstr ""
+"Taste our chef's special, an almond macaroon with orange blossom "
+"buttercream."
+msgstr "
 
 #. module: theme_bistro
 #: model_terms:theme.ir.ui.view,arch:theme_bistro.s_banner

--- a/theme_buzzy/i18n/theme_buzzy.pot
+++ b/theme_buzzy/i18n/theme_buzzy.pot
@@ -27,7 +27,7 @@ msgstr ""
 
 #. module: theme_buzzy
 #: model_terms:theme.ir.ui.view,arch:theme_buzzy.s_three_columns
-msgid "All data <br/>on your hands"
+msgid "All data <br/>in your hands"
 msgstr ""
 
 #. module: theme_buzzy

--- a/theme_clean/i18n/theme_clean.pot
+++ b/theme_clean/i18n/theme_clean.pot
@@ -87,7 +87,7 @@ msgstr ""
 #: model_terms:theme.ir.ui.view,arch:theme_clean.s_cover
 msgid ""
 "Make your finances reach a new level with our online management system. "
-"<br/>Track every penny, directly from the confort of your home."
+"<br/>Track every penny, directly from the comfort of your home."
 msgstr ""
 
 #. module: theme_clean

--- a/theme_enark/i18n/theme_enark.pot
+++ b/theme_enark/i18n/theme_enark.pot
@@ -108,7 +108,7 @@ msgstr ""
 msgid ""
 "We are a contemporary architecture firm working mainly in the residential, "
 "commercial and office sectors. Our projects are built all over the world, in"
-" urban and natural environments."
+" urban and rural environments."
 msgstr ""
 
 #. module: theme_enark

--- a/theme_kiddo/i18n/theme_kiddo.pot
+++ b/theme_kiddo/i18n/theme_kiddo.pot
@@ -59,7 +59,7 @@ msgstr ""
 
 #. module: theme_kiddo
 #: model_terms:theme.ir.ui.view,arch:theme_kiddo.s_three_columns
-msgid "For every kids"
+msgid "For every kid"
 msgstr ""
 
 #. module: theme_kiddo

--- a/theme_loftspace/i18n/theme_loftspace.pot
+++ b/theme_loftspace/i18n/theme_loftspace.pot
@@ -37,7 +37,7 @@ msgstr ""
 
 #. module: theme_loftspace
 #: model_terms:theme.ir.ui.view,arch:theme_loftspace.s_cover
-msgid "Discover our unique pieces of furnitures selected for you."
+msgid "Discover our unique pieces of furniture selected for you."
 msgstr ""
 
 #. module: theme_loftspace

--- a/theme_notes/i18n/theme_notes.pot
+++ b/theme_notes/i18n/theme_notes.pot
@@ -93,7 +93,7 @@ msgstr ""
 #: model_terms:theme.ir.ui.view,arch:theme_notes.s_media_list
 msgid ""
 "<br/>\n"
-"        You will find here the different means of transport to get to the festival. The festival is accessible by bike. Be careful, you will be riding in the city centre where there are a lot of cars. Please make sure to park your bikes in the designated areas of the city."
+"        You will find here the different means of transport to get to the festival. The festival is accessible by bike. Be careful, you will be riding in the city centre where there are a lot of cars. Please make sure to park your bike in the designated areas of the city."
 msgstr ""
 
 #. module: theme_notes
@@ -111,7 +111,7 @@ msgstr ""
 msgid ""
 "Aline, is a French singer, songwriter and producer. In 2016, she was ranked "
 "as the most powerful and influential French person by Vanity Fair, who "
-"noticed her \"radiance of French genius."
+"noticed her radiance of French genius."
 msgstr ""
 
 #. module: theme_notes

--- a/theme_orchid/i18n/theme_orchid.pot
+++ b/theme_orchid/i18n/theme_orchid.pot
@@ -107,7 +107,7 @@ msgstr ""
 #. module: theme_orchid
 #: model_terms:theme.ir.ui.view,arch:theme_orchid.s_quotes_carousel
 msgid ""
-"Very nice, colourful shop with many choices in the choir of a very pretty "
+"Very nice, colorful shop with many choices in the heart of a very pretty "
 "town."
 msgstr ""
 

--- a/theme_real_estate/i18n/theme_real_estate.pot
+++ b/theme_real_estate/i18n/theme_real_estate.pot
@@ -113,8 +113,7 @@ msgstr ""
 #: model_terms:theme.ir.ui.view,arch:theme_real_estate.s_three_columns
 msgid ""
 "Elegant, modern sophisticated architecture with an impressive in large scale"
-" home designed with the finest imported finishes. Pyrgon, marble and wood "
-"floors..."
+" home designed with the finest imported finishes. Marble and wood floors..."
 msgstr ""
 
 #. module: theme_real_estate

--- a/theme_yes/i18n/theme_yes.pot
+++ b/theme_yes/i18n/theme_yes.pot
@@ -124,7 +124,7 @@ msgstr ""
 
 #. module: theme_yes
 #: model_terms:theme.ir.ui.view,arch:theme_yes.s_masonry_block_default_template
-msgid "Checkout our list of favorite venues."
+msgid "Check out our list of favorite venues."
 msgstr ""
 
 #. module: theme_yes

--- a/theme_zap/i18n/theme_zap.pot
+++ b/theme_zap/i18n/theme_zap.pot
@@ -17,7 +17,7 @@ msgstr ""
 
 #. module: theme_zap
 #: model_terms:theme.ir.ui.view,arch:theme_zap.s_banner
-msgid "<b>Software innovation</b><br/> as its best."
+msgid "<b>Software innovation</b><br/> at its best."
 msgstr ""
 
 #. module: theme_zap


### PR DESCRIPTION
See commit [1], it changed wording but didn't adapt .pot files. As that commit was targetting master at first, .pot where not needed. When changing the target to odoo 16, we forgot to adapt the .pot.

[1]: https://github.com/odoo/design-themes/commit/7cdb6d2ab7054094b5651a43e3bce8e6c7e26e87