### PR TITLE
[IMP] theme_*: restore base snippet shapes that do not connect blocks

### DIFF
--- a/theme_anelusia/views/new_page_template.xml
+++ b/theme_anelusia/views/new_page_template.xml
@@ -3,50 +3,6 @@
 
 <!-- General customizations -->
 
-<template id="new_page_template_s_call_to_action" inherit_id="website.new_page_template_s_call_to_action">
-    <!-- Shape option -->
-    <xpath expr="//section" position="attributes">
-        <attribute name="data-oe-shape-data">{"shape":"web_editor/Floats/02","flip":[]}</attribute>
-    </xpath>
-    <!-- Shape -->
-    <xpath expr="//div[hasclass('container')]" position="before">
-        <div class="o_we_shape o_web_editor_Floats_02"/>
-    </xpath>
-</template>
-
-<template id="new_page_template_s_call_to_action_about" inherit_id="website.new_page_template_s_call_to_action_about">
-    <!-- Shape option -->
-    <xpath expr="//section" position="attributes">
-        <attribute name="data-oe-shape-data">{"shape":"web_editor/Floats/02","flip":[]}</attribute>
-    </xpath>
-    <!-- Shape -->
-    <xpath expr="//div[hasclass('container')]" position="before">
-        <div class="o_we_shape o_web_editor_Floats_02"/>
-    </xpath>
-</template>
-
-<template id="new_page_template_s_call_to_action_digital" inherit_id="website.new_page_template_s_call_to_action_digital">
-    <!-- Shape option -->
-    <xpath expr="//section" position="attributes">
-        <attribute name="data-oe-shape-data">{"shape":"web_editor/Floats/02","flip":[]}</attribute>
-    </xpath>
-    <!-- Shape -->
-    <xpath expr="//div[hasclass('container')]" position="before">
-        <div class="o_we_shape o_web_editor_Floats_02"/>
-    </xpath>
-</template>
-
-<template id="new_page_template_s_call_to_action_menu" inherit_id="website.new_page_template_s_call_to_action_menu">
-    <!-- Shape option -->
-    <xpath expr="//section" position="attributes">
-        <attribute name="data-oe-shape-data">{"shape":"web_editor/Floats/02","flip":[]}</attribute>
-    </xpath>
-    <!-- Shape -->
-    <xpath expr="//div[hasclass('container')]" position="before">
-        <div class="o_we_shape o_web_editor_Floats_02"/>
-    </xpath>
-</template>
-
 <template id="new_page_template_s_comparisons" inherit_id="website.new_page_template_s_comparisons">
     <!-- Shape option -->
     <xpath expr="//section" position="attributes">
@@ -58,15 +14,13 @@
     </xpath>
 </template>
 
-<template id="new_page_template_s_numbers" inherit_id="website.new_page_template_s_numbers">
-    <!-- Shape option -->
+<template id="new_page_template_s_product_catalog" inherit_id="website.new_page_template_s_product_catalog">
+    <!-- Remove shape option -->
     <xpath expr="//section" position="attributes">
-        <attribute name="data-oe-shape-data">{"shape":"web_editor/Airy/10","flip":[]}</attribute>
+        <attribute name="data-oe-shape-data"/>
     </xpath>
-    <!-- Shape -->
-    <xpath expr="//div[hasclass('container')]" position="before">
-        <div class="o_we_shape o_web_editor_Airy_10"/>
-    </xpath>
+    <!-- Remove shape -->
+    <xpath expr="//div[hasclass('o_we_shape')]" position="replace"/>
 </template>
 
 <!-- Snippet customization Basic Pages -->
@@ -111,17 +65,6 @@
 
 <!-- Snippet customization Landing Pages -->
 
-<template id="new_page_template_landing_s_showcase" inherit_id="website.new_page_template_landing_s_showcase">
-    <!-- Shape option -->
-    <xpath expr="//section" position="attributes">
-        <attribute name="data-oe-shape-data">{"shape":"web_editor/Floats/05","flip":[]}</attribute>
-    </xpath>
-    <!-- Shape -->
-    <xpath expr="//div[hasclass('container')]" position="before">
-        <div class="o_we_shape o_web_editor_Floats_05"/>
-    </xpath>
-</template>
-
 <template id="new_page_template_landing_2_s_cover" inherit_id="website.new_page_template_landing_2_s_cover">
     <xpath expr="//section" position="attributes">
         <attribute name="class" add="o_half_screen_height" remove="o_full_screen_height" separator=" "/>
@@ -156,6 +99,15 @@
     <xpath expr="//section" position="attributes">
         <attribute name="class" add="o_half_screen_height" remove="o_full_screen_height" separator=" "/>
     </xpath>
+</template>
+
+<template id="new_page_template_pricing_s_showcase" inherit_id="website.new_page_template_pricing_s_showcase">
+    <!-- Remove shape option -->
+    <xpath expr="//section" position="attributes">
+        <attribute name="data-oe-shape-data"/>
+    </xpath>
+    <!-- Remove shape -->
+    <xpath expr="//div[hasclass('o_we_shape')]" position="replace"/>
 </template>
 
 <template id="new_page_template_pricing_s_text_block_h1" inherit_id="website.new_page_template_pricing_s_text_block_h1">

--- a/theme_anelusia/views/snippets/s_call_to_action.xml
+++ b/theme_anelusia/views/snippets/s_call_to_action.xml
@@ -5,6 +5,11 @@
     <!-- Section -->
     <xpath expr="//section" position="attributes">
         <attribute name="class" add="pt120 pb104 o_cc4" remove="pt48 pb24 o_cc3" separator=" "/>
+        <attribute name="data-oe-shape-data">{"shape":"web_editor/Floats/02","flip":[]}</attribute>
+    </xpath>
+    <!-- Shape -->
+    <xpath expr="//div[hasclass('container')]" position="before">
+        <div class="o_we_shape o_web_editor_Floats_02"/>
     </xpath>
     <!-- Title & subtitle -->
     <xpath expr="//div[hasclass('col-lg-9')]" position="attributes">
@@ -34,17 +39,6 @@
     </xpath>
     <xpath expr="//a[hasclass('btn')]/t" position="replace" mode="inner">
         Discover it
-    </xpath>
-</template>
-
-<template id="configurator_s_call_to_action" inherit_id="website.configurator_s_call_to_action">
-    <!-- Shape option -->
-    <xpath expr="//section" position="attributes">
-        <attribute name="data-oe-shape-data">{"shape":"web_editor/Floats/02","flip":[]}</attribute>
-    </xpath>
-    <!-- Shape -->
-    <xpath expr="//div[hasclass('container')]" position="before">
-        <div class="o_we_shape o_web_editor_Floats_02"/>
     </xpath>
 </template>
 

--- a/theme_anelusia/views/snippets/s_numbers.xml
+++ b/theme_anelusia/views/snippets/s_numbers.xml
@@ -5,12 +5,6 @@
     <!-- Section -->
     <xpath expr="//section" position="attributes">
         <attribute name="class" add="o_half_screen_height o_cc4" remove="o_cc2" separator=" "/>
-    </xpath>
-</template>
-
-<template id="configurator_s_numbers" inherit_id="website.configurator_s_numbers">
-    <!-- Shape option -->
-    <xpath expr="//section" position="attributes">
         <attribute name="data-oe-shape-data">{"shape":"web_editor/Airy/10","flip":[]}</attribute>
     </xpath>
     <!-- Shape -->

--- a/theme_anelusia/views/snippets/s_product_catalog.xml
+++ b/theme_anelusia/views/snippets/s_product_catalog.xml
@@ -5,15 +5,9 @@
     <!-- Section -->
     <xpath expr="//section" position="attributes">
         <attribute name="class" add="o_cc o_cc4" separator=" "/>
+        <attribute name="data-oe-shape-data">{"shape":"web_editor/Airy/11","flip":[]}</attribute>
         <!-- Remove the background image -->
         <attribute name="style"/>
-    </xpath>
-</template>
-
-<template id="configurator_s_product_catalog" inherit_id="website.configurator_s_product_catalog">
-    <!-- Shape option -->
-    <xpath expr="//section" position="attributes">
-        <attribute name="data-oe-shape-data">{"shape":"web_editor/Airy/11","flip":[]}</attribute>
     </xpath>
     <!-- Shape -->
     <xpath expr="//div[hasclass('container')]" position="before">

--- a/theme_anelusia/views/snippets/s_showcase.xml
+++ b/theme_anelusia/views/snippets/s_showcase.xml
@@ -5,6 +5,11 @@
     <!-- Section -->
     <xpath expr="//section" position="attributes">
         <attribute name="class" add="pt120 pb120" remove="pt48 pb48" separator=" "/>
+        <attribute name="data-oe-shape-data">{"shape":"web_editor/Floats/05","flip":[]}</attribute>
+    </xpath>
+    <!-- Shape -->
+    <xpath expr="//div[hasclass('container')]" position="before">
+        <div class="o_we_shape o_web_editor_Floats_05"/>
     </xpath>
 </template>
 

--- a/theme_artists/views/new_page_template.xml
+++ b/theme_artists/views/new_page_template.xml
@@ -42,17 +42,6 @@
     </xpath>
 </template>
 
-<template id="new_page_template_s_features" inherit_id="website.new_page_template_s_features">
-    <!-- Shape option -->
-    <xpath expr="//section" position="attributes">
-        <attribute name="data-oe-shape-data">{"shape":"web_editor/Airy/14","flip":[]}</attribute>
-    </xpath>
-    <!-- Shape -->
-    <xpath expr="//div[hasclass('container')]" position="before">
-        <div class="o_we_shape o_web_editor_Airy_14"/>
-    </xpath>
-</template>
-
 <template id="new_page_template_s_numbers" inherit_id="website.new_page_template_s_numbers">
     <!-- Shape option -->
     <xpath expr="//section" position="attributes">
@@ -86,14 +75,8 @@
 </template>
 
 <template id="new_page_template_about_s_cover" inherit_id="website.new_page_template_about_s_cover">
-    <!-- Shape option -->
     <xpath expr="//section" position="attributes">
         <attribute name="class" add="o_half_screen_height" remove="o_full_screen_height" separator=" "/>
-        <attribute name="data-oe-shape-data">{"shape":"web_editor/Floats/02","flip":[]}</attribute>
-    </xpath>
-    <!-- Shape -->
-    <xpath expr="//div[hasclass('container')]" position="before">
-        <div class="o_we_shape o_web_editor_Floats_02"/>
     </xpath>
 </template>
 
@@ -147,28 +130,6 @@
     </xpath>
 </template>
 
-<template id="new_page_template_landing_0_s_cover" inherit_id="website.new_page_template_landing_0_s_cover">
-    <!-- Shape option -->
-    <xpath expr="//section" position="attributes">
-        <attribute name="data-oe-shape-data">{"shape":"web_editor/Floats/02","flip":[]}</attribute>
-    </xpath>
-    <!-- Shape -->
-    <xpath expr="//div[hasclass('container')]" position="before">
-        <div class="o_we_shape o_web_editor_Floats_02"/>
-    </xpath>
-</template>
-
-<template id="new_page_template_landing_2_s_cover" inherit_id="website.new_page_template_landing_2_s_cover">
-    <!-- Shape option -->
-    <xpath expr="//section" position="attributes">
-        <attribute name="data-oe-shape-data">{"shape":"web_editor/Floats/02","flip":[]}</attribute>
-    </xpath>
-    <!-- Shape -->
-    <xpath expr="//div[hasclass('container')]" position="before">
-        <div class="o_we_shape o_web_editor_Floats_02"/>
-    </xpath>
-</template>
-
 <template id="new_page_template_landing_2_s_text_block_h2" inherit_id="website.new_page_template_landing_2_s_text_block_h2">
     <xpath expr="//section" position="attributes">
         <attribute name="class" add="o_cc4" remove="o_cc2" separator=" "/>
@@ -184,17 +145,6 @@
 <template id="new_page_template_landing_3_s_text_block_h2" inherit_id="website.new_page_template_landing_3_s_text_block_h2">
     <xpath expr="//section" position="attributes">
         <attribute name="class" add="o_cc4" remove="o_cc2" separator=" "/>
-    </xpath>
-</template>
-
-<template id="new_page_template_landing_4_s_cover" inherit_id="website.new_page_template_landing_4_s_cover">
-    <!-- Shape option -->
-    <xpath expr="//section" position="attributes">
-        <attribute name="data-oe-shape-data">{"shape":"web_editor/Floats/02","flip":[]}</attribute>
-    </xpath>
-    <!-- Shape -->
-    <xpath expr="//div[hasclass('container')]" position="before">
-        <div class="o_we_shape o_web_editor_Floats_02"/>
     </xpath>
 </template>
 
@@ -223,14 +173,8 @@
 </template>
 
 <template id="new_page_template_gallery_s_cover" inherit_id="website.new_page_template_gallery_s_cover">
-    <!-- Shape option -->
     <xpath expr="//section" position="attributes">
         <attribute name="class" add="o_half_screen_height" remove="o_full_screen_height" separator=" "/>
-        <attribute name="data-oe-shape-data">{"shape":"web_editor/Floats/02","flip":[]}</attribute>
-    </xpath>
-    <!-- Shape -->
-    <xpath expr="//div[hasclass('container')]" position="before">
-        <div class="o_we_shape o_web_editor_Floats_02"/>
     </xpath>
 </template>
 
@@ -282,11 +226,6 @@
     <!-- Shape option -->
     <xpath expr="//section" position="attributes">
         <attribute name="class" add="o_half_screen_height" remove="o_full_screen_height" separator=" "/>
-        <attribute name="data-oe-shape-data">{"shape":"web_editor/Floats/02","flip":[]}</attribute>
-    </xpath>
-    <!-- Shape -->
-    <xpath expr="//div[hasclass('container')]" position="before">
-        <div class="o_we_shape o_web_editor_Floats_02"/>
     </xpath>
 </template>
 

--- a/theme_artists/views/snippets/s_cover.xml
+++ b/theme_artists/views/snippets/s_cover.xml
@@ -5,6 +5,11 @@
     <!-- Section -->
     <xpath expr="//section" position="attributes">
         <attribute name="class" add="pt200 pb200 o_cc o_cc4" remove="pb96 pt96 s_parallax_bg parallax s_parallax_is_fixed bg-black-50" separator=" "/>
+        <attribute name="data-oe-shape-data">{"shape":"web_editor/Floats/02","flip":[]}</attribute>
+    </xpath>
+    <!-- Shape -->
+    <xpath expr="//div[hasclass('container')]" position="before">
+        <div class="o_we_shape o_web_editor_Floats_02"/>
     </xpath>
     <!-- Remove filter & parallax -->
     <xpath expr="//div[hasclass('o_we_bg_filter')]" position="replace"/>
@@ -15,17 +20,6 @@
     </xpath>
     <xpath expr="//h1" position="after">
         <p><br/></p>
-    </xpath>
-</template>
-
-<template id="configurator_s_cover" inherit_id="website.configurator_s_cover">
-    <!-- Shape option -->
-    <xpath expr="//section" position="attributes">
-        <attribute name="data-oe-shape-data">{"shape":"web_editor/Floats/02","flip":[]}</attribute>
-    </xpath>
-    <!-- Shape -->
-    <xpath expr="//div[hasclass('container')]" position="before">
-        <div class="o_we_shape o_web_editor_Floats_02"/>
     </xpath>
 </template>
 

--- a/theme_artists/views/snippets/s_features.xml
+++ b/theme_artists/views/snippets/s_features.xml
@@ -5,6 +5,11 @@
     <!-- Section -->
     <xpath expr="//section" position="attributes">
         <attribute name="class" add="o_cc o_cc4" separator=" "/>
+        <attribute name="data-oe-shape-data">{"shape":"web_editor/Airy/14","flip":[]}</attribute>
+    </xpath>
+    <!-- Shape -->
+    <xpath expr="//div[hasclass('container')]" position="before">
+        <div class="o_we_shape o_web_editor_Airy_14"/>
     </xpath>
     <!-- Feature #01 - Icon -->
     <xpath expr="//i" position="attributes">
@@ -13,17 +18,6 @@
     <!-- Feature #03 - Icon -->
     <xpath expr="(//i)[3]" position="attributes">
         <attribute name="class" add="bg-o-color-5" remove="bg-secondary" separator=" "/>
-    </xpath>
-</template>
-
-<template id="configurator_s_features" inherit_id="website.configurator_s_features">
-    <!-- Shape option -->
-    <xpath expr="//section" position="attributes">
-        <attribute name="data-oe-shape-data">{"shape":"web_editor/Airy/14","flip":[]}</attribute>
-    </xpath>
-    <!-- Shape -->
-    <xpath expr="//div[hasclass('container')]" position="before">
-        <div class="o_we_shape o_web_editor_Airy_14"/>
     </xpath>
 </template>
 

--- a/theme_avantgarde/views/customizations.xml
+++ b/theme_avantgarde/views/customizations.xml
@@ -5,9 +5,13 @@
 <template id="s_cover" inherit_id="website.s_cover" name="Avantgarde s_cover">
     <xpath expr="//section" position="attributes">
         <attribute name="class" add="s_parallax_no_overflow_hidden o_full_screen_height" remove="s_parallax_is_fixed s_parallax" separator=" "/>
+        <attribute name="data-oe-shape-data">{"shape":"web_editor/Origins/18","flip":["x"]}</attribute>
     </xpath>
     <xpath expr="//span[hasclass('s_parallax_bg')]" position="attributes">
         <attribute name="style" remove="background-position: 50% 0;" add="background-position: 50% 80%;" separator=";"/>
+    </xpath>
+    <xpath expr="//div[hasclass('s_allow_columns')]" position="before">
+        <div class="o_we_shape o_web_editor_Origins_18" style="background-image: url('/web_editor/shape/web_editor/Origins/18.svg?c1=o-color-2&amp;flip=x'); background-position: 50% 50%;"/>
     </xpath>
     <xpath expr="//h1" position="attributes">
         <attribute name="class" add="text-o-color-1 text-break" separator=" "/>
@@ -21,15 +25,6 @@
     </xpath>
     <xpath expr="//a[hasclass('btn')]" position="attributes">
         <attribute name="class" add="btn-lg" separator=" "/>
-    </xpath>
-</template>
-
-<template id="configurator_s_cover" inherit_id="website.configurator_s_cover" name="Avantgarde s_cover">
-    <xpath expr="//section" position="attributes">
-        <attribute name="data-oe-shape-data">{"shape":"web_editor/Origins/18","flip":["x"]}</attribute>
-    </xpath>
-    <xpath expr="//div[hasclass('s_allow_columns')]" position="before">
-        <div class="o_we_shape o_web_editor_Origins_18" style="background-image: url('/web_editor/shape/web_editor/Origins/18.svg?c1=o-color-2&amp;flip=x'); background-position: 50% 50%;"/>
     </xpath>
 </template>
 

--- a/theme_avantgarde/views/new_page_template.xml
+++ b/theme_avantgarde/views/new_page_template.xml
@@ -37,10 +37,6 @@
 <template id="new_page_template_about_s_cover" inherit_id="website.new_page_template_about_s_cover">
     <xpath expr="//section" position="attributes">
         <attribute name="class" add="o_half_screen_height o_cc5" remove="o_full_screen_height" separator=" "/>
-        <attribute name="data-oe-shape-data">{"shape":"web_editor/Origins/18","flip":["x"]}</attribute>
-    </xpath>
-    <xpath expr="//div[hasclass('s_allow_columns')]" position="before">
-        <div class="o_we_shape o_web_editor_Origins_18" style="background-image: url('/web_editor/shape/web_editor/Origins/18.svg?c1=o-color-2&amp;flip=x'); background-position: 50% 50%;"/>
     </xpath>
 </template>
 
@@ -48,31 +44,19 @@
 
 <template id="new_page_template_landing_0_s_cover" inherit_id="website.new_page_template_landing_0_s_cover">
     <xpath expr="//section" position="attributes">
-    <attribute name="class" add="o_cc5" separator=" "/>
-        <attribute name="data-oe-shape-data">{"shape":"web_editor/Origins/18","flip":["x"]}</attribute>
-    </xpath>
-    <xpath expr="//div[hasclass('s_allow_columns')]" position="before">
-        <div class="o_we_shape o_web_editor_Origins_18" style="background-image: url('/web_editor/shape/web_editor/Origins/18.svg?c1=o-color-2&amp;flip=x'); background-position: 50% 50%;"/>
+        <attribute name="class" add="o_cc5" separator=" "/>
     </xpath>
 </template>
 
 <template id="new_page_template_landing_2_s_cover" inherit_id="website.new_page_template_landing_2_s_cover">
     <xpath expr="//section" position="attributes">
         <attribute name="class" add="o_half_screen_height o_cc5" remove="o_full_screen_height" separator=" "/>
-        <attribute name="data-oe-shape-data">{"shape":"web_editor/Origins/18","flip":["x"]}</attribute>
-    </xpath>
-    <xpath expr="//div[hasclass('s_allow_columns')]" position="before">
-        <div class="o_we_shape o_web_editor_Origins_18" style="background-image: url('/web_editor/shape/web_editor/Origins/18.svg?c1=o-color-2&amp;flip=x'); background-position: 50% 50%;"/>
     </xpath>
 </template>
 
 <template id="new_page_template_landing_4_s_cover" inherit_id="website.new_page_template_landing_4_s_cover">
     <xpath expr="//section" position="attributes">
-    <attribute name="class" add="o_cc5" separator=" "/>
-        <attribute name="data-oe-shape-data">{"shape":"web_editor/Origins/18","flip":["x"]}</attribute>
-    </xpath>
-    <xpath expr="//div[hasclass('s_allow_columns')]" position="before">
-        <div class="o_we_shape o_web_editor_Origins_18" style="background-image: url('/web_editor/shape/web_editor/Origins/18.svg?c1=o-color-2&amp;flip=x'); background-position: 50% 50%;"/>
+        <attribute name="class" add="o_cc5" separator=" "/>
     </xpath>
 </template>
 
@@ -81,10 +65,6 @@
 <template id="new_page_template_gallery_s_cover" inherit_id="website.new_page_template_gallery_s_cover">
     <xpath expr="//section" position="attributes">
         <attribute name="class" add="o_half_screen_height o_cc5" remove="o_full_screen_height" separator=" "/>
-        <attribute name="data-oe-shape-data">{"shape":"web_editor/Origins/18","flip":["x"]}</attribute>
-    </xpath>
-    <xpath expr="//div[hasclass('s_allow_columns')]" position="before">
-        <div class="o_we_shape o_web_editor_Origins_18" style="background-image: url('/web_editor/shape/web_editor/Origins/18.svg?c1=o-color-2&amp;flip=x'); background-position: 50% 50%;"/>
     </xpath>
 </template>
 
@@ -101,10 +81,6 @@
 <template id="new_page_template_pricing_s_cover" inherit_id="website.new_page_template_pricing_s_cover">
     <xpath expr="//section" position="attributes">
         <attribute name="class" add="o_half_screen_height o_cc5" remove="o_full_screen_height" separator=" "/>
-        <attribute name="data-oe-shape-data">{"shape":"web_editor/Origins/18","flip":["x"]}</attribute>
-    </xpath>
-    <xpath expr="//div[hasclass('s_allow_columns')]" position="before">
-        <div class="o_we_shape o_web_editor_Origins_18" style="background-image: url('/web_editor/shape/web_editor/Origins/18.svg?c1=o-color-2&amp;flip=x'); background-position: 50% 50%;"/>
     </xpath>
 </template>
 

--- a/theme_beauty/views/new_page_template.xml
+++ b/theme_beauty/views/new_page_template.xml
@@ -48,11 +48,16 @@
 <template id="new_page_template_s_numbers" inherit_id="website.new_page_template_s_numbers">
     <xpath expr="//section" position="attributes">
         <attribute name="class" add="o_cc4" remove="o_cc3" separator=" "/>
-        <attribute name="data-oe-shape-data">{"shape":"web_editor/Rainy/10","flip":[]}</attribute>
     </xpath>
-    <xpath expr="//div[hasclass('container')]" position="before">
-        <div class="o_we_shape o_web_editor_Rainy_10"/>
+</template>
+
+<template id="new_page_template_s_picture" inherit_id="website.new_page_template_s_picture">
+    <!-- Remove shape option -->
+    <xpath expr="//section" position="attributes">
+        <attribute name="data-oe-shape-data"/>
     </xpath>
+    <!-- Remove shape -->
+    <xpath expr="//div[hasclass('o_we_shape')]" position="replace"/>
 </template>
 
 <template id="new_page_template_s_picture_only" inherit_id="website.new_page_template_s_picture_only" primary="True">
@@ -86,10 +91,6 @@
 <template id="new_page_template_about_full_s_numbers" inherit_id="website.new_page_template_about_full_s_numbers">
     <xpath expr="//section" position="attributes">
         <attribute name="class" add="o_cc4" remove="o_cc3" separator=" "/>
-        <attribute name="data-oe-shape-data">{"shape":"web_editor/Rainy/10","flip":[]}</attribute>
-    </xpath>
-    <xpath expr="//div[hasclass('container')]" position="before">
-        <div class="o_we_shape o_web_editor_Rainy_10"/>
     </xpath>
 </template>
 

--- a/theme_beauty/views/snippets/s_numbers.xml
+++ b/theme_beauty/views/snippets/s_numbers.xml
@@ -5,12 +5,6 @@
     <!-- Section -->
     <xpath expr="//section" position="attributes">
         <attribute name="class" add="o_cc3" remove="o_cc2" separator=" "/>
-    </xpath>
-</template>
-
-<template id="configurator_s_numbers" inherit_id="website.configurator_s_numbers">
-    <!-- Shape option -->
-    <xpath expr="//section" position="attributes">
         <attribute name="data-oe-shape-data">{"shape":"web_editor/Rainy/10","flip":[]}</attribute>
     </xpath>
     <!-- Shape -->

--- a/theme_beauty/views/snippets/s_picture.xml
+++ b/theme_beauty/views/snippets/s_picture.xml
@@ -5,12 +5,6 @@
     <!-- Section -->
     <xpath expr="//section" position="attributes">
         <attribute name="class" add="o_cc1" remove="o_cc2" separator=" "/>
-    </xpath>
-</template>
-
-<template id="configurator_s_picture" inherit_id="website.configurator_s_picture">
-    <!-- Shape option -->
-    <xpath expr="//section" position="attributes">
         <attribute name="data-oe-shape-data">{"shape":"web_editor/Rainy/06","flip":["x"]}</attribute>
     </xpath>
     <!-- Shape -->

--- a/theme_bewise/views/customizations.xml
+++ b/theme_bewise/views/customizations.xml
@@ -6,7 +6,12 @@
     <xpath expr="//section" position="attributes">
         <attribute name="class" add="pt200 pb200 o_cc o_cc5 oe_img_bg o_bg_img_center" remove="bg-black-50 s_parallax_is_fixed parallax pt96 pb96" separator=" "/>
         <attribute name="style">background-image: url('/web/image/website.s_cover_default_image'); background-position: 50% 50%;</attribute>
+        <attribute name="data-oe-shape-data">{"shape":"web_editor/Rainy/08_001","flip":[]}</attribute>
         <attribute name="data-scroll-background-ratio">0</attribute>
+    </xpath>
+    <!-- Shape -->
+    <xpath expr="//div[hasclass('container')]" position="before">
+        <div class="o_we_shape o_web_editor_Rainy_08_001"/>
     </xpath>
     <!-- Remove the background image for parallax -->
     <xpath expr="//span[hasclass('s_parallax_bg')]" position="replace"/>
@@ -24,16 +29,6 @@
     </xpath>
     <xpath expr="//p" position="after">
     <p><br/></p>
-    </xpath>
-</template>
-
-<template id="configurator_s_cover" inherit_id="website.configurator_s_cover" name="Be Wise s_cover">
-    <xpath expr="//section" position="attributes">
-        <attribute name="data-oe-shape-data">{"shape":"web_editor/Rainy/08_001","flip":[]}</attribute>
-    </xpath>
-    <!-- Shape -->
-    <xpath expr="//div[hasclass('container')]" position="before">
-        <div class="o_we_shape o_web_editor_Rainy_08_001"/>
     </xpath>
 </template>
 
@@ -93,6 +88,10 @@
 <template id="s_numbers" inherit_id="website.s_numbers" name="Be Wise s_numbers">
     <xpath expr="//section" position="attributes">
         <attribute name="class" add="o_cc3" remove="o_cc2" separator=" "/>
+        <attribute name="data-oe-shape-data">{"shape":"web_editor/Blobs/11","flip":["x"]}</attribute>
+    </xpath>
+    <xpath expr="//section/div" position="before">
+        <div class="o_we_shape o_web_editor_Blobs_11" style="background-image: url('/web_editor/shape/web_editor/Blobs/11.svg?c1=o-color-1&amp;flip=x'); background-position: 50% 50%;"/>
     </xpath>
     <xpath expr="//h6" position="replace" mode="inner">
         Faculties
@@ -108,15 +107,6 @@
     </xpath>
     <xpath expr="//div[hasclass('row')]/div[4]/span" position="replace" mode="inner" >
         16,456
-    </xpath>
-</template>
-
-<template id="configurator_s_numbers" inherit_id="website.configurator_s_numbers" name="Be Wise s_numbers">
-    <xpath expr="//section" position="attributes">
-        <attribute name="data-oe-shape-data">{"shape":"web_editor/Blobs/11","flip":["x"]}</attribute>
-    </xpath>
-    <xpath expr="//section/div" position="before">
-        <div class="o_we_shape o_web_editor_Blobs_11" style="background-image: url('/web_editor/shape/web_editor/Blobs/11.svg?c1=o-color-1&amp;flip=x'); background-position: 50% 50%;"/>
     </xpath>
 </template>
 
@@ -207,6 +197,14 @@
 
 <!-- ======== CALL TO ACTION ======== -->
 <template id="s_call_to_action" inherit_id="website.s_call_to_action" name="Be Wise s_call_to_action">
+    <!-- Shape options -->
+    <xpath expr="//section" position="attributes">
+        <attribute name="data-oe-shape-data">{"shape":"web_editor/Blobs/11","flip":[]}</attribute>
+    </xpath>
+    <!-- Shape -->
+    <xpath expr="//section/div" position="before">
+        <div class="o_we_shape o_web_editor_Blobs_11"/>
+    </xpath>
     <!-- Title -->
     <xpath expr="//h3" position="replace">
         <h4><b>3,000 students</b> graduate each year and find a job within 2 months</h4>
@@ -218,16 +216,6 @@
     <!-- Button -->
     <xpath expr="//a[hasclass('btn')]" position="attributes">
         <attribute name="class" add="btn-lg" separator=" "/>
-    </xpath>
-</template>
-
-<template id="configurator_s_call_to_action" inherit_id="website.configurator_s_call_to_action" name="Be Wise s_call_to_action">
-    <xpath expr="//section" position="attributes">
-        <attribute name="data-oe-shape-data">{"shape":"web_editor/Blobs/11","flip":[]}</attribute>
-    </xpath>
-    <!-- Shape -->
-    <xpath expr="//section/div" position="before">
-        <div class="o_we_shape o_web_editor_Blobs_11"/>
     </xpath>
 </template>
 
@@ -366,6 +354,14 @@
 
 <!-- ======== MEDIA LIST ======== -->
 <template id="s_media_list" inherit_id="website.s_media_list" name="Be Wise s_media_list">
+    <!-- Shape options -->
+    <xpath expr="//section" position="attributes">
+        <attribute name="data-oe-shape-data">{"shape":"web_editor/Airy/04_001","flip":[]}</attribute>
+    </xpath>
+    <!-- Shape -->
+    <xpath expr="//div[hasclass('container')]" position="before">
+        <div class="o_we_shape o_web_editor_Airy_04_001"/>
+    </xpath>
     <!-- Item #1 -->
     <xpath expr="//div[hasclass('s_media_list_item')]" position="attributes">
         <attribute name="class" add="col-lg-10" remove="col-lg-12" separator=" "/>
@@ -410,16 +406,6 @@
     </xpath>
 </template>
 
-<template id="configurator_s_media_list" inherit_id="website.configurator_s_media_list" name="Be Wise s_media_list">
-    <xpath expr="//section" position="attributes">
-        <attribute name="data-oe-shape-data">{"shape":"web_editor/Airy/04_001","flip":[]}</attribute>
-    </xpath>
-    <!-- Shape -->
-    <xpath expr="//div[hasclass('container')]" position="before">
-        <div class="o_we_shape o_web_editor_Airy_04_001"/>
-    </xpath>
-</template>
-
 <!-- ======== COMPARISONS ======== -->
 <template id="s_comparisons" inherit_id="website.s_comparisons" name="Be Wise s_comparisons">
     <xpath expr="//div[hasclass('card')]//li[hasclass('list-group-item')]" position="replace" mode="inner">
@@ -454,19 +440,11 @@
 <template id="s_product_catalog" inherit_id="website.s_product_catalog" name="Be Wise s_product_catalog">
     <xpath expr="//section" position="attributes">
         <attribute name="class" add="o_cc o_cc5 pt120 pb120" remove="pt48 pb32" separator=" "/>
-    </xpath>
-    <!-- Filter -->
-    <xpath expr="//div[hasclass('container')]" position="before">
-        <div class="o_we_bg_filter bg-black-75"/>
-    </xpath>
-</template>
-
-<template id="configurator_s_product_catalog" inherit_id="website.configurator_s_product_catalog" name="Be Wise s_product_catalog">
-    <xpath expr="//section" position="attributes">
         <attribute name="data-oe-shape-data">{"shape":"web_editor/Floats/06","flip":[]}</attribute>
     </xpath>
-    <!-- Shape -->
+    <!-- Filter & shape -->
     <xpath expr="//div[hasclass('container')]" position="before">
+        <div class="o_we_bg_filter bg-black-75"/>
         <div class="o_we_shape o_web_editor_Floats_06"/>
     </xpath>
 </template>

--- a/theme_bewise/views/new_page_template.xml
+++ b/theme_bewise/views/new_page_template.xml
@@ -3,34 +3,31 @@
 
 <!-- General customizations -->
 
-<template id="new_page_template_s_call_to_action" inherit_id="website.new_page_template_s_call_to_action">
+<template id="new_page_template_s_call_to_action_digital" inherit_id="website.new_page_template_s_call_to_action_digital">
+    <!-- Remove shape option -->
     <xpath expr="//section" position="attributes">
-        <attribute name="data-oe-shape-data">{"shape":"web_editor/Blobs/11","flip":[]}</attribute>
+        <attribute name="data-oe-shape-data"/>
     </xpath>
-    <!-- Shape -->
-    <xpath expr="//section/div" position="before">
-        <div class="o_we_shape o_web_editor_Blobs_11"/>
-    </xpath>
+    <!-- Remove shape -->
+    <xpath expr="//div[hasclass('o_we_shape')]" position="replace"/>
 </template>
 
-<template id="new_page_template_s_call_to_action_about" inherit_id="website.new_page_template_s_call_to_action_about">
+<template id="new_page_template_s_media_list" inherit_id="website.new_page_template_s_media_list">
+    <!-- Remove shape option -->
     <xpath expr="//section" position="attributes">
-        <attribute name="data-oe-shape-data">{"shape":"web_editor/Blobs/11","flip":[]}</attribute>
+        <attribute name="data-oe-shape-data"/>
     </xpath>
-    <!-- Shape -->
-    <xpath expr="//section/div" position="before">
-        <div class="o_we_shape o_web_editor_Blobs_11"/>
-    </xpath>
+    <!-- Remove shape -->
+    <xpath expr="//div[hasclass('o_we_shape')]" position="replace"/>
 </template>
 
-<template id="new_page_template_s_call_to_action_menu" inherit_id="website.new_page_template_s_call_to_action_menu">
+<template id="new_page_template_s_product_catalog" inherit_id="website.new_page_template_s_product_catalog">
+    <!-- Remove shape option -->
     <xpath expr="//section" position="attributes">
-        <attribute name="data-oe-shape-data">{"shape":"web_editor/Blobs/11","flip":[]}</attribute>
+        <attribute name="data-oe-shape-data"/>
     </xpath>
-    <!-- Shape -->
-    <xpath expr="//section/div" position="before">
-        <div class="o_we_shape o_web_editor_Blobs_11"/>
-    </xpath>
+    <!-- Remove shape -->
+    <xpath expr="//div[hasclass('o_we_shape')]" position="replace"/>
 </template>
 
 <!-- Snippet customization Basic Pages -->
@@ -51,43 +48,19 @@
 <template id="new_page_template_about_s_cover" inherit_id="website.new_page_template_about_s_cover">
     <xpath expr="//section" position="attributes">
         <attribute name="class" add="o_half_screen_height" remove="o_full_screen_height" separator=" "/>
-        <attribute name="data-oe-shape-data">{"shape":"web_editor/Rainy/08_001","flip":[]}</attribute>
-    </xpath>
-    <!-- Shape -->
-    <xpath expr="//div[hasclass('container')]" position="before">
-        <div class="o_we_shape o_web_editor_Rainy_08_001"/>
     </xpath>
 </template>
 
-<template id="new_page_template_about_full_s_numbers" inherit_id="website.new_page_template_about_full_s_numbers">
+<template id="new_page_template_about_personal_s_numbers" inherit_id="website.new_page_template_about_personal_s_numbers">
+    <!-- Remove shape option -->
     <xpath expr="//section" position="attributes">
-        <attribute name="data-oe-shape-data">{"shape":"web_editor/Blobs/11","flip":["x"]}</attribute>
+        <attribute name="data-oe-shape-data"/>
     </xpath>
-    <xpath expr="//section/div" position="before">
-        <div class="o_we_shape o_web_editor_Blobs_11" style="background-image: url('/web_editor/shape/web_editor/Blobs/11.svg?c1=o-color-1&amp;flip=x'); background-position: 50% 50%;"/>
-    </xpath>
-</template>
-
-<template id="new_page_template_about_map_s_numbers" inherit_id="website.new_page_template_about_map_s_numbers">
-    <xpath expr="//section" position="attributes">
-        <attribute name="data-oe-shape-data">{"shape":"web_editor/Blobs/11","flip":["x"]}</attribute>
-    </xpath>
-    <xpath expr="//section/div" position="before">
-        <div class="o_we_shape o_web_editor_Blobs_11" style="background-image: url('/web_editor/shape/web_editor/Blobs/11.svg?c1=o-color-1&amp;flip=x'); background-position: 50% 50%;"/>
-    </xpath>
+    <!-- Remove shape -->
+    <xpath expr="//div[hasclass('o_we_shape')]" position="replace"/>
 </template>
 
 <!-- Snippet customization Landing Pages -->
-
-<template id="new_page_template_landing_0_s_cover" inherit_id="website.new_page_template_landing_0_s_cover">
-    <xpath expr="//section" position="attributes">
-        <attribute name="data-oe-shape-data">{"shape":"web_editor/Rainy/08_001","flip":[]}</attribute>
-    </xpath>
-    <!-- Shape -->
-    <xpath expr="//div[hasclass('container')]" position="before">
-        <div class="o_we_shape o_web_editor_Rainy_08_001"/>
-    </xpath>
-</template>
 
 <template id="new_page_template_landing_1_s_banner" inherit_id="website.new_page_template_landing_1_s_banner">
     <!-- Shape option -->
@@ -103,21 +76,6 @@
 <template id="new_page_template_landing_2_s_cover" inherit_id="website.new_page_template_landing_2_s_cover">
     <xpath expr="//section" position="attributes">
         <attribute name="class" add="o_half_screen_height" remove="o_full_screen_height" separator=" "/>
-        <attribute name="data-oe-shape-data">{"shape":"web_editor/Rainy/08_001","flip":[]}</attribute>
-    </xpath>
-    <!-- Shape -->
-    <xpath expr="//div[hasclass('container')]" position="before">
-        <div class="o_we_shape o_web_editor_Rainy_08_001"/>
-    </xpath>
-</template>
-
-<template id="new_page_template_landing_4_s_cover" inherit_id="website.new_page_template_landing_4_s_cover">
-    <xpath expr="//section" position="attributes">
-        <attribute name="data-oe-shape-data">{"shape":"web_editor/Rainy/08_001","flip":[]}</attribute>
-    </xpath>
-    <!-- Shape -->
-    <xpath expr="//div[hasclass('container')]" position="before">
-        <div class="o_we_shape o_web_editor_Rainy_08_001"/>
     </xpath>
 </template>
 
@@ -126,11 +84,6 @@
 <template id="new_page_template_gallery_s_cover" inherit_id="website.new_page_template_gallery_s_cover">
     <xpath expr="//section" position="attributes">
         <attribute name="class" add="o_half_screen_height" remove="o_full_screen_height" separator=" "/>
-        <attribute name="data-oe-shape-data">{"shape":"web_editor/Rainy/08_001","flip":[]}</attribute>
-    </xpath>
-    <!-- Shape -->
-    <xpath expr="//div[hasclass('container')]" position="before">
-        <div class="o_we_shape o_web_editor_Rainy_08_001"/>
     </xpath>
 </template>
 
@@ -147,11 +100,6 @@
 <template id="new_page_template_pricing_s_cover" inherit_id="website.new_page_template_pricing_s_cover">
     <xpath expr="//section" position="attributes">
         <attribute name="class" add="o_half_screen_height" remove="o_full_screen_height" separator=" "/>
-        <attribute name="data-oe-shape-data">{"shape":"web_editor/Rainy/08_001","flip":[]}</attribute>
-    </xpath>
-    <!-- Shape -->
-    <xpath expr="//div[hasclass('container')]" position="before">
-        <div class="o_we_shape o_web_editor_Rainy_08_001"/>
     </xpath>
 </template>
 

--- a/theme_bookstore/views/new_page_template.xml
+++ b/theme_bookstore/views/new_page_template.xml
@@ -39,6 +39,15 @@
 
 <!-- General customizations -->
 
+<template id="new_page_template_s_media_list" inherit_id="website.new_page_template_s_media_list">
+    <!-- Remove shape option -->
+    <xpath expr="//section" position="attributes">
+        <attribute name="data-oe-shape-data"/>
+    </xpath>
+    <!-- Remove shape -->
+    <xpath expr="//div[hasclass('o_we_shape')]" position="replace"/>
+</template>
+
 <!-- Snippet customization Basic Pages -->
 
 <template id="new_page_template_basic_2_s_text_block_h1" inherit_id="website.new_page_template_basic_2_s_text_block_h1">
@@ -54,11 +63,6 @@
     <!-- Section -->
     <xpath expr="//section" position="attributes">
         <attribute name="class" add="o_half_screen_height" remove="o_full_screen_height" separator=" "/>
-        <attribute name="data-oe-shape-data">{"shape":"web_editor/Floats/03","flip":[]}</attribute>
-    </xpath>
-    <!-- Shape -->
-    <xpath expr="//div[hasclass('container')]" position="before">
-        <div class="o_we_shape o_web_editor_Floats_03"/>
     </xpath>
 </template>
 
@@ -78,11 +82,6 @@
     <!-- Shape option -->
     <xpath expr="//section" position="attributes">
         <attribute name="class" add="o_cc2" remove="o_cc3" separator=" "/>
-        <attribute name="data-oe-shape-data">{"shape":"web_editor/Floats/12","flip":[]}</attribute>
-    </xpath>
-    <!-- Shape -->
-    <xpath expr="//div[hasclass('container')]" position="before">
-        <div class="o_we_shape o_web_editor_Floats_12"/>
     </xpath>
 </template>
 
@@ -90,12 +89,17 @@
     <!-- Shape option -->
     <xpath expr="//section" position="attributes">
         <attribute name="class" add="o_cc2" remove="o_cc3" separator=" "/>
-        <attribute name="data-oe-shape-data">{"shape":"web_editor/Floats/12","flip":[]}</attribute>
     </xpath>
-    <!-- Shape -->
-    <xpath expr="//div[hasclass('container')]" position="before">
-        <div class="o_we_shape o_web_editor_Floats_12"/>
+</template>
+
+
+<template id="new_page_template_about_personal_s_numbers" inherit_id="website.new_page_template_about_personal_s_numbers">
+    <!-- Remove shape option -->
+    <xpath expr="//section" position="attributes">
+        <attribute name="data-oe-shape-data"/>
     </xpath>
+    <!-- Remove shape -->
+    <xpath expr="//div[hasclass('o_we_shape')]" position="replace"/>
 </template>
 
 <template id="new_page_template_about_map_s_text_block_h1" inherit_id="website.new_page_template_about_map_s_text_block_h1">
@@ -106,26 +110,10 @@
 
 <!-- Snippet customization Landing Pages -->
 
-<template id="new_page_template_landing_0_s_cover" inherit_id="website.new_page_template_landing_0_s_cover">
-    <!-- Section -->
-    <xpath expr="//section" position="attributes">
-        <attribute name="data-oe-shape-data">{"shape":"web_editor/Floats/03","flip":[]}</attribute>
-    </xpath>
-    <!-- Shape -->
-    <xpath expr="//div[hasclass('container')]" position="before">
-        <div class="o_we_shape o_web_editor_Floats_03"/>
-    </xpath>
-</template>
-
 <template id="new_page_template_landing_2_s_cover" inherit_id="website.new_page_template_landing_2_s_cover">
     <!-- Section -->
     <xpath expr="//section" position="attributes">
         <attribute name="class" add="o_half_screen_height" remove="o_full_screen_height" separator=" "/>
-        <attribute name="data-oe-shape-data">{"shape":"web_editor/Floats/03","flip":[]}</attribute>
-    </xpath>
-    <!-- Shape -->
-    <xpath expr="//div[hasclass('container')]" position="before">
-        <div class="o_we_shape o_web_editor_Floats_03"/>
     </xpath>
 </template>
 
@@ -141,28 +129,12 @@
     </xpath>
 </template>
 
-<template id="new_page_template_landing_4_s_cover" inherit_id="website.new_page_template_landing_4_s_cover">
-    <!-- Section -->
-    <xpath expr="//section" position="attributes">
-        <attribute name="data-oe-shape-data">{"shape":"web_editor/Floats/03","flip":[]}</attribute>
-    </xpath>
-    <!-- Shape -->
-    <xpath expr="//div[hasclass('container')]" position="before">
-        <div class="o_we_shape o_web_editor_Floats_03"/>
-    </xpath>
-</template>
-
 <!-- Snippet customization Gallery Pages -->
 
 <template id="new_page_template_gallery_s_cover" inherit_id="website.new_page_template_gallery_s_cover">
     <!-- Section -->
     <xpath expr="//section" position="attributes">
         <attribute name="class" add="o_half_screen_height" remove="o_full_screen_height" separator=" "/>
-        <attribute name="data-oe-shape-data">{"shape":"web_editor/Floats/03","flip":[]}</attribute>
-    </xpath>
-    <!-- Shape -->
-    <xpath expr="//div[hasclass('container')]" position="before">
-        <div class="o_we_shape o_web_editor_Floats_03"/>
     </xpath>
 </template>
 
@@ -180,11 +152,6 @@
     <!-- Section -->
     <xpath expr="//section" position="attributes">
         <attribute name="class" add="o_half_screen_height" remove="o_full_screen_height" separator=" "/>
-        <attribute name="data-oe-shape-data">{"shape":"web_editor/Floats/03","flip":[]}</attribute>
-    </xpath>
-    <!-- Shape -->
-    <xpath expr="//div[hasclass('container')]" position="before">
-        <div class="o_we_shape o_web_editor_Floats_03"/>
     </xpath>
 </template>
 

--- a/theme_bookstore/views/snippets/s_cover.xml
+++ b/theme_bookstore/views/snippets/s_cover.xml
@@ -6,11 +6,16 @@
     <xpath expr="//section" position="attributes">
         <attribute name="class" add="oe_img_bg o_full_screen_height" remove="parallax s_parallax_is_fixed bg-black-50" separator=" "/>
         <attribute name="data-scroll-background-ratio">0</attribute>
+        <attribute name="data-oe-shape-data">{"shape":"web_editor/Floats/03","flip":[]}</attribute>
         <attribute name="style">background-image: url('/web/image/website.s_cover_default_image'); background-position: 50% 55%;</attribute>
     </xpath>
     <!-- Filter -->
     <xpath expr="//div[hasclass('o_we_bg_filter')]" position="replace">
         <div class="o_we_bg_filter bg-white-75"/>
+    </xpath>
+    <!-- Shape -->
+    <xpath expr="//div[hasclass('container')]" position="before">
+        <div class="o_we_shape o_web_editor_Floats_03"/>
     </xpath>
     <!-- Disable Parallax -->
     <xpath expr="//span[hasclass('s_parallax_bg')]" position="replace"/>
@@ -25,17 +30,6 @@
     <!-- Button -->
     <xpath expr="//a[hasclass('btn')]/t" position="replace" mode="inner">
         Discover more
-    </xpath>
-</template>
-
-<template id="configurator_s_cover" inherit_id="website.configurator_s_cover">
-    <!-- Section -->
-    <xpath expr="//section" position="attributes">
-        <attribute name="data-oe-shape-data">{"shape":"web_editor/Floats/03","flip":[]}</attribute>
-    </xpath>
-    <!-- Shape -->
-    <xpath expr="//div[hasclass('container')]" position="before">
-        <div class="o_we_shape o_web_editor_Floats_03"/>
     </xpath>
 </template>
 

--- a/theme_bookstore/views/snippets/s_media_list.xml
+++ b/theme_bookstore/views/snippets/s_media_list.xml
@@ -5,6 +5,11 @@
     <!-- Section -->
     <xpath expr="//section" position="attributes">
         <attribute name="class" add="o_cc5" remove="o_cc2" separator=" "/>
+        <attribute name="data-oe-shape-data">{"shape":"web_editor/Wavy/10","flip":[]}</attribute>
+    </xpath>
+    <!-- Shape -->
+    <xpath expr="//div[hasclass('container')]" position="before">
+        <div class="o_we_shape o_web_editor_Wavy_10"/>
     </xpath>
     <!-- Container -->
     <xpath expr="//div[hasclass('container')]" position="attributes">
@@ -24,17 +29,6 @@
     <!-- Media item #3 -->
     <xpath expr="//div[hasclass('s_media_list_item')][3]/div" position="attributes">
         <attribute name="class" remove="o_cc o_cc1" separator=" "/>
-    </xpath>
-</template>
-
-<template id="configurator_s_media_list" inherit_id="website.configurator_s_media_list">
-    <!-- Shape option -->
-    <xpath expr="//section" position="attributes">
-        <attribute name="data-oe-shape-data">{"shape":"web_editor/Wavy/10","flip":[]}</attribute>
-    </xpath>
-    <!-- Shape -->
-    <xpath expr="//div[hasclass('container')]" position="before">
-        <div class="o_we_shape o_web_editor_Wavy_10"/>
     </xpath>
 </template>
 

--- a/theme_bookstore/views/snippets/s_numbers.xml
+++ b/theme_bookstore/views/snippets/s_numbers.xml
@@ -5,6 +5,11 @@
     <!-- Section -->
     <xpath expr="//section" position="attributes">
         <attribute name="class" add="o_cc1 pt112 pb112" remove="o_cc2 pt24 pb24" separator=" "/>
+        <attribute name="data-oe-shape-data">{"shape":"web_editor/Floats/12","flip":[]}</attribute>
+    </xpath>
+    <!-- Shape -->
+    <xpath expr="//div[hasclass('container')]" position="before">
+        <div class="o_we_shape o_web_editor_Floats_12"/>
     </xpath>
     <!-- Titles -->
     <xpath expr="//h6" position="replace" mode="inner">
@@ -18,17 +23,6 @@
     </xpath>
     <xpath expr="//h6" position="replace" mode="inner">
         Outstanding images
-    </xpath>
-</template>
-
-<template id="configurator_s_numbers" inherit_id="website.configurator_s_numbers">
-    <!-- Shape option -->
-    <xpath expr="//section" position="attributes">
-        <attribute name="data-oe-shape-data">{"shape":"web_editor/Floats/12","flip":[]}</attribute>
-    </xpath>
-    <!-- Shape -->
-    <xpath expr="//div[hasclass('container')]" position="before">
-        <div class="o_we_shape o_web_editor_Floats_12"/>
     </xpath>
 </template>
 

--- a/theme_buzzy/views/new_page_template.xml
+++ b/theme_buzzy/views/new_page_template.xml
@@ -39,15 +39,40 @@
 
 <!-- General customizations -->
 
-<template id="new_page_template_s_quotes_carousel" inherit_id="website.new_page_template_s_quotes_carousel">
-    <!-- Shape option -->
-    <xpath expr="//div[hasclass('s_quotes_carousel')]" position="attributes">
-        <attribute name="data-oe-shape-data">{"shape":"web_editor/Rainy/10","flip":[]}</attribute>
+<template id="new_page_template_s_call_to_action" inherit_id="website.new_page_template_s_call_to_action">
+    <!-- Remove shape option -->
+    <xpath expr="//section" position="attributes">
+        <attribute name="data-oe-shape-data"/>
     </xpath>
-    <!-- Shape -->
-    <xpath expr="//ol[hasclass('carousel-indicators')]" position="before">
-        <div class="o_we_shape o_web_editor_Rainy_10"/>
+    <!-- Remove shape -->
+    <xpath expr="//div[hasclass('o_we_shape')]" position="replace"/>
+</template>
+
+<template id="new_page_template_s_call_to_action_about" inherit_id="website.new_page_template_s_call_to_action_about">
+    <!-- Remove shape option -->
+    <xpath expr="//section" position="attributes">
+        <attribute name="data-oe-shape-data"/>
     </xpath>
+    <!-- Remove shape -->
+    <xpath expr="//div[hasclass('o_we_shape')]" position="replace"/>
+</template>
+
+<template id="new_page_template_s_call_to_action_menu" inherit_id="website.new_page_template_s_call_to_action_menu">
+    <!-- Remove shape option -->
+    <xpath expr="//section" position="attributes">
+        <attribute name="data-oe-shape-data"/>
+    </xpath>
+    <!-- Remove shape -->
+    <xpath expr="//div[hasclass('o_we_shape')]" position="replace"/>
+</template>
+
+<template id="new_page_template_s_product_catalog" inherit_id="website.new_page_template_s_product_catalog">
+    <!-- Remove shape option -->
+    <xpath expr="//section" position="attributes">
+        <attribute name="data-oe-shape-data"/>
+    </xpath>
+    <!-- Remove shape -->
+    <xpath expr="//div[hasclass('o_we_shape')]" position="replace"/>
 </template>
 
 <template id="new_page_template_s_showcase" inherit_id="website.new_page_template_s_showcase">
@@ -80,17 +105,6 @@
 
 <!-- Snippet customization Basic Pages -->
 
-<template id="new_page_template_basic_s_features" inherit_id="website.new_page_template_basic_s_features">
-    <!-- Shape option -->
-    <xpath expr="//section" position="attributes">
-        <attribute name="data-oe-shape-data">{"shape":"web_editor/Rainy/09_001","flip":[]}</attribute>
-    </xpath>
-    <!-- Shape -->
-    <xpath expr="//div[hasclass('container')]" position="before">
-        <div class="o_we_shape o_web_editor_Rainy_09_001"/>
-    </xpath>
-</template>
-
 <!-- Snippet customization About Pages -->
 
 <template id="new_page_template_about_s_banner" inherit_id="website.new_page_template_about_s_banner">
@@ -108,22 +122,6 @@
     <!-- Shape option -->
     <xpath expr="//section" position="attributes">
         <attribute name="class" add="o_half_screen_height" remove="o_full_screen_height" separator=" "/>
-        <attribute name="data-oe-shape-data">{"shape":"web_editor/Airy/03_001","flip":[]}</attribute>
-    </xpath>
-    <!-- Shape -->
-    <xpath expr="//div[hasclass('o_we_bg_filter')]" position="after">
-        <div class="o_we_shape o_web_editor_Airy_03_001"/>
-    </xpath>
-</template>
-
-<template id="new_page_template_about_s_features" inherit_id="website.new_page_template_about_s_features">
-    <!-- Shape option -->
-    <xpath expr="//section" position="attributes">
-        <attribute name="data-oe-shape-data">{"shape":"web_editor/Rainy/09_001","flip":[]}</attribute>
-    </xpath>
-    <!-- Shape -->
-    <xpath expr="//div[hasclass('container')]" position="before">
-        <div class="o_we_shape o_web_editor_Rainy_09_001"/>
     </xpath>
 </template>
 
@@ -151,31 +149,9 @@
     </xpath>
 </template>
 
-<template id="new_page_template_about_full_s_numbers" inherit_id="website.new_page_template_about_full_s_numbers">
-    <!-- Shape option -->
-    <xpath expr="//section" position="attributes">
-        <attribute name="data-oe-shape-data">{"shape":"web_editor/Zigs/02_001","flip":[]}</attribute>
-    </xpath>
-    <!-- Shape -->
-    <xpath expr="//div[hasclass('container')]" position="before">
-        <div class="o_we_shape o_web_editor_Zigs_02_001"/>
-    </xpath>
-</template>
-
 <template id="new_page_template_about_full_s_text_block_h1" inherit_id="website.new_page_template_about_full_s_text_block_h1">
     <xpath expr="//section" position="attributes">
         <attribute name="class" add="pb40 pb40 pt40" separator=" "/>
-    </xpath>
-</template>
-
-<template id="new_page_template_about_map_s_numbers" inherit_id="website.new_page_template_about_map_s_numbers">
-    <!-- Shape option -->
-    <xpath expr="//section" position="attributes">
-        <attribute name="data-oe-shape-data">{"shape":"web_editor/Zigs/02_001","flip":[]}</attribute>
-    </xpath>
-    <!-- Shape -->
-    <xpath expr="//div[hasclass('container')]" position="before">
-        <div class="o_we_shape o_web_editor_Zigs_02_001"/>
     </xpath>
 </template>
 
@@ -195,6 +171,15 @@
     </xpath>
 </template>
 
+<template id="new_page_template_about_personal_s_numbers" inherit_id="website.new_page_template_about_personal_s_numbers">
+    <!-- Remove shape option -->
+    <xpath expr="//section" position="attributes">
+        <attribute name="data-oe-shape-data"/>
+    </xpath>
+    <!-- Remove shape -->
+    <xpath expr="//div[hasclass('o_we_shape')]" position="replace"/>
+</template>
+
 <template id="new_page_template_about_personal_s_text_block_h2" inherit_id="website.new_page_template_about_personal_s_text_block_h2">
     <xpath expr="//section" position="attributes">
         <attribute name="class" add="o_cc4" remove="o_cc3" separator=" "/>
@@ -206,7 +191,10 @@
 <template id="new_page_template_landing_s_features" inherit_id="website.new_page_template_landing_s_features">
     <xpath expr="//section" position="attributes">
         <attribute name="class" add="o_cc2" separator=" "/>
+        <attribute name="data-oe-shape-data"/>
     </xpath>
+    <!-- Remove shape -->
+    <xpath expr="//div[hasclass('o_we_shape')]" position="replace"/>
 </template>
 
 <template id="new_page_template_landing_s_text_cover" inherit_id="website.new_page_template_landing_s_text_cover">
@@ -226,16 +214,29 @@
     </xpath>
 </template>
 
+<template id="new_page_template_landing_0_s_cover" inherit_id="website.new_page_template_landing_0_s_cover">
+    <!-- Remove shape option -->
+    <xpath expr="//section" position="attributes">
+        <attribute name="data-oe-shape-data"/>
+    </xpath>
+    <!-- Remove shape -->
+    <xpath expr="//div[hasclass('o_we_shape')]" position="replace"/>
+</template>
+
 <template id="new_page_template_landing_2_s_cover" inherit_id="website.new_page_template_landing_2_s_cover">
     <!-- Shape option -->
     <xpath expr="//section" position="attributes">
         <attribute name="class" add="o_half_screen_height" remove="o_full_screen_height" separator=" "/>
-        <attribute name="data-oe-shape-data">{"shape":"web_editor/Airy/03_001","flip":[]}</attribute>
     </xpath>
-    <!-- Shape -->
-    <xpath expr="//div[hasclass('o_we_bg_filter')]" position="after">
-        <div class="o_we_shape o_web_editor_Airy_03_001"/>
+</template>
+
+<template id="new_page_template_landing_4_s_cover" inherit_id="website.new_page_template_landing_4_s_cover">
+    <!-- Remove shape option -->
+    <xpath expr="//section" position="attributes">
+        <attribute name="data-oe-shape-data"/>
     </xpath>
+    <!-- Remove shape -->
+    <xpath expr="//div[hasclass('o_we_shape')]" position="replace"/>
 </template>
 
 <!-- Snippet customization Gallery Pages -->
@@ -255,11 +256,6 @@
     <!-- Shape option -->
     <xpath expr="//section" position="attributes">
         <attribute name="class" add="o_half_screen_height" remove="o_full_screen_height" separator=" "/>
-        <attribute name="data-oe-shape-data">{"shape":"web_editor/Airy/03_001","flip":[]}</attribute>
-    </xpath>
-    <!-- Shape -->
-    <xpath expr="//div[hasclass('o_we_bg_filter')]" position="after">
-        <div class="o_we_shape o_web_editor_Airy_03_001"/>
     </xpath>
 </template>
 
@@ -289,11 +285,6 @@
     <!-- Shape option -->
     <xpath expr="//section" position="attributes">
         <attribute name="class" add="o_half_screen_height" remove="o_full_screen_height" separator=" "/>
-        <attribute name="data-oe-shape-data">{"shape":"web_editor/Airy/03_001","flip":[]}</attribute>
-    </xpath>
-    <!-- Shape -->
-    <xpath expr="//div[hasclass('o_we_bg_filter')]" position="after">
-        <div class="o_we_shape o_web_editor_Airy_03_001"/>
     </xpath>
 </template>
 

--- a/theme_buzzy/views/snippets/s_call_to_action.xml
+++ b/theme_buzzy/views/snippets/s_call_to_action.xml
@@ -5,6 +5,11 @@
     <!-- Section -->
     <xpath expr="//section" position="attributes">
         <attribute name="class" add="o_cc5 pt88 pb48" remove="o_cc3 pt48 pb24" separator=" "/>
+        <attribute name="data-oe-shape-data">{"shape":"web_editor/Rainy/08_001","flip":[]}</attribute>
+    </xpath>
+    <!-- Shape -->
+    <xpath expr="//div[hasclass('container')]" position="before">
+        <div class="o_we_shape o_web_editor_Rainy_08_001"/>
     </xpath>
     <!-- Container -->
     <xpath expr="//div[hasclass('container')]" position="attributes">
@@ -25,17 +30,6 @@
     <!-- Right Column -->
     <xpath expr="//div[hasclass('row')]//div[2]" position="attributes">
         <attribute name="class" add="col-lg-4" remove="col-lg-3" separator=" "/>
-    </xpath>
-</template>
-
-<template id="configurator_s_call_to_action" inherit_id="website.configurator_s_call_to_action">
-    <!-- Shape option -->
-    <xpath expr="//section" position="attributes">
-        <attribute name="data-oe-shape-data">{"shape":"web_editor/Rainy/08_001","flip":[]}</attribute>
-    </xpath>
-    <!-- Shape -->
-    <xpath expr="//div[hasclass('container')]" position="before">
-        <div class="o_we_shape o_web_editor_Rainy_08_001"/>
     </xpath>
 </template>
 

--- a/theme_buzzy/views/snippets/s_cover.xml
+++ b/theme_buzzy/views/snippets/s_cover.xml
@@ -5,10 +5,15 @@
     <!-- Section -->
     <xpath expr="//section" position="attributes">
         <attribute name="class" add="o_cc o_cc5 pt112 pb112" remove="pt96 pb96 bg-black-50" separator=" "/>
+        <attribute name="data-oe-shape-data">{"shape":"web_editor/Airy/03_001","flip":[]}</attribute>
     </xpath>
     <!-- Filter -->
     <xpath expr="//div[hasclass('o_we_bg_filter')]" position="replace">
         <div class="o_we_bg_filter" style="background-color: rgba(52,54,67,0.75) !important;"/>
+    </xpath>
+    <!-- Shape -->
+    <xpath expr="//div[hasclass('o_we_bg_filter')]" position="after">
+        <div class="o_we_shape o_web_editor_Airy_03_001"/>
     </xpath>
     <!-- Title -->
     <xpath expr="//h1" position="replace" mode="inner">
@@ -23,14 +28,4 @@
     </xpath>
 </template>
 
-<template id="configurator_s_cover" inherit_id="website.configurator_s_cover">
-    <!-- Shape option -->
-    <xpath expr="//section" position="attributes">
-        <attribute name="data-oe-shape-data">{"shape":"web_editor/Airy/03_001","flip":[]}</attribute>
-    </xpath>
-    <!-- Shape -->
-    <xpath expr="//div[hasclass('o_we_bg_filter')]" position="after">
-        <div class="o_we_shape o_web_editor_Airy_03_001"/>
-    </xpath>
-</template>
 </odoo>

--- a/theme_buzzy/views/snippets/s_features.xml
+++ b/theme_buzzy/views/snippets/s_features.xml
@@ -5,6 +5,11 @@
     <!-- Section -->
     <xpath expr="//section" position="attributes">
         <attribute name="class" add="o_cc o_cc5" separator=" "/>
+        <attribute name="data-oe-shape-data">{"shape":"web_editor/Rainy/09_001","flip":[]}</attribute>
+    </xpath>
+    <!-- Shape -->
+    <xpath expr="//div[hasclass('container')]" position="before">
+        <div class="o_we_shape o_web_editor_Rainy_09_001"/>
     </xpath>
     <!-- Feature #2 - Icon -->
     <xpath expr="//div[hasclass('row')]//div[2]//i" position="attributes">
@@ -13,17 +18,6 @@
     <!-- Feature #3 - Icon -->
     <xpath expr="//div[hasclass('row')]//div[3]//i" position="attributes">
         <attribute name="class" add="bg-o-color-1" remove="bg-secondary" separator=" "/>
-    </xpath>
-</template>
-
-<template id="configurator_s_features" inherit_id="website.configurator_s_features">
-    <!-- Shape option -->
-    <xpath expr="//section" position="attributes">
-        <attribute name="data-oe-shape-data">{"shape":"web_editor/Rainy/09_001","flip":[]}</attribute>
-    </xpath>
-    <!-- Shape -->
-    <xpath expr="//div[hasclass('container')]" position="before">
-        <div class="o_we_shape o_web_editor_Rainy_09_001"/>
     </xpath>
 </template>
 

--- a/theme_buzzy/views/snippets/s_numbers.xml
+++ b/theme_buzzy/views/snippets/s_numbers.xml
@@ -5,12 +5,6 @@
     <!-- Section -->
     <xpath expr="//section" position="attributes">
         <attribute name="class" add="o_cc4 pt96 pb96" remove="o_cc2 pt24 pb24" separator=" "/>
-    </xpath>
-</template>
-
-<template id="configurator_s_numbers" inherit_id="website.configurator_s_numbers">
-    <!-- Shape option -->
-    <xpath expr="//section" position="attributes">
         <attribute name="data-oe-shape-data">{"shape":"web_editor/Zigs/02_001","flip":[]}</attribute>
     </xpath>
     <!-- Shape -->

--- a/theme_buzzy/views/snippets/s_process_steps.xml
+++ b/theme_buzzy/views/snippets/s_process_steps.xml
@@ -5,6 +5,11 @@
     <!-- Section -->
     <xpath expr="//section" position="attributes">
         <attribute name="class" add="o_cc o_cc5" separator=" "/>
+        <attribute name="data-oe-shape-data">{"shape":"web_editor/Rainy/08_001","flip":[]}</attribute>
+    </xpath>
+    <!-- Shape -->
+    <xpath expr="//div[hasclass('container')]" position="before">
+        <div class="o_we_shape o_web_editor_Rainy_08_001"/>
     </xpath>
     <!-- Icon #2 -->
     <xpath expr="(//i)[2]" position="attributes">

--- a/theme_buzzy/views/snippets/s_product_catalog.xml
+++ b/theme_buzzy/views/snippets/s_product_catalog.xml
@@ -5,15 +5,9 @@
     <!-- Section -->
     <xpath expr="//section" position="attributes">
         <attribute name="class" add="o_cc o_cc4 pb88 pt88" remove="pb32 pt48" separator=" "/>
+        <attribute name="data-oe-shape-data">{"shape":"web_editor/Airy/07","flip":[]}</attribute>
         <!-- Enable SVG dynamic color functionality -->
         <attribute name="style">background-image: url('/web_editor/shape/theme_buzzy/s_product_catalog.svg?c1=o-color-1'); background-position: 50% 0%;</attribute>
-    </xpath>
-</template>
-
-<template id="configurator_s_product_catalog" inherit_id="website.configurator_s_product_catalog">
-    <!-- Shape option -->
-    <xpath expr="//section" position="attributes">
-        <attribute name="data-oe-shape-data">{"shape":"web_editor/Airy/07","flip":[]}</attribute>
     </xpath>
     <!-- Shape -->
     <xpath expr="//section/*" position="before">

--- a/theme_buzzy/views/snippets/s_quotes_carousel.xml
+++ b/theme_buzzy/views/snippets/s_quotes_carousel.xml
@@ -5,6 +5,11 @@
     <!-- Carousel -->
     <xpath expr="//div[hasclass('s_quotes_carousel')]" position="attributes">
         <attribute name="class" add="s_carousel_rounded o_cc5" remove="s_carousel_default o_cc2" separator=" "/>
+        <attribute name="data-oe-shape-data">{"shape":"web_editor/Rainy/10","flip":[]}</attribute>
+    </xpath>
+    <!-- Shape -->
+    <xpath expr="//ol[hasclass('carousel-indicators')]" position="before">
+        <div class="o_we_shape o_web_editor_Rainy_10"/>
     </xpath>
     <!-- Icons quote -->
     <xpath expr="//i" position="attributes">
@@ -25,17 +30,6 @@
     </xpath>
     <xpath expr="(//div[hasclass('carousel-item')])[3]" position="attributes">
         <attribute name="style"/>
-    </xpath>
-</template>
-
-<template id="configurator_s_quotes_carousel" inherit_id="website.configurator_s_quotes_carousel">
-    <!-- Shape option -->
-    <xpath expr="//div[hasclass('s_quotes_carousel')]" position="attributes">
-        <attribute name="data-oe-shape-data">{"shape":"web_editor/Rainy/10","flip":[]}</attribute>
-    </xpath>
-    <!-- Shape -->
-    <xpath expr="//ol[hasclass('carousel-indicators')]" position="before">
-        <div class="o_we_shape o_web_editor_Rainy_10"/>
     </xpath>
 </template>
 

--- a/theme_clean/views/new_page_template.xml
+++ b/theme_clean/views/new_page_template.xml
@@ -59,28 +59,6 @@
     </xpath>
 </template>
 
-<template id="new_page_template_about_full_s_numbers" inherit_id="website.new_page_template_about_full_s_numbers">
-    <!-- Shape option -->
-    <xpath expr="//section" position="attributes">
-        <attribute name="data-oe-shape-data">{"shape":"web_editor/Airy/10","flip":[]}</attribute>
-    </xpath>
-    <!-- Shape -->
-    <xpath expr="//div[hasclass('container')]" position="before">
-        <div class="o_we_shape o_web_editor_Airy_10"/>
-    </xpath>
-</template>
-
-<template id="new_page_template_about_map_s_numbers" inherit_id="website.new_page_template_about_map_s_numbers">
-    <!-- Shape option -->
-    <xpath expr="//section" position="attributes">
-        <attribute name="data-oe-shape-data">{"shape":"web_editor/Airy/10","flip":[]}</attribute>
-    </xpath>
-    <!-- Shape -->
-    <xpath expr="//div[hasclass('container')]" position="before">
-        <div class="o_we_shape o_web_editor_Airy_10"/>
-    </xpath>
-</template>
-
 <template id="new_page_template_about_map_s_text_block_h1" inherit_id="website.new_page_template_about_map_s_text_block_h1">
     <xpath expr="//section" position="attributes">
         <attribute name="class" add="pb0" remove="pb40" separator=" "/>
@@ -90,7 +68,10 @@
 <template id="new_page_template_about_personal_s_numbers" inherit_id="website.new_page_template_about_personal_s_numbers">
     <xpath expr="//section" position="attributes">
         <attribute name="class" add="o_cc3" remove="o_cc4" separator=" "/>
+        <attribute name="data-oe-shape-data"/>
     </xpath>
+    <!-- Remove shape -->
+    <xpath expr="//div[hasclass('o_we_shape')]" position="replace"/>
 </template>
 
 <!-- Snippet customization Landing Pages -->

--- a/theme_clean/views/snippets/s_numbers.xml
+++ b/theme_clean/views/snippets/s_numbers.xml
@@ -5,12 +5,6 @@
     <!-- Section -->
     <xpath expr="//section" position="attributes">
         <attribute name="class" add="o_cc4 pt64" remove="o_cc2 pt24" separator=" "/>
-    </xpath>
-</template>
-
-<template id="configurator_s_numbers" inherit_id="website.configurator_s_numbers">
-    <!-- Shape option -->
-    <xpath expr="//section" position="attributes">
         <attribute name="data-oe-shape-data">{"shape":"web_editor/Airy/10","flip":[]}</attribute>
     </xpath>
     <!-- Shape -->

--- a/theme_graphene/views/customizations.xml
+++ b/theme_graphene/views/customizations.xml
@@ -278,6 +278,10 @@
 <template id="s_picture" inherit_id="website.s_picture" name="Graphene s_picture">
     <xpath expr="//section" position="attributes">
         <attribute name="class" add="pb0 pt48" remove="pb24 pt48" separator=" "/>
+        <attribute name="data-oe-shape-data">{"shape":"web_editor/Zigs/01_001","flip":[]}</attribute>
+    </xpath>
+    <xpath expr="//section/div[hasclass('container')]" position="before">
+        <div class="o_we_shape o_web_editor_Zigs_01_001"/>
     </xpath>
     <!-- Content -->
     <xpath expr="//h2" position="replace" mode="inner">
@@ -288,15 +292,6 @@
     </xpath>
     <xpath expr="//img" position="attributes">
         <attribute name="class" add="p-0 border-0" separator=" " />
-    </xpath>
-</template>
-
-<template id="configurator_s_picture" inherit_id="website.configurator_s_picture" name="Graphene s_picture">
-    <xpath expr="//section" position="attributes">
-        <attribute name="data-oe-shape-data">{"shape":"web_editor/Zigs/01_001","flip":[]}</attribute>
-    </xpath>
-    <xpath expr="//section/div[hasclass('container')]" position="before">
-        <div class="o_we_shape o_web_editor_Zigs_01_001"/>
     </xpath>
 </template>
 

--- a/theme_graphene/views/new_page_template.xml
+++ b/theme_graphene/views/new_page_template.xml
@@ -20,7 +20,25 @@
     </xpath>
 </template>
 
+<template id="new_page_template_s_picture_only" inherit_id="website.new_page_template_s_picture_only">
+    <!-- Remove shape option -->
+    <xpath expr="//section" position="attributes">
+        <attribute name="data-oe-shape-data"/>
+    </xpath>
+    <!-- Remove shape -->
+    <xpath expr="//div[hasclass('o_we_shape')]" position="replace"/>
+</template>
+
 <!-- Snippet customization Basic Pages -->
+
+<template id="new_page_template_basic_s_picture" inherit_id="website.new_page_template_basic_s_picture">
+    <!-- Remove shape option -->
+    <xpath expr="//section" position="attributes">
+        <attribute name="data-oe-shape-data"/>
+    </xpath>
+    <!-- Remove shape -->
+    <xpath expr="//div[hasclass('o_we_shape')]" position="replace"/>
+</template>
 
 <!-- Snippet customization About Pages -->
 
@@ -39,15 +57,6 @@
     </xpath>
     <xpath expr="//section/div[hasclass('container')]" position="before">
         <div class="o_we_shape o_web_editor_Origins_02_001"/>
-    </xpath>
-</template>
-
-<template id="new_page_template_about_s_picture" inherit_id="website.new_page_template_about_s_picture">
-    <xpath expr="//section" position="attributes">
-        <attribute name="data-oe-shape-data">{"shape":"web_editor/Zigs/01_001","flip":[]}</attribute>
-    </xpath>
-    <xpath expr="//section/div[hasclass('container')]" position="before">
-        <div class="o_we_shape o_web_editor_Zigs_01_001"/>
     </xpath>
 </template>
 
@@ -157,6 +166,15 @@
 </template>
 
 <!-- Snippet customization Team Pages -->
+
+<template id="new_page_template_team_s_picture" inherit_id="website.new_page_template_team_s_picture">
+    <!-- Remove shape option -->
+    <xpath expr="//section" position="attributes">
+        <attribute name="data-oe-shape-data"/>
+    </xpath>
+    <!-- Remove shape -->
+    <xpath expr="//div[hasclass('o_we_shape')]" position="replace"/>
+</template>
 
 <template id="new_page_template_team_s_text_block_h1" inherit_id="website.new_page_template_team_s_text_block_h1">
     <xpath expr="//section" position="attributes">

--- a/theme_kea/views/new_page_template.xml
+++ b/theme_kea/views/new_page_template.xml
@@ -26,6 +26,15 @@
     </xpath>
 </template>
 
+<template id="new_page_template_s_media_list" inherit_id="website.new_page_template_s_media_list">
+    <!-- Remove shape option -->
+    <xpath expr="//section" position="attributes">
+        <attribute name="data-oe-shape-data"/>
+    </xpath>
+    <!-- Remove shape -->
+    <xpath expr="//div[hasclass('o_we_shape')]" position="replace"/>
+</template>
+
 <template id="new_page_template_s_picture_only" inherit_id="website.new_page_template_s_picture_only">
     <!-- Shape option -->
     <xpath expr="//section" position="attributes">
@@ -71,14 +80,8 @@
 <!-- Snippet customization About Pages -->
 
 <template id="new_page_template_about_s_cover" inherit_id="website.new_page_template_about_s_cover">
-    <!-- Shape option -->
     <xpath expr="//section" position="attributes">
         <attribute name="class" add="o_half_screen_height" remove="o_full_screen_height" separator=" "/>
-        <attribute name="data-oe-shape-data">{"shape":"web_editor/Floats/02","flip":[]}</attribute>
-    </xpath>
-    <!-- Shape -->
-    <xpath expr="//div[hasclass('o_we_bg_filter')]" position="after">
-        <div class="o_we_shape o_web_editor_Floats_02"/>
     </xpath>
 </template>
 
@@ -163,26 +166,9 @@
     </xpath>
 </template>
 
-<template id="new_page_template_landing_0_s_cover" inherit_id="website.new_page_template_landing_0_s_cover">
-    <!-- Shape option -->
-    <xpath expr="//section" position="attributes">
-        <attribute name="data-oe-shape-data">{"shape":"web_editor/Floats/02","flip":[]}</attribute>
-    </xpath>
-    <!-- Shape -->
-    <xpath expr="//div[hasclass('o_we_bg_filter')]" position="after">
-        <div class="o_we_shape o_web_editor_Floats_02"/>
-    </xpath>
-</template>
-
 <template id="new_page_template_landing_2_s_cover" inherit_id="website.new_page_template_landing_2_s_cover">
-    <!-- Shape option -->
     <xpath expr="//section" position="attributes">
         <attribute name="class" add="o_half_screen_height" remove="o_full_screen_height" separator=" "/>
-        <attribute name="data-oe-shape-data">{"shape":"web_editor/Floats/02","flip":[]}</attribute>
-    </xpath>
-    <!-- Shape -->
-    <xpath expr="//div[hasclass('o_we_bg_filter')]" position="after">
-        <div class="o_we_shape o_web_editor_Floats_02"/>
     </xpath>
 </template>
 
@@ -198,28 +184,11 @@
     </xpath>
 </template>
 
-<template id="new_page_template_landing_4_s_cover" inherit_id="website.new_page_template_landing_4_s_cover">
-    <!-- Shape option -->
-    <xpath expr="//section" position="attributes">
-        <attribute name="data-oe-shape-data">{"shape":"web_editor/Floats/02","flip":[]}</attribute>
-    </xpath>
-    <!-- Shape -->
-    <xpath expr="//div[hasclass('o_we_bg_filter')]" position="after">
-        <div class="o_we_shape o_web_editor_Floats_02"/>
-    </xpath>
-</template>
-
 <!-- Snippet customization Gallery Pages -->
 
 <template id="new_page_template_gallery_s_cover" inherit_id="website.new_page_template_gallery_s_cover">
-    <!-- Shape option -->
     <xpath expr="//section" position="attributes">
         <attribute name="class" add="o_half_screen_height" remove="o_full_screen_height" separator=" "/>
-        <attribute name="data-oe-shape-data">{"shape":"web_editor/Floats/02","flip":[]}</attribute>
-    </xpath>
-    <!-- Shape -->
-    <xpath expr="//div[hasclass('o_we_bg_filter')]" position="after">
-        <div class="o_we_shape o_web_editor_Floats_02"/>
     </xpath>
 </template>
 
@@ -228,14 +197,8 @@
 <!-- Snippet customization Pricing Pages -->
 
 <template id="new_page_template_pricing_s_cover" inherit_id="website.new_page_template_pricing_s_cover">
-    <!-- Shape option -->
     <xpath expr="//section" position="attributes">
         <attribute name="class" add="o_half_screen_height" remove="o_full_screen_height" separator=" "/>
-        <attribute name="data-oe-shape-data">{"shape":"web_editor/Floats/02","flip":[]}</attribute>
-    </xpath>
-    <!-- Shape -->
-    <xpath expr="//div[hasclass('o_we_bg_filter')]" position="after">
-        <div class="o_we_shape o_web_editor_Floats_02"/>
     </xpath>
 </template>
 

--- a/theme_kea/views/snippets/s_cover.xml
+++ b/theme_kea/views/snippets/s_cover.xml
@@ -6,7 +6,12 @@
     <xpath expr="//section" position="attributes">
         <attribute name="class" add="oe_img_bg o_full_screen_height" remove="parallax s_parallax_is_fixed" separator=" "/>
         <attribute name="data-scroll-background-ratio">0</attribute>
+        <attribute name="data-oe-shape-data">{"shape":"web_editor/Floats/02","flip":[]}</attribute>
         <attribute name="style">background-image: url('/web/image/website.s_cover_default_image'); background-position: 50% 0;</attribute>
+    </xpath>
+    <!-- Shape -->
+    <xpath expr="//div[hasclass('o_we_bg_filter')]" position="after">
+        <div class="o_we_shape o_web_editor_Floats_02"/>
     </xpath>
     <!-- Disable Parallax -->
     <xpath expr="//span[hasclass('s_parallax_bg')]" position="replace"/>
@@ -21,17 +26,6 @@
     <!-- Button -->
     <xpath expr="//a[hasclass('btn')]" position="replace">
         <a href="#0" class="btn btn-lg btn-primary">Discover more</a>
-    </xpath>
-</template>
-
-<template id="configurator_s_cover" inherit_id="website.configurator_s_cover">
-    <!-- Shape option -->
-    <xpath expr="//section" position="attributes">
-        <attribute name="data-oe-shape-data">{"shape":"web_editor/Floats/02","flip":[]}</attribute>
-    </xpath>
-    <!-- Shape -->
-    <xpath expr="//div[hasclass('o_we_bg_filter')]" position="after">
-        <div class="o_we_shape o_web_editor_Floats_02"/>
     </xpath>
 </template>
 

--- a/theme_kea/views/snippets/s_media_list.xml
+++ b/theme_kea/views/snippets/s_media_list.xml
@@ -5,6 +5,11 @@
     <!-- Section -->
     <xpath expr="//section" position="attributes">
         <attribute name="class" add="o_cc2 pt64 pb64" remove="o_cc1 pt32 pb32" separator=" "/>
+        <attribute name="data-oe-shape-data">{"shape":"web_editor/Floats/01","flip":[]}</attribute>
+    </xpath>
+    <!-- Shape -->
+    <xpath expr="//div[hasclass('container')]" position="before">
+        <div class="o_we_shape o_web_editor_Floats_01"/>
     </xpath>
     <!-- Row 1 -->
     <xpath expr="(//div[hasclass('row')])[2]" position="attributes">
@@ -77,17 +82,6 @@
     </xpath>
     <xpath expr="(//p)[3]" position="replace" mode="inner">
         Use this snippet to build various types of components that feature a left- or right-aligned image alongside textual content. Duplicate the element to create a list that fits your needs.
-    </xpath>
-</template>
-
-<template id="configurator_s_media_list" inherit_id="website.configurator_s_media_list">
-    <!-- Shape option -->
-    <xpath expr="//section" position="attributes">
-        <attribute name="data-oe-shape-data">{"shape":"web_editor/Floats/01","flip":[]}</attribute>
-    </xpath>
-    <!-- Shape -->
-    <xpath expr="//div[hasclass('container')]" position="before">
-        <div class="o_we_shape o_web_editor_Floats_01"/>
     </xpath>
 </template>
 

--- a/theme_kiddo/views/new_page_template.xml
+++ b/theme_kiddo/views/new_page_template.xml
@@ -11,50 +11,6 @@
 
 <!-- General customizations -->
 
-<template id="new_page_template_s_call_to_action" inherit_id="website.new_page_template_s_call_to_action">
-    <!-- Section -->
-    <xpath expr="//section" position="attributes">
-        <attribute name="data-oe-shape-data">{"shape":"web_editor/Floats/14"}</attribute>
-    </xpath>
-    <!-- Shape -->
-    <xpath expr="//div[hasclass('container')]" position="before">
-        <div class="o_we_shape o_web_editor_Floats_14"/>
-    </xpath>
-</template>
-
-<template id="new_page_template_s_call_to_action_about" inherit_id="website.new_page_template_s_call_to_action_about">
-    <!-- Section -->
-    <xpath expr="//section" position="attributes">
-        <attribute name="data-oe-shape-data">{"shape":"web_editor/Floats/14"}</attribute>
-    </xpath>
-    <!-- Shape -->
-    <xpath expr="//div[hasclass('container')]" position="before">
-        <div class="o_we_shape o_web_editor_Floats_14"/>
-    </xpath>
-</template>
-
-<template id="new_page_template_s_call_to_action_digital" inherit_id="website.new_page_template_s_call_to_action_digital">
-    <!-- Section -->
-    <xpath expr="//section" position="attributes">
-        <attribute name="data-oe-shape-data">{"shape":"web_editor/Floats/14"}</attribute>
-    </xpath>
-    <!-- Shape -->
-    <xpath expr="//div[hasclass('container')]" position="before">
-        <div class="o_we_shape o_web_editor_Floats_14"/>
-    </xpath>
-</template>
-
-<template id="new_page_template_s_call_to_action_menu" inherit_id="website.new_page_template_s_call_to_action_menu">
-    <!-- Section -->
-    <xpath expr="//section" position="attributes">
-        <attribute name="data-oe-shape-data">{"shape":"web_editor/Floats/14"}</attribute>
-    </xpath>
-    <!-- Shape -->
-    <xpath expr="//div[hasclass('container')]" position="before">
-        <div class="o_we_shape o_web_editor_Floats_14"/>
-    </xpath>
-</template>
-
 <template id="new_page_template_s_picture_only" inherit_id="website.new_page_template_s_picture_only">
     <!-- Section -->
     <xpath expr="//section" position="attributes">
@@ -68,6 +24,15 @@
 
 <!-- Snippet customization Basic Pages -->
 
+<template id="new_page_template_basic_s_image_text" inherit_id="website.new_page_template_basic_s_image_text">
+    <!-- Remove shape option -->
+    <xpath expr="//section" position="attributes">
+        <attribute name="data-oe-shape-data"/>
+    </xpath>
+    <!-- Remove shape -->
+    <xpath expr="//div[hasclass('o_we_shape')]" position="replace"/>
+</template>
+
 <template id="new_page_template_basic_s_picture" inherit_id="website.new_page_template_basic_s_picture">
     <!-- Section -->
     <xpath expr="//section" position="attributes">
@@ -77,6 +42,15 @@
     <xpath expr="//div[hasclass('container')]" position="before">
         <div class="o_we_shape o_web_editor_Origins_16" style="background-image: url('/web_editor/shape/web_editor/Origins/16.svg?c3=o-color-2&amp;flip=x'); background-position: 50% 50%;"/>
     </xpath>
+</template>
+
+<template id="new_page_template_basic_s_text_image" inherit_id="website.new_page_template_basic_s_text_image">
+    <!-- Remove shape option -->
+    <xpath expr="//section" position="attributes">
+        <attribute name="data-oe-shape-data"/>
+    </xpath>
+    <!-- Remove shape -->
+    <xpath expr="//div[hasclass('o_we_shape')]" position="replace"/>
 </template>
 
 <template id="new_page_template_basic_2_s_text_block_h1" inherit_id="website.new_page_template_basic_2_s_text_block_h1">
@@ -99,14 +73,8 @@
 </template>
 
 <template id="new_page_template_about_s_cover" inherit_id="website.new_page_template_about_s_cover">
-    <!-- Section -->
     <xpath expr="//section" position="attributes">
         <attribute name="class" add="o_half_screen_height" remove="o_full_screen_height" separator=" "/>
-        <attribute name="data-oe-shape-data">{"shape":"web_editor/Floats/14"}</attribute>
-    </xpath>
-    <!-- Shape -->
-    <xpath expr="//div[hasclass('container')]" position="before">
-        <div class="o_we_shape o_web_editor_Floats_14"/>
     </xpath>
 </template>
 
@@ -138,31 +106,9 @@
     </xpath>
 </template>
 
-<template id="new_page_template_about_full_s_image_text" inherit_id="website.new_page_template_about_full_s_image_text">
-    <!-- Shape option -->
-    <xpath expr="//section" position="attributes">
-        <attribute name="data-oe-shape-data">{"shape":"web_editor/Floats/13","flip":["x"]}</attribute>
-    </xpath>
-    <!-- Shape -->
-    <xpath expr="//div[hasclass('container')]" position="before">
-        <div class="o_we_shape o_web_editor_Floats_13" style="background-image: url('/web_editor/shape/web_editor/Floats/13.svg?c1=o-color-1&amp;c2=o-color-2&amp;c5=o-color-5&amp;flip=x'); background-position: 50% 50%;"/>
-    </xpath>
-</template>
-
 <template id="new_page_template_about_full_s_numbers" inherit_id="website.new_page_template_about_full_s_numbers">
     <xpath expr="//section" position="attributes">
         <attribute name="class" add="o_cc2" remove="o_cc3" separator=" "/>
-    </xpath>
-</template>
-
-<template id="new_page_template_about_full_s_text_image" inherit_id="website.new_page_template_about_full_s_text_image">
-    <!-- Shape option -->
-    <xpath expr="//section" position="attributes">
-        <attribute name="data-oe-shape-data">{"shape":"web_editor/Floats/13","flip":["y"]}</attribute>
-    </xpath>
-    <!-- Shape -->
-    <xpath expr="//div[hasclass('container')]" position="before">
-        <div class="o_we_shape o_web_editor_Floats_13" style="background-image: url('/web_editor/shape/web_editor/Floats/13.svg?c1=o-color-1&amp;c2=o-color-2&amp;c5=o-color-5&amp;flip=y'); background-position: 50% 50%;"/>
     </xpath>
 </template>
 
@@ -172,15 +118,13 @@
     </xpath>
 </template>
 
-<template id="new_page_template_about_personal_s_image_text" inherit_id="website.new_page_template_about_personal_s_image_text">
-    <!-- Shape option -->
+<template id="new_page_template_about_map_s_text_image" inherit_id="website.new_page_template_about_map_s_text_image">
+    <!-- Remove shape option -->
     <xpath expr="//section" position="attributes">
-        <attribute name="data-oe-shape-data">{"shape":"web_editor/Floats/13","flip":["x"]}</attribute>
+        <attribute name="data-oe-shape-data"/>
     </xpath>
-    <!-- Shape -->
-    <xpath expr="//div[hasclass('container')]" position="before">
-        <div class="o_we_shape o_web_editor_Floats_13" style="background-image: url('/web_editor/shape/web_editor/Floats/13.svg?c1=o-color-1&amp;c2=o-color-2&amp;c5=o-color-5&amp;flip=x'); background-position: 50% 50%;"/>
-    </xpath>
+    <!-- Remove shape -->
+    <xpath expr="//div[hasclass('o_we_shape')]" position="replace"/>
 </template>
 
 <!-- Snippet customization Landing Pages -->
@@ -188,28 +132,6 @@
 <template id="new_page_template_landing_s_features" inherit_id="website.new_page_template_landing_s_features">
     <xpath expr="//section" position="attributes">
         <attribute name="class" add="o_cc2" separator=" "/>
-    </xpath>
-</template>
-
-<template id="new_page_template_landing_s_text_image" inherit_id="website.new_page_template_landing_s_text_image">
-    <!-- Shape option -->
-    <xpath expr="//section" position="attributes">
-        <attribute name="data-oe-shape-data">{"shape":"web_editor/Floats/13","flip":["y"]}</attribute>
-    </xpath>
-    <!-- Shape -->
-    <xpath expr="//div[hasclass('container')]" position="before">
-        <div class="o_we_shape o_web_editor_Floats_13" style="background-image: url('/web_editor/shape/web_editor/Floats/13.svg?c1=o-color-1&amp;c2=o-color-2&amp;c5=o-color-5&amp;flip=y'); background-position: 50% 50%;"/>
-    </xpath>
-</template>
-
-<template id="new_page_template_landing_0_s_cover" inherit_id="website.new_page_template_landing_0_s_cover">
-    <!-- Section -->
-    <xpath expr="//section" position="attributes">
-        <attribute name="data-oe-shape-data">{"shape":"web_editor/Floats/14"}</attribute>
-    </xpath>
-    <!-- Shape -->
-    <xpath expr="//div[hasclass('container')]" position="before">
-        <div class="o_we_shape o_web_editor_Floats_14"/>
     </xpath>
 </template>
 
@@ -228,11 +150,6 @@
     <!-- Section -->
     <xpath expr="//section" position="attributes">
         <attribute name="class" add="o_half_screen_height" remove="o_full_screen_height" separator=" "/>
-        <attribute name="data-oe-shape-data">{"shape":"web_editor/Floats/14"}</attribute>
-    </xpath>
-    <!-- Shape -->
-    <xpath expr="//div[hasclass('container')]" position="before">
-        <div class="o_we_shape o_web_editor_Floats_14"/>
     </xpath>
 </template>
 
@@ -264,6 +181,15 @@
     </xpath>
 </template>
 
+<template id="new_page_template_landing_4_s_cover" inherit_id="website.new_page_template_landing_4_s_cover">
+    <!-- Remove shape option -->
+    <xpath expr="//section" position="attributes">
+        <attribute name="data-oe-shape-data"/>
+    </xpath>
+    <!-- Remove shape -->
+    <xpath expr="//div[hasclass('o_we_shape')]" position="replace"/>
+</template>
+
 <!-- Snippet customization Gallery Pages -->
 
 <template id="new_page_template_gallery_s_banner" inherit_id="website.new_page_template_gallery_s_banner">
@@ -281,48 +207,37 @@
     <!-- Section -->
     <xpath expr="//section" position="attributes">
         <attribute name="class" add="o_half_screen_height" remove="o_full_screen_height" separator=" "/>
-        <attribute name="data-oe-shape-data">{"shape":"web_editor/Floats/14"}</attribute>
     </xpath>
-    <!-- Shape -->
-    <xpath expr="//div[hasclass('container')]" position="before">
-        <div class="o_we_shape o_web_editor_Floats_14"/>
+</template>
+
+<template id="new_page_template_gallery_s_image_text" inherit_id="website.new_page_template_gallery_s_image_text">
+    <!-- Remove shape option -->
+    <xpath expr="//section" position="attributes">
+        <attribute name="data-oe-shape-data"/>
     </xpath>
+    <!-- Remove shape -->
+    <xpath expr="//div[hasclass('o_we_shape')]" position="replace"/>
+</template>
+
+<template id="new_page_template_gallery_s_image_text_2nd" inherit_id="website.new_page_template_gallery_s_image_text_2nd">
+    <!-- Remove shape option -->
+    <xpath expr="//section" position="attributes">
+        <attribute name="data-oe-shape-data"/>
+    </xpath>
+    <!-- Remove shape -->
+    <xpath expr="//div[hasclass('o_we_shape')]" position="replace"/>
+</template>
+
+<template id="new_page_template_gallery_s_text_image" inherit_id="website.new_page_template_gallery_s_text_image">
+    <!-- Remove shape option -->
+    <xpath expr="//section" position="attributes">
+        <attribute name="data-oe-shape-data"/>
+    </xpath>
+    <!-- Remove shape -->
+    <xpath expr="//div[hasclass('o_we_shape')]" position="replace"/>
 </template>
 
 <!-- Snippet customization Services Pages -->
-
-<template id="new_page_template_services_s_image_text" inherit_id="website.new_page_template_services_s_image_text">
-    <!-- Shape option -->
-    <xpath expr="//section" position="attributes">
-        <attribute name="data-oe-shape-data">{"shape":"web_editor/Floats/13","flip":["x"]}</attribute>
-    </xpath>
-    <!-- Shape -->
-    <xpath expr="//div[hasclass('container')]" position="before">
-        <div class="o_we_shape o_web_editor_Floats_13" style="background-image: url('/web_editor/shape/web_editor/Floats/13.svg?c1=o-color-1&amp;c2=o-color-2&amp;c5=o-color-5&amp;flip=x'); background-position: 50% 50%;"/>
-    </xpath>
-</template>
-
-<template id="new_page_template_services_s_image_text_2nd" inherit_id="website.new_page_template_services_s_image_text_2nd">
-    <!-- Shape option -->
-    <xpath expr="//section" position="attributes">
-        <attribute name="data-oe-shape-data">{"shape":"web_editor/Floats/13","flip":["x"]}</attribute>
-    </xpath>
-    <!-- Shape -->
-    <xpath expr="//div[hasclass('container')]" position="before">
-        <div class="o_we_shape o_web_editor_Floats_13" style="background-image: url('/web_editor/shape/web_editor/Floats/13.svg?c1=o-color-1&amp;c2=o-color-2&amp;c5=o-color-5&amp;flip=x'); background-position: 50% 50%;"/>
-    </xpath>
-</template>
-
-<template id="new_page_template_services_s_text_image" inherit_id="website.new_page_template_services_s_text_image">
-    <!-- Shape option -->
-    <xpath expr="//section" position="attributes">
-        <attribute name="data-oe-shape-data">{"shape":"web_editor/Floats/13","flip":["y"]}</attribute>
-    </xpath>
-    <!-- Shape -->
-    <xpath expr="//div[hasclass('container')]" position="before">
-        <div class="o_we_shape o_web_editor_Floats_13" style="background-image: url('/web_editor/shape/web_editor/Floats/13.svg?c1=o-color-1&amp;c2=o-color-2&amp;c5=o-color-5&amp;flip=y'); background-position: 50% 50%;"/>
-    </xpath>
-</template>
 
 <!-- Snippet customization Pricing Pages -->
 
@@ -330,12 +245,34 @@
     <!-- Section -->
     <xpath expr="//section" position="attributes">
         <attribute name="class" add="o_half_screen_height" remove="o_full_screen_height" separator=" "/>
-        <attribute name="data-oe-shape-data">{"shape":"web_editor/Floats/14"}</attribute>
     </xpath>
-    <!-- Shape -->
-    <xpath expr="//div[hasclass('container')]" position="before">
-        <div class="o_we_shape o_web_editor_Floats_14"/>
+</template>
+
+<template id="new_page_template_pricing_s_image_text" inherit_id="website.new_page_template_pricing_s_image_text">
+    <!-- Remove shape option -->
+    <xpath expr="//section" position="attributes">
+        <attribute name="data-oe-shape-data"/>
     </xpath>
+    <!-- Remove shape -->
+    <xpath expr="//div[hasclass('o_we_shape')]" position="replace"/>
+</template>
+
+<template id="new_page_template_pricing_s_image_text_2nd" inherit_id="website.new_page_template_pricing_s_image_text_2nd">
+    <!-- Remove shape option -->
+    <xpath expr="//section" position="attributes">
+        <attribute name="data-oe-shape-data"/>
+    </xpath>
+    <!-- Remove shape -->
+    <xpath expr="//div[hasclass('o_we_shape')]" position="replace"/>
+</template>
+
+<template id="new_page_template_pricing_s_text_image" inherit_id="website.new_page_template_pricing_s_text_image">
+    <!-- Remove shape option -->
+    <xpath expr="//section" position="attributes">
+        <attribute name="data-oe-shape-data"/>
+    </xpath>
+    <!-- Remove shape -->
+    <xpath expr="//div[hasclass('o_we_shape')]" position="replace"/>
 </template>
 
 <!-- Snippet customization Team Pages -->
@@ -343,13 +280,19 @@
 <template id="new_page_template_team_s_image_text" inherit_id="website.new_page_template_team_s_image_text">
     <xpath expr="//section" position="attributes">
         <attribute name="class" add="pt32" remove="pt232" separator=" "/>
+        <attribute name="data-oe-shape-data"/>
     </xpath>
+    <!-- Remove shape -->
+    <xpath expr="//div[hasclass('o_we_shape')]" position="replace"/>
 </template>
 
 <template id="new_page_template_team_s_image_text_2nd" inherit_id="website.new_page_template_team_s_image_text_2nd">
     <xpath expr="//section" position="attributes">
         <attribute name="class" add="pt32" remove="pt232" separator=" "/>
+        <attribute name="data-oe-shape-data"/>
     </xpath>
+    <!-- Remove shape -->
+    <xpath expr="//div[hasclass('o_we_shape')]" position="replace"/>
 </template>
 
 <template id="new_page_template_team_s_text_block_h1" inherit_id="website.new_page_template_team_s_text_block_h1">
@@ -361,7 +304,10 @@
 <template id="new_page_template_team_s_text_image" inherit_id="website.new_page_template_team_s_text_image">
     <xpath expr="//section" position="attributes">
         <attribute name="class" add="pb32" remove="pb232" separator=" "/>
+        <attribute name="data-oe-shape-data"/>
     </xpath>
+    <!-- Remove shape -->
+    <xpath expr="//div[hasclass('o_we_shape')]" position="replace"/>
 </template>
 
 <template id="new_page_template_team_0_s_three_columns" inherit_id="website.new_page_template_team_0_s_three_columns">

--- a/theme_kiddo/views/snippets/s_call_to_action.xml
+++ b/theme_kiddo/views/snippets/s_call_to_action.xml
@@ -5,6 +5,12 @@
     <!-- Section -->
     <xpath expr="//section" position="attributes">
         <attribute name="class" add="o_cc2 pt152 pb152 o_colored_level" remove="pt48 pb24 o_cc3" separator=" "/>
+        <attribute name="data-oe-shape-data">{"shape":"web_editor/Floats/14"}</attribute>
+    </xpath>
+
+    <!-- Shape -->
+    <xpath expr="//div[hasclass('container')]" position="before">
+        <div class="o_we_shape o_web_editor_Floats_14"/>
     </xpath>
 
     <!-- Paragraph -->
@@ -19,18 +25,6 @@
 
     <!-- Remove last column with button -->
     <xpath expr="//div[hasclass('col-lg-3')]" position="replace"/>
-</template>
-
-<template id="configurator_s_call_to_action" inherit_id="website.configurator_s_call_to_action">
-    <!-- Section -->
-    <xpath expr="//section" position="attributes">
-        <attribute name="data-oe-shape-data">{"shape":"web_editor/Floats/14"}</attribute>
-    </xpath>
-
-    <!-- Shape -->
-    <xpath expr="//div[hasclass('container')]" position="before">
-        <div class="o_we_shape o_web_editor_Floats_14"/>
-    </xpath>
 </template>
 
 </odoo>

--- a/theme_kiddo/views/snippets/s_cover.xml
+++ b/theme_kiddo/views/snippets/s_cover.xml
@@ -5,11 +5,17 @@
     <!-- Section -->
     <xpath expr="//section" position="attributes">
         <attribute name="class" add="o_full_screen_height o_cc o_cc1" remove="bg-black-50" separator=" "/>
+        <attribute name="data-oe-shape-data">{"shape":"web_editor/Floats/14"}</attribute>
     </xpath>
 
     <!-- Filter -->
     <xpath expr="//div[hasclass('o_we_bg_filter')]" position="attributes">
         <attribute name="class" add="bg-white-75" remove="bg-black-50" separator=" "/>
+    </xpath>
+
+    <!-- Shape -->
+    <xpath expr="//div[hasclass('container')]" position="before">
+        <div class="o_we_shape o_web_editor_Floats_14"/>
     </xpath>
 
     <!-- Heading -->
@@ -40,18 +46,6 @@
     <!-- Button -->
     <xpath expr="//a[hasclass('btn')]" position="attributes">
         <attribute name="class" add="btn-lg" separator=" "/>
-    </xpath>
-</template>
-
-<template id="configurator_s_cover" inherit_id="website.configurator_s_cover">
-    <!-- Section -->
-    <xpath expr="//section" position="attributes">
-        <attribute name="data-oe-shape-data">{"shape":"web_editor/Floats/14"}</attribute>
-    </xpath>
-
-    <!-- Shape -->
-    <xpath expr="//div[hasclass('container')]" position="before">
-        <div class="o_we_shape o_web_editor_Floats_14"/>
     </xpath>
 </template>
 

--- a/theme_kiddo/views/snippets/s_image_text.xml
+++ b/theme_kiddo/views/snippets/s_image_text.xml
@@ -5,6 +5,12 @@
     <!-- Section -->
     <xpath expr="//section" position="attributes">
         <attribute name="class" add="o_cc o_cc2 pb64 pt64" remove="pb32 pt32" separator=" "/>
+        <attribute name="data-oe-shape-data">{"shape":"web_editor/Floats/13","flip":["x"]}</attribute>
+    </xpath>
+
+    <!-- Shape -->
+    <xpath expr="//div[hasclass('container')]" position="before">
+        <div class="o_we_shape o_web_editor_Floats_13" style="background-image: url('/web_editor/shape/web_editor/Floats/13.svg?c1=o-color-1&amp;c2=o-color-2&amp;c5=o-color-5&amp;flip=x'); background-position: 50% 50%;"/>
     </xpath>
 
     <!-- Last column -->
@@ -38,18 +44,6 @@
         <attribute name="data-original-mimetype">image/jpeg</attribute>
         <attribute name="data-file-name">s_image_text.svg</attribute>
         <attribute name="data-shape-colors">;;;;</attribute>
-    </xpath>
-</template>
-
-<template id="configurator_s_image_text" inherit_id="website.configurator_s_image_text">
-    <!-- Shape option -->
-    <xpath expr="//section" position="attributes">
-        <attribute name="data-oe-shape-data">{"shape":"web_editor/Floats/13","flip":["x"]}</attribute>
-    </xpath>
-
-    <!-- Shape -->
-    <xpath expr="//div[hasclass('container')]" position="before">
-        <div class="o_we_shape o_web_editor_Floats_13" style="background-image: url('/web_editor/shape/web_editor/Floats/13.svg?c1=o-color-1&amp;c2=o-color-2&amp;c5=o-color-5&amp;flip=x'); background-position: 50% 50%;"/>
     </xpath>
 </template>
 

--- a/theme_kiddo/views/snippets/s_text_image.xml
+++ b/theme_kiddo/views/snippets/s_text_image.xml
@@ -5,6 +5,12 @@
     <!-- Section -->
     <xpath expr="//section" position="attributes">
         <attribute name="class" add="pb64 pt64" remove="pb32 pt32" separator=" "/>
+        <attribute name="data-oe-shape-data">{"shape":"web_editor/Floats/13","flip":["y"]}</attribute>
+    </xpath>
+
+    <!-- Shape -->
+    <xpath expr="//div[hasclass('container')]" position="before">
+        <div class="o_we_shape o_web_editor_Floats_13" style="background-image: url('/web_editor/shape/web_editor/Floats/13.svg?c1=o-color-1&amp;c2=o-color-2&amp;c5=o-color-5&amp;flip=y'); background-position: 50% 50%;"/>
     </xpath>
 
     <!-- First column -->
@@ -26,18 +32,6 @@
         <attribute name="data-original-mimetype">image/jpeg</attribute>
         <attribute name="data-file-name">content_img_13.svg</attribute>
         <attribute name="data-shape-colors">;;;;</attribute>
-    </xpath>
-</template>
-
-<template id="configurator_s_text_image" inherit_id="website.configurator_s_text_image">
-    <!-- Shape option -->
-    <xpath expr="//section" position="attributes">
-        <attribute name="data-oe-shape-data">{"shape":"web_editor/Floats/13","flip":["y"]}</attribute>
-    </xpath>
-
-    <!-- Shape -->
-    <xpath expr="//div[hasclass('container')]" position="before">
-        <div class="o_we_shape o_web_editor_Floats_13" style="background-image: url('/web_editor/shape/web_editor/Floats/13.svg?c1=o-color-1&amp;c2=o-color-2&amp;c5=o-color-5&amp;flip=y'); background-position: 50% 50%;"/>
     </xpath>
 </template>
 

--- a/theme_loftspace/views/new_page_template.xml
+++ b/theme_loftspace/views/new_page_template.xml
@@ -55,18 +55,34 @@
     </xpath>
 </template>
 
-<template id="new_page_template_s_numbers" inherit_id="website.new_page_template_s_numbers">
-    <!-- Shape option -->
+<template id="new_page_template_s_product_catalog" inherit_id="website.new_page_template_s_product_catalog">
+    <!-- Remove shape option -->
     <xpath expr="//section" position="attributes">
-        <attribute name="data-oe-shape-data">{"shape":"web_editor/Airy/03_001","flip":["y"]}</attribute>
+        <attribute name="data-oe-shape-data"/>
     </xpath>
-    <!-- Shape -->
-    <xpath expr="//div[hasclass('container')]" position="before">
-        <div class="o_we_shape o_web_editor_Airy_03_001" style="background-image: url('/web_editor/shape/web_editor/Airy/03_001.svg?c5=o-color-1&amp;flip=y'); background-position: 50% 100%;"/>
-    </xpath>
+    <!-- Remove shape -->
+    <xpath expr="//div[hasclass('o_we_shape')]" position="replace"/>
 </template>
 
 <!-- Snippet customization Basic Pages -->
+
+<template id="new_page_template_basic_s_image_text" inherit_id="website.new_page_template_basic_s_image_text">
+    <!-- Remove shape option -->
+    <xpath expr="//section" position="attributes">
+        <attribute name="data-oe-shape-data"/>
+    </xpath>
+    <!-- Remove shape -->
+    <xpath expr="//div[hasclass('o_we_shape')]" position="replace"/>
+</template>
+
+<template id="new_page_template_basic_s_text_image" inherit_id="website.new_page_template_basic_s_text_image">
+    <!-- Remove shape option -->
+    <xpath expr="//section" position="attributes">
+        <attribute name="data-oe-shape-data"/>
+    </xpath>
+    <!-- Remove shape -->
+    <xpath expr="//div[hasclass('o_we_shape')]" position="replace"/>
+</template>
 
 <!-- Snippet customization About Pages -->
 
@@ -88,32 +104,19 @@
     </xpath>
 </template>
 
-<template id="new_page_template_about_s_image_text" inherit_id="website.new_page_template_about_s_image_text">
-    <!-- Shape option -->
-    <xpath expr="//section" position="attributes">
-        <attribute name="data-oe-shape-data">{"shape":"web_editor/Airy/10","flip":["x"]}</attribute>
-    </xpath>
-    <!-- Shape -->
-    <xpath expr="//div[hasclass('container')]" position="before">
-        <div class="o_we_shape o_web_editor_Airy_10" style="background-image: url('/web_editor/shape/web_editor/Airy/10.svg?c5=o-color-1&amp;flip=x'); background-position: 50% 100%;"/>
-    </xpath>
-</template>
-
 <template id="new_page_template_about_full_1_s_text_block_h1" inherit_id="website.new_page_template_about_full_1_s_text_block_h1">
     <xpath expr="//section" position="attributes">
         <attribute name="class" add="o_cc2" separator=" "/>
     </xpath>
 </template>
 
-<template id="new_page_template_about_full_s_text_image" inherit_id="website.new_page_template_about_full_s_text_image">
-    <!-- Shape option -->
+<template id="new_page_template_about_map_s_text_image" inherit_id="website.new_page_template_about_map_s_text_image">
+    <!-- Remove shape option -->
     <xpath expr="//section" position="attributes">
-        <attribute name="data-oe-shape-data">{"shape":"web_editor/Airy/10","flip":[]}</attribute>
+        <attribute name="data-oe-shape-data"/>
     </xpath>
-    <!-- Shape -->
-    <xpath expr="//div[hasclass('container')]" position="before">
-        <div class="o_we_shape o_web_editor_Airy_10"/>
-    </xpath>
+    <!-- Remove shape -->
+    <xpath expr="//div[hasclass('o_we_shape')]" position="replace"/>
 </template>
 
 <template id="new_page_template_about_personal_s_text_block_h2" inherit_id="website.new_page_template_about_personal_s_text_block_h2">
@@ -123,17 +126,6 @@
 </template>
 
 <!-- Snippet customization Landing Pages -->
-
-<template id="new_page_template_landing_s_text_image" inherit_id="website.new_page_template_landing_s_text_image">
-    <!-- Shape option -->
-    <xpath expr="//section" position="attributes">
-        <attribute name="data-oe-shape-data">{"shape":"web_editor/Airy/10","flip":[]}</attribute>
-    </xpath>
-    <!-- Shape -->
-    <xpath expr="//div[hasclass('container')]" position="before">
-        <div class="o_we_shape o_web_editor_Airy_10"/>
-    </xpath>
-</template>
 
 <template id="new_page_template_landing_1_s_banner" inherit_id="website.new_page_template_landing_1_s_banner">
     <!-- Shape option -->
@@ -173,40 +165,34 @@
     </xpath>
 </template>
 
+<template id="new_page_template_gallery_s_image_text" inherit_id="website.new_page_template_gallery_s_image_text">
+    <!-- Remove shape option -->
+    <xpath expr="//section" position="attributes">
+        <attribute name="data-oe-shape-data"/>
+    </xpath>
+    <!-- Remove shape -->
+    <xpath expr="//div[hasclass('o_we_shape')]" position="replace"/>
+</template>
+
+<template id="new_page_template_gallery_s_image_text_2nd" inherit_id="website.new_page_template_gallery_s_image_text_2nd">
+    <!-- Remove shape option -->
+    <xpath expr="//section" position="attributes">
+        <attribute name="data-oe-shape-data"/>
+    </xpath>
+    <!-- Remove shape -->
+    <xpath expr="//div[hasclass('o_we_shape')]" position="replace"/>
+</template>
+
+<template id="new_page_template_gallery_s_text_image" inherit_id="website.new_page_template_gallery_s_text_image">
+    <!-- Remove shape option -->
+    <xpath expr="//section" position="attributes">
+        <attribute name="data-oe-shape-data"/>
+    </xpath>
+    <!-- Remove shape -->
+    <xpath expr="//div[hasclass('o_we_shape')]" position="replace"/>
+</template>
+
 <!-- Snippet customization Services Pages -->
-
-<template id="new_page_template_services_s_image_text" inherit_id="website.new_page_template_services_s_image_text">
-    <!-- Shape option -->
-    <xpath expr="//section" position="attributes">
-        <attribute name="data-oe-shape-data">{"shape":"web_editor/Airy/10","flip":["x"]}</attribute>
-    </xpath>
-    <!-- Shape -->
-    <xpath expr="//div[hasclass('container')]" position="before">
-        <div class="o_we_shape o_web_editor_Airy_10" style="background-image: url('/web_editor/shape/web_editor/Airy/10.svg?c5=o-color-1&amp;flip=x'); background-position: 50% 100%;"/>
-    </xpath>
-</template>
-
-<template id="new_page_template_services_s_image_text_2nd" inherit_id="website.new_page_template_services_s_image_text_2nd">
-    <!-- Shape option -->
-    <xpath expr="//section" position="attributes">
-        <attribute name="data-oe-shape-data">{"shape":"web_editor/Airy/10","flip":["x"]}</attribute>
-    </xpath>
-    <!-- Shape -->
-    <xpath expr="//div[hasclass('container')]" position="before">
-        <div class="o_we_shape o_web_editor_Airy_10" style="background-image: url('/web_editor/shape/web_editor/Airy/10.svg?c5=o-color-1&amp;flip=x'); background-position: 50% 100%;"/>
-    </xpath>
-</template>
-
-<template id="new_page_template_services_s_text_image" inherit_id="website.new_page_template_services_s_text_image">
-    <!-- Shape option -->
-    <xpath expr="//section" position="attributes">
-        <attribute name="data-oe-shape-data">{"shape":"web_editor/Airy/10","flip":[]}</attribute>
-    </xpath>
-    <!-- Shape -->
-    <xpath expr="//div[hasclass('container')]" position="before">
-        <div class="o_we_shape o_web_editor_Airy_10"/>
-    </xpath>
-</template>
 
 <!-- Snippet customization Pricing Pages -->
 
@@ -217,40 +203,34 @@
     </xpath>
 </template>
 
+<template id="new_page_template_pricing_s_image_text" inherit_id="website.new_page_template_pricing_s_image_text">
+    <!-- Remove shape option -->
+    <xpath expr="//section" position="attributes">
+        <attribute name="data-oe-shape-data"/>
+    </xpath>
+    <!-- Remove shape -->
+    <xpath expr="//div[hasclass('o_we_shape')]" position="replace"/>
+</template>
+
+<template id="new_page_template_pricing_s_image_text_2nd" inherit_id="website.new_page_template_pricing_s_image_text_2nd">
+    <!-- Remove shape option -->
+    <xpath expr="//section" position="attributes">
+        <attribute name="data-oe-shape-data"/>
+    </xpath>
+    <!-- Remove shape -->
+    <xpath expr="//div[hasclass('o_we_shape')]" position="replace"/>
+</template>
+
+<template id="new_page_template_pricing_s_text_image" inherit_id="website.new_page_template_pricing_s_text_image">
+    <!-- Remove shape option -->
+    <xpath expr="//section" position="attributes">
+        <attribute name="data-oe-shape-data"/>
+    </xpath>
+    <!-- Remove shape -->
+    <xpath expr="//div[hasclass('o_we_shape')]" position="replace"/>
+</template>
+
 <!-- Snippet customization Team Pages -->
-
-<template id="new_page_template_team_s_image_text" inherit_id="website.new_page_template_team_s_image_text">
-    <!-- Shape option -->
-    <xpath expr="//section" position="attributes">
-        <attribute name="data-oe-shape-data">{"shape":"web_editor/Airy/10","flip":["x"]}</attribute>
-    </xpath>
-    <!-- Shape -->
-    <xpath expr="//div[hasclass('container')]" position="before">
-        <div class="o_we_shape o_web_editor_Airy_10" style="background-image: url('/web_editor/shape/web_editor/Airy/10.svg?c5=o-color-1&amp;flip=x'); background-position: 50% 100%;"/>
-    </xpath>
-</template>
-
-<template id="new_page_template_team_s_image_text_2nd" inherit_id="website.new_page_template_team_s_image_text_2nd">
-    <!-- Shape option -->
-    <xpath expr="//section" position="attributes">
-        <attribute name="data-oe-shape-data">{"shape":"web_editor/Airy/10","flip":["x"]}</attribute>
-    </xpath>
-    <!-- Shape -->
-    <xpath expr="//div[hasclass('container')]" position="before">
-        <div class="o_we_shape o_web_editor_Airy_10" style="background-image: url('/web_editor/shape/web_editor/Airy/10.svg?c5=o-color-1&amp;flip=x'); background-position: 50% 100%;"/>
-    </xpath>
-</template>
-
-<template id="new_page_template_team_s_text_image" inherit_id="website.new_page_template_team_s_text_image">
-    <!-- Shape option -->
-    <xpath expr="//section" position="attributes">
-        <attribute name="data-oe-shape-data">{"shape":"web_editor/Airy/10","flip":[]}</attribute>
-    </xpath>
-    <!-- Shape -->
-    <xpath expr="//div[hasclass('container')]" position="before">
-        <div class="o_we_shape o_web_editor_Airy_10"/>
-    </xpath>
-</template>
 
 <template id="new_page_template_team_s_text_block_h1" inherit_id="website.new_page_template_team_s_text_block_h1">
     <xpath expr="//section" position="attributes">

--- a/theme_loftspace/views/snippets/s_image_text.xml
+++ b/theme_loftspace/views/snippets/s_image_text.xml
@@ -5,6 +5,11 @@
     <!-- Section -->
     <xpath expr="//section" position="attributes">
         <attribute name="class" add="pt64 pb64" remove="pt32 pb32" separator=" "/>
+        <attribute name="data-oe-shape-data">{"shape":"web_editor/Airy/10","flip":["x"]}</attribute>
+    </xpath>
+    <!-- Shape -->
+    <xpath expr="//div[hasclass('container')]" position="before">
+        <div class="o_we_shape o_web_editor_Airy_10" style="background-image: url('/web_editor/shape/web_editor/Airy/10.svg?c5=o-color-1&amp;flip=x'); background-position: 50% 100%;"/>
     </xpath>
     <!-- Img wrapper -->
     <xpath expr="//div[hasclass('row')]//div" position="attributes">
@@ -13,17 +18,6 @@
     <!-- Column text -->
     <xpath expr="//div[hasclass('row')]//div[2]" position="attributes">
         <attribute name="class" add="offset-lg-1" separator=" "/>
-    </xpath>
-</template>
-
-<template id="configurator_s_image_text" inherit_id="website.configurator_s_image_text">
-    <!-- Shape option -->
-    <xpath expr="//section" position="attributes">
-        <attribute name="data-oe-shape-data">{"shape":"web_editor/Airy/10","flip":["x"]}</attribute>
-    </xpath>
-    <!-- Shape -->
-    <xpath expr="//div[hasclass('container')]" position="before">
-        <div class="o_we_shape o_web_editor_Airy_10" style="background-image: url('/web_editor/shape/web_editor/Airy/10.svg?c5=o-color-1&amp;flip=x'); background-position: 50% 100%;"/>
     </xpath>
 </template>
 

--- a/theme_loftspace/views/snippets/s_numbers.xml
+++ b/theme_loftspace/views/snippets/s_numbers.xml
@@ -5,12 +5,6 @@
     <!-- Section -->
     <xpath expr="//section" position="attributes">
         <attribute name="class" add="pt80 pb192 o_cc5" remove="pt24 pb24 o_cc2" separator=" "/>
-    </xpath>
-</template>
-
-<template id="configurator_s_numbers" inherit_id="website.configurator_s_numbers">
-    <!-- Shape option -->
-    <xpath expr="//section" position="attributes">
         <attribute name="data-oe-shape-data">{"shape":"web_editor/Airy/03_001","flip":["y"]}</attribute>
     </xpath>
     <!-- Shape -->

--- a/theme_loftspace/views/snippets/s_product_catalog.xml
+++ b/theme_loftspace/views/snippets/s_product_catalog.xml
@@ -5,20 +5,11 @@
     <!-- Section -->
     <xpath expr="//section" position="attributes">
         <attribute name="class" add="o_cc o_cc5 pt112 pb112" remove="pt48 pb32" separator=" "/>
-    </xpath>
-    <!-- Filter -->
-    <xpath expr="//div[hasclass('container')]" position="before">
-        <div class="o_we_bg_filter bg-black-50"/>
-    </xpath>
-</template>
-
-<template id="configurator_s_product_catalog" inherit_id="website.configurator_s_product_catalog">
-    <!-- Shape option -->
-    <xpath expr="//section" position="attributes">
         <attribute name="data-oe-shape-data">{"shape":"web_editor/Floats/09","flip":[]}</attribute>
     </xpath>
-    <!-- Shape -->
+    <!-- Filter & shape -->
     <xpath expr="//div[hasclass('container')]" position="before">
+        <div class="o_we_bg_filter bg-black-50"/>
         <div class="o_we_shape o_web_editor_Floats_09"/>
     </xpath>
 </template>

--- a/theme_loftspace/views/snippets/s_text_image.xml
+++ b/theme_loftspace/views/snippets/s_text_image.xml
@@ -5,21 +5,15 @@
     <!-- Section -->
     <xpath expr="//section" position="attributes">
         <attribute name="class" add="pt64 pb64 o_cc o_cc5" remove="pt32 pb32" separator=" "/>
-    </xpath>
-    <!-- Img wrapper -->
-    <xpath expr="//div[hasclass('row')]//div[2]" position="attributes">
-        <attribute name="class" add="col-lg-5 offset-lg-1" remove="col-lg-6" separator=" "/>
-    </xpath>
-</template>
-
-<template id="configurator_s_text_image" inherit_id="website.configurator_s_text_image">
-    <!-- Shape option -->
-    <xpath expr="//section" position="attributes">
         <attribute name="data-oe-shape-data">{"shape":"web_editor/Airy/10","flip":[]}</attribute>
     </xpath>
     <!-- Shape -->
     <xpath expr="//div[hasclass('container')]" position="before">
         <div class="o_we_shape o_web_editor_Airy_10"/>
+    </xpath>
+    <!-- Img wrapper -->
+    <xpath expr="//div[hasclass('row')]//div[2]" position="attributes">
+        <attribute name="class" add="col-lg-5 offset-lg-1" remove="col-lg-6" separator=" "/>
     </xpath>
 </template>
 

--- a/theme_nano/views/new_page_template.xml
+++ b/theme_nano/views/new_page_template.xml
@@ -39,6 +39,15 @@
 
 <!-- General customizations -->
 
+<template id="new_page_template_s_parallax" inherit_id="website.new_page_template_s_parallax">
+    <!-- Remove shape option -->
+    <xpath expr="//section" position="attributes">
+        <attribute name="data-oe-shape-data"/>
+    </xpath>
+    <!-- Remove shape -->
+    <xpath expr="//div[hasclass('o_we_shape')]" position="replace"/>
+</template>
+
 <template id="new_page_template_s_text_block" inherit_id="website.new_page_template_s_text_block">
     <xpath expr="//section" position="attributes">
         <attribute name="class" add="o_cc5 pt40" remove="pt96 o_cc1" separator=" "/>
@@ -55,17 +64,6 @@
 </template>
 
 <!-- Snippet customization Basic Pages -->
-
-<template id="new_page_template_basic_s_features" inherit_id="website.new_page_template_basic_s_features">
-    <!-- Shape option -->
-    <xpath expr="//section" position="attributes">
-        <attribute name="data-oe-shape-data">{"shape":"web_editor/Floats/12"}</attribute>
-    </xpath>
-    <xpath expr="//*[hasclass('container')]" position="before">
-        <div class="o_we_shape o_web_editor_Floats_12"/>
-    </xpath>
-    
-</template>
 
 <template id="new_page_template_basic_s_text_block_h1" inherit_id="website.new_page_template_basic_s_text_block_h1">
     <xpath expr="//section" position="attributes">
@@ -89,16 +87,6 @@
     </xpath>
     <xpath expr="//*[hasclass('container')]" position="before">
         <div class="o_we_shape o_web_editor_Bold_12_001" style="background-image: url('/web_editor/shape/web_editor/Bold/12_001.svg?c1=rgba%280%2C%200%2C%200%2C%200.5%29&amp;c2=rgba%280%2C%200%2C%200%2C%200.25%29&amp;c5=o-color-5&amp;flip=x'); background-position: 50% 50%;"/>
-    </xpath>
-</template>
-
-<template id="new_page_template_about_s_features" inherit_id="website.new_page_template_about_s_features">
-    <!-- Shape option -->
-    <xpath expr="//section" position="attributes">
-        <attribute name="data-oe-shape-data">{"shape":"web_editor/Floats/12"}</attribute>
-    </xpath>
-    <xpath expr="//*[hasclass('container')]" position="before">
-        <div class="o_we_shape o_web_editor_Floats_12"/>
     </xpath>
 </template>
 
@@ -188,6 +176,15 @@
 </template>
 
 <!-- Snippet customization Landing Pages -->
+
+<template id="new_page_template_landing_s_features" inherit_id="website.new_page_template_landing_s_features">
+    <!-- Remove shape option -->
+    <xpath expr="//section" position="attributes">
+        <attribute name="data-oe-shape-data"/>
+    </xpath>
+    <!-- Remove shape -->
+    <xpath expr="//div[hasclass('o_we_shape')]" position="replace"/>
+</template>
 
 <template id="new_page_template_landing_0_s_cover" inherit_id="website.new_page_template_landing_0_s_cover">
     <!-- Shape option -->

--- a/theme_nano/views/snippets/s_features.xml
+++ b/theme_nano/views/snippets/s_features.xml
@@ -5,6 +5,10 @@
     <!-- Section -->
     <xpath expr="//section" position="attributes">
         <attribute name="class" add="pt40 pb48 o_cc o_cc5" remove="pt32 pb32" separator=" "/>
+        <attribute name="data-oe-shape-data">{"shape":"web_editor/Floats/12"}</attribute>
+    </xpath>
+    <xpath expr="//*[hasclass('container')]" position="before">
+        <div class="o_we_shape o_web_editor_Floats_12"/>
     </xpath>
     <!-- Column #01 -->
     <xpath expr="//h3" position="replace" mode="inner">
@@ -29,16 +33,6 @@
     </xpath>
     <xpath expr="(//p)[3]" position="replace" mode="inner">
         We craft long-lasting goods.
-    </xpath>
-</template>
-
-<template id="configurator_s_features" inherit_id="website.configurator_s_features">
-    <!-- Shape option -->
-    <xpath expr="//section" position="attributes">
-        <attribute name="data-oe-shape-data">{"shape":"web_editor/Floats/12"}</attribute>
-    </xpath>
-    <xpath expr="//*[hasclass('container')]" position="before">
-        <div class="o_we_shape o_web_editor_Floats_12"/>
     </xpath>
 </template>
 

--- a/theme_nano/views/snippets/s_parallax.xml
+++ b/theme_nano/views/snippets/s_parallax.xml
@@ -5,6 +5,11 @@
     <!-- Section -->
     <xpath expr="//section" position="attributes">
         <attribute name="class" add="pt48 pb48" separator=" "/>
+        <attribute name="data-oe-shape-data">{"shape":"web_editor/Rainy/10", "flip":["x","y"]}</attribute>
+    </xpath>
+    <!-- Shape -->
+    <xpath expr="//*[hasclass('oe_structure')]" position="before">
+        <div class="o_we_shape o_web_editor_Rainy_10" style="background-image: url('/web_editor/shape/web_editor/Rainy/10.svg?c1=o-color-1&amp;c3=o-color-3&amp;flip=xy'); background-position: 50% 50%;"/>
     </xpath>
     <!-- Content -->
     <xpath expr="//*[hasclass('oe_structure')]" position="inside">
@@ -13,17 +18,6 @@
                 <h3 style="text-align: center;"><font class="bg-o-color-5">Feel free to come up with your big idea. <br/> We take care of the rest.</font></h3>
             </div>
         </section>
-    </xpath>
-</template>
-
-<template id="configurator_s_parallax" inherit_id="website.configurator_s_parallax">
-    <!-- Shape option -->
-    <xpath expr="//section" position="attributes">
-        <attribute name="data-oe-shape-data">{"shape":"web_editor/Rainy/10", "flip":["x","y"]}</attribute>
-    </xpath>
-    <!-- Shape -->
-    <xpath expr="//*[hasclass('oe_structure')]" position="before">
-        <div class="o_we_shape o_web_editor_Rainy_10" style="background-image: url('/web_editor/shape/web_editor/Rainy/10.svg?c1=o-color-1&amp;c3=o-color-3&amp;flip=xy'); background-position: 50% 50%;"/>
     </xpath>
 </template>
 

--- a/theme_notes/views/new_page_template.xml
+++ b/theme_notes/views/new_page_template.xml
@@ -11,37 +11,13 @@
 
 <!-- General customizations -->
 
-<template id="new_page_template_s_call_to_action" inherit_id="website.new_page_template_s_call_to_action">
-    <!-- Shape option -->
+<template id="new_page_template_s_call_to_action_digital" inherit_id="website.new_page_template_s_call_to_action_digital">
+    <!-- Remove shape option -->
     <xpath expr="//section" position="attributes">
-        <attribute name="data-oe-shape-data">{"shape":"web_editor/Floats/12","flip":[]}</attribute>
+        <attribute name="data-oe-shape-data"/>
     </xpath>
-    <!-- Shape -->
-    <xpath expr="//div[hasclass('container')]" position="before">
-        <div class="o_we_shape o_web_editor_Floats_12"/>
-    </xpath>
-</template>
-
-<template id="new_page_template_s_call_to_action_about" inherit_id="website.new_page_template_s_call_to_action_about">
-    <!-- Shape option -->
-    <xpath expr="//section" position="attributes">
-        <attribute name="data-oe-shape-data">{"shape":"web_editor/Floats/12","flip":[]}</attribute>
-    </xpath>
-    <!-- Shape -->
-    <xpath expr="//div[hasclass('container')]" position="before">
-        <div class="o_we_shape o_web_editor_Floats_12"/>
-    </xpath>
-</template>
-
-<template id="new_page_template_s_call_to_action_menu" inherit_id="website.new_page_template_s_call_to_action_menu">
-    <!-- Shape option -->
-    <xpath expr="//section" position="attributes">
-        <attribute name="data-oe-shape-data">{"shape":"web_editor/Floats/12","flip":[]}</attribute>
-    </xpath>
-    <!-- Shape -->
-    <xpath expr="//div[hasclass('container')]" position="before">
-        <div class="o_we_shape o_web_editor_Floats_12"/>
-    </xpath>
+    <!-- Remove shape -->
+    <xpath expr="//div[hasclass('o_we_shape')]" position="replace"/>
 </template>
 
 <template id="new_page_template_s_carousel" inherit_id="website.new_page_template_s_carousel">
@@ -71,22 +47,29 @@
     </xpath>
 </template>
 
-<template id="new_page_template_s_parallax" inherit_id="website.new_page_template_s_parallax">
-    <!-- Shape option -->
+<template id="new_page_template_s_comparisons" inherit_id="website.new_page_template_s_comparisons">
+    <!-- Remove shape option -->
     <xpath expr="//section" position="attributes">
-        <attribute name="data-oe-shape-data">{"shape":"web_editor/Rainy/08_001","flip":[]}</attribute>
+        <attribute name="data-oe-shape-data"/>
     </xpath>
-    <!-- Shape -->
-    <xpath expr="//div[hasclass('o_we_bg_filter')]" position="after">
-        <div class="o_we_shape o_web_editor_Rainy_08_001"/>
+    <!-- Remove shape -->
+    <xpath expr="//div[hasclass('o_we_shape')]" position="replace"/>
+</template>
+
+<template id="new_page_template_s_image_text" inherit_id="website.new_page_template_s_image_text">
+    <!-- Remove shape option -->
+    <xpath expr="//section" position="attributes">
+        <attribute name="data-oe-shape-data"/>
     </xpath>
 </template>
 
-<template id="new_page_template_s_text_image" inherit_id="website.new_page_template_s_text_image">
-    <!-- Shape option -->
+<template id="new_page_template_s_product_catalog" inherit_id="website.new_page_template_s_product_catalog">
+    <!-- Remove shape option -->
     <xpath expr="//section" position="attributes">
-        <attribute name="data-oe-shape-data">{"shape":"web_editor/Wavy/11","flip":["x"]}</attribute>
+        <attribute name="data-oe-shape-data"/>
     </xpath>
+    <!-- Remove shape -->
+    <xpath expr="//div[hasclass('o_we_shape')]" position="replace"/>
 </template>
 
 <!-- Snippet customization Basic Pages -->
@@ -101,14 +84,8 @@
 <!-- Snippet customization About Pages -->
 
 <template id="new_page_template_about_s_banner" inherit_id="website.new_page_template_about_s_banner">
-    <!-- Shape option -->
     <xpath expr="//section" position="attributes">
-    <attribute name="class" add="o_half_screen_height" remove="o_full_screen_height" separator=" "/>
-        <attribute name="data-oe-shape-data">{"shape":"web_editor/Floats/08","flip":["x","y"]}</attribute>
-    </xpath>
-    <!-- Shape -->
-    <xpath expr="//div[hasclass('container')]" position="before">
-        <div class="o_we_shape o_web_editor_Floats_08" style="background-image: url('/web_editor/shape/web_editor/Floats/08.svg?c1=o-color-1&amp;c2=o-color-2&amp;c3=o-color-3&amp;c5=o-color-1&amp;flip=xy'); background-position: 100% 100%;"/>
+        <attribute name="class" add="o_half_screen_height" remove="o_full_screen_height" separator=" "/>
     </xpath>
 </template>
 
@@ -181,14 +158,8 @@
 </template>
 
 <template id="new_page_template_landing_1_s_banner" inherit_id="website.new_page_template_landing_1_s_banner">
-    <!-- Shape option -->
     <xpath expr="//section" position="attributes">
-    <attribute name="class" add="o_half_screen_height" remove="o_full_screen_height" separator=" "/>
-        <attribute name="data-oe-shape-data">{"shape":"web_editor/Floats/08","flip":["x","y"]}</attribute>
-    </xpath>
-    <!-- Shape -->
-    <xpath expr="//div[hasclass('container')]" position="before">
-        <div class="o_we_shape o_web_editor_Floats_08" style="background-image: url('/web_editor/shape/web_editor/Floats/08.svg?c1=o-color-1&amp;c2=o-color-2&amp;c3=o-color-3&amp;c5=o-color-1&amp;flip=xy'); background-position: 100% 100%;"/>
+        <attribute name="class" add="o_half_screen_height" remove="o_full_screen_height" separator=" "/>
     </xpath>
 </template>
 
@@ -212,17 +183,20 @@
     <xpath expr="//section" position="replace"/>
 </template>
 
+<template id="new_page_template_landing_5_s_banner" inherit_id="website.new_page_template_landing_5_s_banner">
+    <!-- Remove shape option -->
+    <xpath expr="//section" position="attributes">
+        <attribute name="data-oe-shape-data"/>
+    </xpath>
+    <!-- Remove shape -->
+    <xpath expr="//div[hasclass('o_we_shape')]" position="replace"/>
+</template>
+
 <!-- Snippet customization Gallery Pages -->
 
 <template id="new_page_template_gallery_s_banner" inherit_id="website.new_page_template_gallery_s_banner">
-    <!-- Shape option -->
     <xpath expr="//section" position="attributes">
-    <attribute name="class" add="o_half_screen_height" remove="o_full_screen_height" separator=" "/>
-        <attribute name="data-oe-shape-data">{"shape":"web_editor/Floats/08","flip":["x","y"]}</attribute>
-    </xpath>
-    <!-- Shape -->
-    <xpath expr="//div[hasclass('container')]" position="before">
-        <div class="o_we_shape o_web_editor_Floats_08" style="background-image: url('/web_editor/shape/web_editor/Floats/08.svg?c1=o-color-1&amp;c2=o-color-2&amp;c3=o-color-3&amp;c5=o-color-1&amp;flip=xy'); background-position: 100% 100%;"/>
+        <attribute name="class" add="o_half_screen_height" remove="o_full_screen_height" separator=" "/>
     </xpath>
 </template>
 

--- a/theme_notes/views/snippets/s_banner.xml
+++ b/theme_notes/views/snippets/s_banner.xml
@@ -5,21 +5,15 @@
     <!-- Section -->
     <xpath expr="//section" position="attributes">
         <attribute name="class" add="o_cc o_cc5" separator=" "/>
-    </xpath>
-    <!-- Title -->
-    <xpath expr="//h1" position="replace" mode="inner">
-        Enjoy the atmosphere
-    </xpath>
-</template>
-
-<template id="configurator_s_banner" inherit_id="website.configurator_s_banner">
-    <!-- Shape option -->
-    <xpath expr="//section" position="attributes">
         <attribute name="data-oe-shape-data">{"shape":"web_editor/Floats/08","flip":["x","y"]}</attribute>
     </xpath>
     <!-- Shape -->
     <xpath expr="//div[hasclass('container')]" position="before">
         <div class="o_we_shape o_web_editor_Floats_08" style="background-image: url('/web_editor/shape/web_editor/Floats/08.svg?c1=o-color-1&amp;c2=o-color-2&amp;c3=o-color-3&amp;c5=o-color-1&amp;flip=xy'); background-position: 100% 100%;"/>
+    </xpath>
+    <!-- Title -->
+    <xpath expr="//h1" position="replace" mode="inner">
+        Enjoy the atmosphere
     </xpath>
 </template>
 

--- a/theme_notes/views/snippets/s_call_to_action.xml
+++ b/theme_notes/views/snippets/s_call_to_action.xml
@@ -5,11 +5,13 @@
     <!-- Section -->
     <xpath expr="//section" position="attributes">
         <attribute name="class" add="pb72 pt96 oe_img_bg o_bg_img_center" remove="pt48 pb24" separator=" "/>
+        <attribute name="data-oe-shape-data">{"shape":"web_editor/Floats/12","flip":[]}</attribute>
         <attribute name="style">background-image: url('/web/image/website.s_call_to_action_default_image'); background-position: 50% 34%;</attribute>
     </xpath>
-    <!-- Filter -->
+    <!-- Shape & filter -->
     <xpath expr="//div[hasclass('container')]" position="before">
         <div class="o_we_bg_filter bg-black-50"/>
+        <div class="o_we_shape o_web_editor_Floats_12"/>
     </xpath>
     <!-- Title -->
     <xpath expr="//h3" position="replace">
@@ -25,17 +27,6 @@
     </xpath>
     <xpath expr="//a[hasclass('btn')]" position="replace" mode="inner">
         Get your ticket
-    </xpath>
-</template>
-
-<template id="configurator_s_call_to_action" inherit_id="website.configurator_s_call_to_action">
-    <!-- Shape option -->
-    <xpath expr="//section" position="attributes">
-        <attribute name="data-oe-shape-data">{"shape":"web_editor/Floats/12","flip":[]}</attribute>
-    </xpath>
-    <!-- Shape -->
-    <xpath expr="//div[hasclass('container')]" position="before">
-        <div class="o_we_shape o_web_editor_Floats_12"/>
     </xpath>
 </template>
 

--- a/theme_notes/views/snippets/s_comparisons.xml
+++ b/theme_notes/views/snippets/s_comparisons.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <odoo>
 
-<template id="configurator_s_comparisons" inherit_id="website.configurator_s_comparisons">
+<template id="s_comparisons" inherit_id="website.s_comparisons">
     <!-- Shape option -->
     <xpath expr="//section" position="attributes">
         <attribute name="data-oe-shape-data">{"shape":"web_editor/Floats/05","flip":[]}</attribute>

--- a/theme_notes/views/snippets/s_image_text.xml
+++ b/theme_notes/views/snippets/s_image_text.xml
@@ -5,6 +5,7 @@
     <!-- Section -->
     <xpath expr="//section" position="attributes">
         <attribute name="class" add="o_cc o_cc5 pt80 pb80" remove="pt32 pb32" separator=" "/>
+        <attribute name="data-oe-shape-data">{"shape":"web_editor/Wavy/11","flip":[]}</attribute>
     </xpath>
     <!-- Text wrapper -->
     <xpath expr="//div[hasclass('col-lg-6')][2]" position="attributes">
@@ -23,13 +24,6 @@
     <!-- Img wrapper -->
     <xpath expr="//div[hasclass('col-lg-6')]" position="attributes">
         <attribute name="class" add="col-lg-4" remove="col-lg-6" separator=" "/>
-    </xpath>
-</template>
-
-<template id="configurator_s_image_text" inherit_id="website.configurator_s_image_text">
-    <!-- Shape option -->
-    <xpath expr="//section" position="attributes">
-        <attribute name="data-oe-shape-data">{"shape":"web_editor/Wavy/11","flip":[]}</attribute>
     </xpath>
 </template>
 

--- a/theme_notes/views/snippets/s_parallax.xml
+++ b/theme_notes/views/snippets/s_parallax.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <odoo>
 
-<template id="configurator_s_parallax" inherit_id="website.configurator_s_parallax">
+<template id="s_parallax" inherit_id="website.s_parallax">
     <!-- Shape option -->
     <xpath expr="//section" position="attributes">
         <attribute name="data-oe-shape-data">{"shape":"web_editor/Rainy/08_001","flip":[]}</attribute>

--- a/theme_notes/views/snippets/s_product_catalog.xml
+++ b/theme_notes/views/snippets/s_product_catalog.xml
@@ -5,11 +5,13 @@
     <!-- Section -->
     <xpath expr="//section" position="attributes">
         <attribute name="class" add="o_cc o_cc5 pb160 pt160 parallax s_parallax_is_fixed s_parallax_no_overflow_hidden o_full_screen_height" remove="pb32 pt48" separator=" "/>
+        <attribute name="data-oe-shape-data">{"shape":"web_editor/Wavy/10","flip":[]}</attribute>
         <attribute name="data-scroll-background-ratio">1</attribute>
     </xpath>
-    <!-- Background image -->
+    <!-- Shape & Background image -->
     <xpath expr="//section/*" position="before">
         <span class="s_parallax_bg oe_img_bg o_bg_img_center" style="background-image: url('/web/image/website.s_product_catalog_default_image');"/>
+        <div class="o_we_shape o_web_editor_Wavy_10"/>
     </xpath>
     <!-- Title & subtitles -->
     <xpath expr="//h2" position="replace">
@@ -64,17 +66,6 @@
     </xpath>
     <xpath expr="(//ul)[2]/t[3]/t[2]" position="replace" mode="inner">
         $115.50
-    </xpath>
-</template>
-
-<template id="configurator_s_product_catalog" inherit_id="website.configurator_s_product_catalog">
-    <!-- Shape option -->
-    <xpath expr="//section" position="attributes">
-        <attribute name="data-oe-shape-data">{"shape":"web_editor/Wavy/10","flip":[]}</attribute>
-    </xpath>
-    <!-- Shape -->
-    <xpath expr="//section/*" position="before">
-        <div class="o_we_shape o_web_editor_Wavy_10"/>
     </xpath>
 </template>
 

--- a/theme_notes/views/snippets/s_text_image.xml
+++ b/theme_notes/views/snippets/s_text_image.xml
@@ -5,6 +5,7 @@
     <!-- Section -->
     <xpath expr="//section" position="attributes">
         <attribute name="class" add="o_cc o_cc1 pt80 pb80" remove="pt32 pb32" separator=" "/>
+        <attribute name="data-oe-shape-data">{"shape":"web_editor/Wavy/11","flip":["x"]}</attribute>
     </xpath>
     <!-- Title & Paragraph -->
     <xpath expr="//h2" position="replace" mode="inner">
@@ -22,13 +23,6 @@
     <!-- Image wrapper -->
     <xpath expr="//div[hasclass('col-lg-6')][2]" position="attributes">
         <attribute name="class" add="col-lg-4 offset-lg-2" remove="col-lg-6" separator=" "/>
-    </xpath>
-</template>
-
-<template id="configurator_s_text_image" inherit_id="website.configurator_s_text_image">
-    <!-- Shape option -->
-    <xpath expr="//section" position="attributes">
-        <attribute name="data-oe-shape-data">{"shape":"web_editor/Wavy/11","flip":["x"]}</attribute>
     </xpath>
 </template>
 

--- a/theme_odoo_experts/views/new_page_template.xml
+++ b/theme_odoo_experts/views/new_page_template.xml
@@ -46,6 +46,15 @@
     </xpath>
 </template>
 
+<template id="new_page_template_s_product_catalog" inherit_id="website.new_page_template_s_product_catalog">
+    <!-- Remove shape option -->
+    <xpath expr="//section" position="attributes">
+        <attribute name="data-oe-shape-data"/>
+    </xpath>
+    <!-- Remove shape -->
+    <xpath expr="//div[hasclass('o_we_shape')]" position="replace"/>
+</template>
+
 <template id="new_page_template_s_text_image" inherit_id="website.new_page_template_s_text_image">
     <!-- Shape option -->
     <xpath expr="//section" position="attributes">
@@ -57,15 +66,22 @@
     </xpath>
 </template>
 
-<template id="new_page_template_s_three_columns" inherit_id="website.new_page_template_s_three_columns">
-    <!-- Shape option -->
+<template id="new_page_template_s_three_columns_2nd" inherit_id="website.new_page_template_s_three_columns_2nd">
+    <!-- Remove shape option -->
     <xpath expr="//section" position="attributes">
-        <attribute name="data-oe-shape-data">{"shape":"web_editor/Floats/04","flip":[]}</attribute>
+        <attribute name="data-oe-shape-data"/>
     </xpath>
-    <!-- Shape -->
-    <xpath expr="//div[hasclass('container')]" position="before">
-        <div class="o_we_shape o_web_editor_Floats_04"/>
+    <!-- Remove shape -->
+    <xpath expr="//div[hasclass('o_we_shape')]" position="replace"/>
+</template>
+
+<template id="new_page_template_s_three_columns_menu" inherit_id="website.new_page_template_s_three_columns_menu">
+    <!-- Remove shape option -->
+    <xpath expr="//section" position="attributes">
+        <attribute name="data-oe-shape-data"/>
     </xpath>
+    <!-- Remove shape -->
+    <xpath expr="//div[hasclass('o_we_shape')]" position="replace"/>
 </template>
 
 <!-- Snippet customization Basic Pages -->

--- a/theme_odoo_experts/views/snippets/s_product_catalog.xml
+++ b/theme_odoo_experts/views/snippets/s_product_catalog.xml
@@ -5,20 +5,11 @@
     <!-- Section -->
     <xpath expr="//section" position="attributes">
         <attribute name="class" add="o_cc o_cc5 pt96 pb96" remove="pt48 pb32" separator=" "/>
-    </xpath>
-    <!-- Filter -->
-    <xpath expr="//div[hasclass('container')]" position="before">
-        <div class="o_we_bg_filter bg-black-50"/>
-    </xpath>
-</template>
-
-<template id="configurator_s_product_catalog" inherit_id="website.configurator_s_product_catalog">
-    <!-- Shape option -->
-    <xpath expr="//section" position="attributes">
         <attribute name="data-oe-shape-data">{"shape":"web_editor/Airy/03_001","flip":[]}</attribute>
     </xpath>
-    <!-- Shape -->
+    <!-- Filter & shape -->
     <xpath expr="//div[hasclass('container')]" position="before">
+        <div class="o_we_bg_filter bg-black-50"/>
         <div class="o_we_shape o_web_editor_Airy_03_001"/>
     </xpath>
 </template>

--- a/theme_odoo_experts/views/snippets/s_three_columns.xml
+++ b/theme_odoo_experts/views/snippets/s_three_columns.xml
@@ -5,6 +5,11 @@
     <!-- Section -->
     <xpath expr="//section" position="attributes">
         <attribute name="class" add="pt72 pb72 o_colored_level" remove="pt32 pb32" separator=" "/>
+        <attribute name="data-oe-shape-data">{"shape":"web_editor/Floats/04","flip":[]}</attribute>
+    </xpath>
+    <!-- Shape -->
+    <xpath expr="//div[hasclass('container')]" position="before">
+        <div class="o_we_shape o_web_editor_Floats_04"/>
     </xpath>
     <!-- Card #1 -->
     <xpath expr="//div[hasclass('card')]" position="attributes">
@@ -17,17 +22,6 @@
     <!-- Card #3 -->
     <xpath expr="(//div[hasclass('card')])[3]" position="attributes">
         <attribute name="style">border-width: 0px !important; box-shadow: 0px 8px 16px 0px rgba(0, 0, 0, 0.05) !important;</attribute>
-    </xpath>
-</template>
-
-<template id="configurator_s_three_columns" inherit_id="website.configurator_s_three_columns">
-    <!-- Shape option -->
-    <xpath expr="//section" position="attributes">
-        <attribute name="data-oe-shape-data">{"shape":"web_editor/Floats/04","flip":[]}</attribute>
-    </xpath>
-    <!-- Shape -->
-    <xpath expr="//div[hasclass('container')]" position="before">
-        <div class="o_we_shape o_web_editor_Floats_04"/>
     </xpath>
 </template>
 

--- a/theme_orchid/views/new_page_template.xml
+++ b/theme_orchid/views/new_page_template.xml
@@ -39,17 +39,6 @@
 
 <!-- General customizations -->
 
-<template id="new_page_template_s_numbers" inherit_id="website.new_page_template_s_numbers">
-    <!-- Shape option -->
-    <xpath expr="//section" position="attributes">
-        <attribute name="data-oe-shape-data">{"shape":"web_editor/Floats/12","flip":[]}</attribute>
-    </xpath>
-    <!-- Shape -->
-    <xpath expr="//div[hasclass('container')]" position="before">
-        <div class="o_we_shape o_web_editor_Floats_12"/>
-    </xpath>
-</template>
-
 <template id="new_page_template_s_text_image" inherit_id="website.new_page_template_s_text_image">
     <!-- Shape option -->
     <xpath expr="//section" position="attributes">

--- a/theme_orchid/views/snippets/s_numbers.xml
+++ b/theme_orchid/views/snippets/s_numbers.xml
@@ -5,12 +5,6 @@
     <!-- Section -->
     <xpath expr="//section" position="attributes">
         <attribute name="class" add="o_cc3" remove="o_cc2" separator=" "/>
-    </xpath>
-</template>
-
-<template id="configurator_s_numbers" inherit_id="website.configurator_s_numbers">
-    <!-- Shape option -->
-    <xpath expr="//section" position="attributes">
         <attribute name="data-oe-shape-data">{"shape":"web_editor/Floats/12","flip":[]}</attribute>
     </xpath>
     <!-- Shape -->

--- a/theme_paptic/views/customizations.xml
+++ b/theme_paptic/views/customizations.xml
@@ -298,21 +298,15 @@
 <template id="s_comparisons" inherit_id="website.s_comparisons" name="Paptic s_comparisons">
     <xpath expr="//section" position="attributes">
         <attribute name="class" add="pt0 pb80" remove="pt32 pb32" separator=" "/>
-    </xpath>
-    <!-- Left card -->
-    <xpath expr="//div[hasclass('card')]" position="attributes">
-        <attribute name="class" add="bg-o-color-2" remove="bg-200" separator=" "/>
-    </xpath>
-</template>
-
-<template id="configurator_s_comparisons" inherit_id="website.configurator_s_comparisons" name="Paptic s_comparisons">
-    <!-- Shape option -->
-    <xpath expr="//section" position="attributes">
         <attribute name="data-oe-shape-data">{"shape":"web_editor/Floats/03","flip":[]}</attribute>
     </xpath>
     <!-- Shape -->
     <xpath expr="//div[hasclass('container')]" position="before">
         <div class="o_we_shape o_web_editor_Floats_03"/>
+    </xpath>
+    <!-- Left card -->
+    <xpath expr="//div[hasclass('card')]" position="attributes">
+        <attribute name="class" add="bg-o-color-2" remove="bg-200" separator=" "/>
     </xpath>
 </template>
 
@@ -349,12 +343,6 @@
 <template id="s_numbers" inherit_id="website.s_numbers" name="Paptic s_numbers">
     <xpath expr="//section" position="attributes">
         <attribute name="class" add="pt80 pb80 o_cc4" remove="pt24 pb24 o_cc2" separator=" "/>
-    </xpath>
-</template>
-
-<template id="configurator_s_numbers" inherit_id="website.configurator_s_numbers" name="Paptic s_numbers">
-    <!-- Shape option -->
-    <xpath expr="//section" position="attributes">
         <attribute name="data-oe-shape-data">{"shape":"web_editor/Blocks/01_001","flip":[]}</attribute>
     </xpath>
     <!-- Shape -->

--- a/theme_paptic/views/new_page_template.xml
+++ b/theme_paptic/views/new_page_template.xml
@@ -56,15 +56,13 @@
     </xpath>
 </template>
 
-<template id="new_page_template_s_numbers" inherit_id="website.new_page_template_s_numbers">
-    <!-- Shape option -->
+<template id="new_page_template_s_comparisons" inherit_id="website.new_page_template_s_comparisons">
+    <!-- Remove shape option -->
     <xpath expr="//section" position="attributes">
-        <attribute name="data-oe-shape-data">{"shape":"web_editor/Blocks/01_001","flip":[]}</attribute>
+        <attribute name="data-oe-shape-data"/>
     </xpath>
-    <!-- Shape -->
-    <xpath expr="//div[hasclass('container')]" position="before">
-        <div class="o_we_shape o_web_editor_Blocks_01_001"/>
-    </xpath>
+    <!-- Remove shape -->
+    <xpath expr="//div[hasclass('o_we_shape')]" position="replace"/>
 </template>
 
 <template id="new_page_template_s_three_columns" inherit_id="website.new_page_template_s_three_columns">

--- a/theme_real_estate/views/new_page_template.xml
+++ b/theme_real_estate/views/new_page_template.xml
@@ -11,6 +11,15 @@
 
 <!-- General customizations -->
 
+<template id="new_page_template_s_banner" inherit_id="website.new_page_template_s_banner">
+    <!-- Remove shape option -->
+    <xpath expr="//section" position="attributes">
+        <attribute name="data-oe-shape-data"/>
+    </xpath>
+    <!-- Remove shape -->
+    <xpath expr="//div[hasclass('o_we_shape')]" position="replace"/>
+</template>
+
 <template id="new_page_template_s_text_block_h2_contact" inherit_id="website.new_page_template_s_text_block_h2_contact">
     <xpath expr="//section" position="attributes">
         <attribute name="class" remove="o_cc4" separator=" "/>

--- a/theme_real_estate/views/snippets/s_banner.xml
+++ b/theme_real_estate/views/snippets/s_banner.xml
@@ -5,11 +5,13 @@
     <!-- Section -->
     <xpath expr="//section" position="attributes">
         <attribute name="class" add="o_cc o_cc3 parallax s_parallax_is_fixed" remove="pt96 pb96" separator=" "/>
+        <attribute name="data-oe-shape-data">{"shape":"web_editor/Origins/18","flip":["x"]}</attribute>
         <attribute name="data-scroll-background-ratio">1</attribute>
     </xpath>
     <xpath expr="//div[hasclass('container')]" position="before">
         <span class="s_parallax_bg oe_img_bg" style="background-image: url('/web/image/website.s_banner_default_image'); background-position: 50% 0;"/>
         <div class="o_we_bg_filter bg-black-50"/>
+        <div class="o_we_shape o_web_editor_Origins_18" style="background-image: url('/web_editor/shape/web_editor/Origins/18.svg?c1=o-color-2&amp;flip=x'); background-position: 50% 50%;"/>
     </xpath>
 
     <!-- Row - remove grid mode -->
@@ -50,17 +52,6 @@
     </xpath>
     <xpath expr="//a[@t-att-href='cta_btn_href']" position="replace" mode="inner">
         See properties
-    </xpath>
-</template>
-
-<template id="configurator_s_banner" inherit_id="website.configurator_s_banner">
-    <!-- Shape option -->
-    <xpath expr="//section" position="attributes">
-        <attribute name="data-oe-shape-data">{"shape":"web_editor/Origins/18","flip":["x"]}</attribute>
-    </xpath>
-    <!-- Shape -->
-    <xpath expr="//span[hasclass('s_parallax_bg')]" position="after">
-        <div class="o_we_shape o_web_editor_Origins_18" style="background-image: url('/web_editor/shape/web_editor/Origins/18.svg?c1=o-color-2&amp;flip=x'); background-position: 50% 50%;"/>
     </xpath>
 </template>
 

--- a/theme_treehouse/views/new_page_template.xml
+++ b/theme_treehouse/views/new_page_template.xml
@@ -11,50 +11,6 @@
 
 <!-- General customizations -->
 
-<template id="new_page_template_s_call_to_action" inherit_id="website.new_page_template_s_call_to_action">
-    <!-- Shape option -->
-    <xpath expr="//section" position="attributes">
-        <attribute name="data-oe-shape-data">{"shape":"web_editor/Rainy/08_001"}</attribute>
-    </xpath>
-    <!-- Shape -->
-    <xpath expr="//div[hasclass('container')]" position="before">
-        <div class="o_we_shape o_web_editor_Rainy_08_001"/>
-    </xpath>
-</template>
-
-<template id="new_page_template_s_call_to_action_about" inherit_id="website.new_page_template_s_call_to_action_about">
-    <!-- Shape option -->
-    <xpath expr="//section" position="attributes">
-        <attribute name="data-oe-shape-data">{"shape":"web_editor/Rainy/08_001"}</attribute>
-    </xpath>
-    <!-- Shape -->
-    <xpath expr="//div[hasclass('container')]" position="before">
-        <div class="o_we_shape o_web_editor_Rainy_08_001"/>
-    </xpath>
-</template>
-
-<template id="new_page_template_s_call_to_action_digital" inherit_id="website.new_page_template_s_call_to_action_digital">
-    <!-- Shape option -->
-    <xpath expr="//section" position="attributes">
-        <attribute name="data-oe-shape-data">{"shape":"web_editor/Rainy/08_001"}</attribute>
-    </xpath>
-    <!-- Shape -->
-    <xpath expr="//div[hasclass('container')]" position="before">
-        <div class="o_we_shape o_web_editor_Rainy_08_001"/>
-    </xpath>
-</template>
-
-<template id="new_page_template_s_call_to_action_menu" inherit_id="website.new_page_template_s_call_to_action_menu">
-    <!-- Shape option -->
-    <xpath expr="//section" position="attributes">
-        <attribute name="data-oe-shape-data">{"shape":"web_editor/Rainy/08_001"}</attribute>
-    </xpath>
-    <!-- Shape -->
-    <xpath expr="//div[hasclass('container')]" position="before">
-        <div class="o_we_shape o_web_editor_Rainy_08_001"/>
-    </xpath>
-</template>
-
 <template id="new_page_template_s_three_columns" inherit_id="website.new_page_template_s_three_columns">
     <xpath expr="//section" position="attributes">
         <attribute name="class" add="pt0" remove="pt80" separator=" "/>
@@ -70,17 +26,6 @@
 </template>
 
 <!-- Snippet customization About Pages -->
-
-<template id="new_page_template_about_s_banner" inherit_id="website.new_page_template_about_s_banner">
-    <!-- Shape option -->
-    <xpath expr="//section" position="attributes">
-        <attribute name="data-oe-shape-data">{"shape":"web_editor/Floats/12"}</attribute>
-    </xpath>
-    <!-- Shape -->
-    <xpath expr="//*[hasclass('container')]" position="before">
-        <div class="o_we_shape o_web_editor_Floats_12"/>
-    </xpath>
-</template>
 
 <template id="new_page_template_about_s_cover" inherit_id="website.new_page_template_about_s_cover">
     <xpath expr="//section" position="attributes">
@@ -104,17 +49,6 @@
     <xpath expr="//p" position="replace"/>
 </template>
 
-<template id="new_page_template_landing_1_s_banner" inherit_id="website.new_page_template_landing_1_s_banner">
-    <!-- Shape option -->
-    <xpath expr="//section" position="attributes">
-        <attribute name="data-oe-shape-data">{"shape":"web_editor/Floats/12"}</attribute>
-    </xpath>
-    <!-- Shape -->
-    <xpath expr="//*[hasclass('container')]" position="before">
-        <div class="o_we_shape o_web_editor_Floats_12"/>
-    </xpath>
-</template>
-
 <template id="new_page_template_landing_2_s_cover" inherit_id="website.new_page_template_landing_2_s_cover">
     <xpath expr="//section" position="attributes">
         <attribute name="class" add="o_half_screen_height" remove="o_full_screen_height" separator=" "/>
@@ -133,18 +67,16 @@
     </xpath>
 </template>
 
-<!-- Snippet customization Gallery Pages -->
-
-<template id="new_page_template_gallery_s_banner" inherit_id="website.new_page_template_gallery_s_banner">
-    <!-- Shape option -->
+<template id="new_page_template_landing_5_s_banner" inherit_id="website.new_page_template_landing_5_s_banner">
+    <!-- Remove shape option -->
     <xpath expr="//section" position="attributes">
-        <attribute name="data-oe-shape-data">{"shape":"web_editor/Floats/12"}</attribute>
+        <attribute name="data-oe-shape-data"/>
     </xpath>
-    <!-- Shape -->
-    <xpath expr="//*[hasclass('container')]" position="before">
-        <div class="o_we_shape o_web_editor_Floats_12"/>
-    </xpath>
+    <!-- Remove shape -->
+    <xpath expr="//div[hasclass('o_we_shape')]" position="replace"/>
 </template>
+
+<!-- Snippet customization Gallery Pages -->
 
 <template id="new_page_template_gallery_s_cover" inherit_id="website.new_page_template_gallery_s_cover">
     <xpath expr="//section" position="attributes">

--- a/theme_treehouse/views/snippets/s_banner.xml
+++ b/theme_treehouse/views/snippets/s_banner.xml
@@ -5,21 +5,15 @@
     <!-- Section -->
     <xpath expr="//section" position="attributes">
         <attribute name="class" add="o_cc o_cc3" separator=" "/>
-    </xpath>
-    <!-- Title -->
-    <xpath expr="//h1" position="replace" mode="inner">
-        Hello Planet.
-    </xpath>
-</template>
-
-<template id="configurator_s_banner" inherit_id="website.configurator_s_banner">
-    <!-- Shape option -->
-    <xpath expr="//section" position="attributes">
         <attribute name="data-oe-shape-data">{"shape":"web_editor/Floats/12"}</attribute>
     </xpath>
     <!-- Shape -->
     <xpath expr="//*[hasclass('container')]" position="before">
         <div class="o_we_shape o_web_editor_Floats_12"/>
+    </xpath>
+    <!-- Title -->
+    <xpath expr="//h1" position="replace" mode="inner">
+        Hello Planet.
     </xpath>
 </template>
 

--- a/theme_treehouse/views/snippets/s_call_to_action.xml
+++ b/theme_treehouse/views/snippets/s_call_to_action.xml
@@ -5,6 +5,11 @@
     <!-- Section -->
     <xpath expr="//section" position="attributes">
         <attribute name="class" add="pt80 pb48" remove="pt48 pb24" separator=" "/>
+        <attribute name="data-oe-shape-data">{"shape":"web_editor/Rainy/08_001"}</attribute>
+    </xpath>
+    <!-- Shape -->
+    <xpath expr="//div[hasclass('container')]" position="before">
+        <div class="o_we_shape o_web_editor_Rainy_08_001"/>
     </xpath>
     <!-- Column #01 -->
     <xpath expr="//div[hasclass('row')]/*[1]" position="attributes">
@@ -22,17 +27,6 @@
     </xpath>
     <xpath expr="(//p)[2]" position="attributes">
         <attribute name="style">text-align: center;</attribute>
-    </xpath>
-</template>
-
-<template id="configurator_s_call_to_action" inherit_id="website.configurator_s_call_to_action">
-    <!-- Shape option -->
-    <xpath expr="//section" position="attributes">
-        <attribute name="data-oe-shape-data">{"shape":"web_editor/Rainy/08_001"}</attribute>
-    </xpath>
-    <!-- Shape -->
-    <xpath expr="//div[hasclass('container')]" position="before">
-        <div class="o_we_shape o_web_editor_Rainy_08_001"/>
     </xpath>
 </template>
 

--- a/theme_vehicle/views/customizations.xml
+++ b/theme_vehicle/views/customizations.xml
@@ -139,6 +139,11 @@
     <!-- Section -->
     <xpath expr="//section" position="attributes">
         <attribute name="class" add="o_cc5 pt96 pb64" remove="o_cc3 pt48 pb24" separator=" "/>
+        <attribute name="data-oe-shape-data">{"shape":"web_editor/Floats/09","flip":[]}</attribute>
+    </xpath>
+    <!-- Shape -->
+    <xpath expr="//div[hasclass('container')]" position="before">
+        <div class="o_we_shape o_web_editor_Floats_09"/>
     </xpath>
     <!-- Content -->
     <xpath expr="//h3" position="replace" mode="inner">
@@ -155,17 +160,6 @@
     </xpath>
     <xpath expr="//a" position="attributes">
         <attribute name="class" remove="btn-lg" separator=" "/>
-    </xpath>
-</template>
-
-<template id="configurator_s_call_to_action" inherit_id="website.configurator_s_call_to_action" name="Vehicle s_call_to_action">
-    <!-- Shape option -->
-    <xpath expr="//section" position="attributes">
-        <attribute name="data-oe-shape-data">{"shape":"web_editor/Floats/09","flip":[]}</attribute>
-    </xpath>
-    <!-- Shape -->
-    <xpath expr="//div[hasclass('container')]" position="before">
-        <div class="o_we_shape o_web_editor_Floats_09"/>
     </xpath>
 </template>
 

--- a/theme_vehicle/views/new_page_template.xml
+++ b/theme_vehicle/views/new_page_template.xml
@@ -17,50 +17,6 @@
 
 <!-- General customizations -->
 
-<template id="new_page_template_s_call_to_action" inherit_id="website.new_page_template_s_call_to_action">
-    <!-- Shape option -->
-    <xpath expr="//section" position="attributes">
-        <attribute name="data-oe-shape-data">{"shape":"web_editor/Floats/09","flip":[]}</attribute>
-    </xpath>
-    <!-- Shape -->
-    <xpath expr="//div[hasclass('container')]" position="before">
-        <div class="o_we_shape o_web_editor_Floats_09"/>
-    </xpath>
-</template>
-
-<template id="new_page_template_s_call_to_action_about" inherit_id="website.new_page_template_s_call_to_action_about">
-    <!-- Shape option -->
-    <xpath expr="//section" position="attributes">
-        <attribute name="data-oe-shape-data">{"shape":"web_editor/Floats/09","flip":[]}</attribute>
-    </xpath>
-    <!-- Shape -->
-    <xpath expr="//div[hasclass('container')]" position="before">
-        <div class="o_we_shape o_web_editor_Floats_09"/>
-    </xpath>
-</template>
-
-<template id="new_page_template_s_call_to_action_digital" inherit_id="website.new_page_template_s_call_to_action_digital">
-    <!-- Shape option -->
-    <xpath expr="//section" position="attributes">
-        <attribute name="data-oe-shape-data">{"shape":"web_editor/Floats/09","flip":[]}</attribute>
-    </xpath>
-    <!-- Shape -->
-    <xpath expr="//div[hasclass('container')]" position="before">
-        <div class="o_we_shape o_web_editor_Floats_09"/>
-    </xpath>
-</template>
-
-<template id="new_page_template_s_call_to_action_menu" inherit_id="website.new_page_template_s_call_to_action_menu">
-    <!-- Shape option -->
-    <xpath expr="//section" position="attributes">
-        <attribute name="data-oe-shape-data">{"shape":"web_editor/Floats/09","flip":[]}</attribute>
-    </xpath>
-    <!-- Shape -->
-    <xpath expr="//div[hasclass('container')]" position="before">
-        <div class="o_we_shape o_web_editor_Floats_09"/>
-    </xpath>
-</template>
-
 <template id="new_page_template_s_references" inherit_id="website.new_page_template_s_references">
     <xpath expr="//section" position="attributes">
         <attribute name="data-oe-shape-data">{"shape":"web_editor/Origins/05","flip":[]}</attribute>

--- a/theme_yes/views/new_page_template.xml
+++ b/theme_yes/views/new_page_template.xml
@@ -11,15 +11,49 @@
 
 <!-- General customizations -->
 
-<template id="new_page_template_s_images_wall" inherit_id="website.new_page_template_s_images_wall">
-    <!-- Shape option -->
+<template id="new_page_template_s_image_gallery" inherit_id="website.new_page_template_s_image_gallery">
+    <!-- Remove shape option -->
     <xpath expr="//section" position="attributes">
-        <attribute name="data-oe-shape-data">{"shape":"web_editor/Floats/12"}</attribute>
+        <attribute name="data-oe-shape-data"/>
     </xpath>
-    <!-- Shape -->
-    <xpath expr="//*[hasclass('container')]" position="before">
-        <div class="o_we_shape o_web_editor_Floats_12"/>
+    <!-- Remove shape -->
+    <xpath expr="//div[hasclass('o_we_shape')]" position="replace"/>
+</template>
+
+<template id="new_page_template_s_media_list" inherit_id="website.new_page_template_s_media_list">
+    <!-- Remove shape option -->
+    <xpath expr="//section" position="attributes">
+        <attribute name="data-oe-shape-data"/>
     </xpath>
+    <!-- Remove shape -->
+    <xpath expr="//div[hasclass('o_we_shape')]" position="replace"/>
+</template>
+
+<template id="new_page_template_s_three_columns" inherit_id="website.new_page_template_s_three_columns">
+    <!-- Remove shape option -->
+    <xpath expr="//section" position="attributes">
+        <attribute name="data-oe-shape-data"/>
+    </xpath>
+    <!-- Remove shape -->
+    <xpath expr="//div[hasclass('o_we_shape')]" position="replace"/>
+</template>
+
+<template id="new_page_template_s_three_columns_2nd" inherit_id="website.new_page_template_s_three_columns_2nd">
+    <!-- Remove shape option -->
+    <xpath expr="//section" position="attributes">
+        <attribute name="data-oe-shape-data"/>
+    </xpath>
+    <!-- Remove shape -->
+    <xpath expr="//div[hasclass('o_we_shape')]" position="replace"/>
+</template>
+
+<template id="new_page_template_s_three_columns_menu" inherit_id="website.new_page_template_s_three_columns_menu">
+    <!-- Remove shape option -->
+    <xpath expr="//section" position="attributes">
+        <attribute name="data-oe-shape-data"/>
+    </xpath>
+    <!-- Remove shape -->
+    <xpath expr="//div[hasclass('o_we_shape')]" position="replace"/>
 </template>
 
 <!-- Snippet customization Basic Pages -->

--- a/theme_yes/views/snippets/s_image_gallery.xml
+++ b/theme_yes/views/snippets/s_image_gallery.xml
@@ -5,6 +5,11 @@
     <!-- Section -->
     <xpath expr="//section" position="attributes">
         <attribute name="class" add="s_image_gallery_indicators_dots" remove="s_image_gallery_indicators_rounded" separator=" "/>
+        <attribute name="data-oe-shape-data">{"shape":"web_editor/Floats/12", "flip":[]}</attribute>
+    </xpath>
+    <!-- Shape -->
+    <xpath expr="//*[hasclass('container')]" position="before">
+        <div class="o_we_shape o_web_editor_Floats_12"/>
     </xpath>
     <!-- Container -->
     <xpath expr="//*[hasclass('container')]" position="attributes">

--- a/theme_yes/views/snippets/s_images_wall.xml
+++ b/theme_yes/views/snippets/s_images_wall.xml
@@ -2,6 +2,14 @@
 <odoo>
 
 <template id="s_images_wall" inherit_id="website.s_images_wall">
+    <!-- Shape option -->
+    <xpath expr="//section" position="attributes">
+        <attribute name="data-oe-shape-data">{"shape":"web_editor/Floats/12"}</attribute>
+    </xpath>
+    <!-- Shape -->
+    <xpath expr="//*[hasclass('container')]" position="before">
+        <div class="o_we_shape o_web_editor_Floats_12"/>
+    </xpath>
     <!-- Images -->
     <xpath expr="//img" position="attributes">
         <attribute name="class" add="rounded" separator=" "/>
@@ -20,17 +28,6 @@
     </xpath>
     <xpath expr="(//img)[6]" position="attributes">
         <attribute name="class" add="rounded" separator=" "/>
-    </xpath>
-</template>
-
-<template id="configurator_s_images_wall" inherit_id="website.configurator_s_images_wall">
-    <!-- Shape option -->
-    <xpath expr="//section" position="attributes">
-        <attribute name="data-oe-shape-data">{"shape":"web_editor/Floats/12"}</attribute>
-    </xpath>
-    <!-- Shape -->
-    <xpath expr="//*[hasclass('container')]" position="before">
-        <div class="o_we_shape o_web_editor_Floats_12"/>
     </xpath>
 </template>
 

--- a/theme_yes/views/snippets/s_media_list.xml
+++ b/theme_yes/views/snippets/s_media_list.xml
@@ -5,6 +5,11 @@
     <!-- Section -->
     <xpath expr="//section" position="attributes">
         <attribute name="class" add="pt64 pb64 o_cc1" remove="pt32 pb32 o_cc2" separator=" "/>
+        <attribute name="data-oe-shape-data">{"shape":"web_editor/Floats/12","flip":[]}</attribute>
+    </xpath>
+    <!-- Shape -->
+    <xpath expr="//div[hasclass('container')]" position="before">
+        <div class="o_we_shape o_web_editor_Floats_12"/>
     </xpath>
     <!-- Row #1 -->
     <xpath expr="//div[hasclass('s_media_list_item')]" position="attributes">
@@ -62,17 +67,6 @@
     <!-- Row #3 - Image -->
     <xpath expr="(//div[hasclass('s_media_list_item')])[3]//div[hasclass('s_media_list_img_wrapper')]" position="attributes">
         <attribute name="class" add="col-lg-3" remove="col-lg-4" separator=" "/>
-    </xpath>
-</template>
-
-<template id="configurator_s_media_list" inherit_id="website.configurator_s_media_list">
-    <!-- Shape option -->
-    <xpath expr="//section" position="attributes">
-        <attribute name="data-oe-shape-data">{"shape":"web_editor/Floats/12","flip":[]}</attribute>
-    </xpath>
-    <!-- Shape -->
-    <xpath expr="//div[hasclass('container')]" position="before">
-        <div class="o_we_shape o_web_editor_Floats_12"/>
     </xpath>
 </template>
 

--- a/theme_yes/views/snippets/s_three_columns.xml
+++ b/theme_yes/views/snippets/s_three_columns.xml
@@ -5,6 +5,11 @@
     <!-- Section -->
     <xpath expr="//section" position="attributes">
         <attribute name="class" add="o_cc5" remove="o_cc2" separator=" "/>
+        <attribute name="data-oe-shape-data">{"shape":"web_editor/Origins/18"}</attribute>
+    </xpath>
+    <!-- Shape -->
+    <xpath expr="//*[hasclass('container')]" position="before">
+        <div class="o_we_shape o_web_editor_Origins_18"/>
     </xpath>
     <!-- Column 1 -->
     <xpath expr="//*[hasclass('card-title')]" position="replace" mode="inner">
@@ -17,17 +22,6 @@
     <!-- Column 3 -->
     <xpath expr="(//*[hasclass('card-title')])[3]" position="replace" mode="inner">
         Make up &amp;amp; Hair
-    </xpath>
-</template>
-
-<template id="configurator_s_three_columns" inherit_id="website.configurator_s_three_columns">
-    <!-- Shape option -->
-    <xpath expr="//section" position="attributes">
-        <attribute name="data-oe-shape-data">{"shape":"web_editor/Origins/18"}</attribute>
-    </xpath>
-    <!-- Shape -->
-    <xpath expr="//*[hasclass('container')]" position="before">
-        <div class="o_we_shape o_web_editor_Origins_18"/>
     </xpath>
 </template>
 


### PR DESCRIPTION
In [1] all shapes were moved from the base snippet to the specific
configurator snippet. This was a bit overkill.

This commit reverts this partially so that only shapes that connect
with each other are specific to the configurator, but "intra-block"
shapes are restored onto the base snippet.
The "New page from template" snippets are adapted accordingly in order
to produce the same output as before this commit.

[1]: https://github.com/odoo/design-themes/commit/d206c119720d557c11320ebb3d7339890b8f9efa

task-3555325