### PR TITLE
[FIX] theme_*: remove duplicate and conflicting classes

### DIFF
--- a/test_themes/tests/__init__.py
+++ b/test_themes/tests/__init__.py
@@ -2,4 +2,5 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
 from . import test_crawl
+from . import test_new_page_templates
 from . import test_theme_upgrade

--- a/test_themes/tests/test_new_page_templates.py
+++ b/test_themes/tests/test_new_page_templates.py
@@ -1,0 +1,208 @@
+# -*- coding: utf-8 -*-
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+from lxml import html
+
+import logging
+import re
+
+from odoo.addons.website.tools import MockRequest
+from odoo.tests import tagged, TransactionCase
+from odoo.tools import escape_psql
+
+_logger = logging.getLogger(__name__)
+
+CONFLICTUAL_CLASSES = [
+    ['btn-outline-primary', 'btn-primary', 'btn-secondary'],
+    ['btn-block', 'btn-outline-primary'],
+    ['container', 'container-fluid', 'o_container_small'],
+    ['d-block', 'd-flex', 'd-inline-block', 'd-none'],
+    ['d-block', 'd-lg-block', 'd-md-block'],
+    ['d-flex', 'd-md-flex'],
+    ['flex-column', 'flex-column-reverse', 'flex-row', 'flex-row-reverse'],
+    ['g-0', 'g-col-lg-2', 'g-col-lg-3', 'g-col-lg-4', 'g-col-lg-5', 'g-col-lg-6'],
+    ['g-0', 'g-height-5', 'g-height-8', 'g-height-10'],
+    ['h-100', 'o_half_screen_height', 'o_full_screen_height'],
+    ['justify-content-center', 'justify-content-start'],
+    ['nav-link', 'nav-pills', 'nav-tabs'],
+    ['o_cc1', 'o_cc2', 'o_cc3', 'o_cc4', 'o_cc5'],
+    ['o_spc-medium', 'o_spc-none', 'o_spc-small'],
+    ['oi-arrows-h', 'oi-arrows-v', 'oi-chevron-left', 'oi-chevron-right', 'oi-search'],
+    ['position-absolute', 'position-relative'],
+    ['s_carousel_bordered', 's_carousel_default', 's_carousel_rounded'],
+    ['s_image_gallery_indicators_arrows_boxed', 's_image_gallery_indicators_arrows_rounded'],
+    ['text-center', 'text-end', 'text-start'],
+]
+
+# For each RE, associates a whitelist
+CONFLICTUAL_CLASSES_RE = {
+    # Align
+    re.compile(r'^align-(?!(self|items)-).+'): [],
+    re.compile(r'^align-self-.+'): [],
+    re.compile(r'^align-items-.+'): [],
+    # BG
+    re.compile(r'^bg(-|_)'): [
+        'bg_option_menu_gradient',
+    ],
+    # Col
+    re.compile(r'^col-\d+$'): [],
+    re.compile(r'^col-lg-.+'): [],
+    re.compile(r'^offset-\d+$'): [],
+    re.compile(r'^offset-lg-.+'): [],
+    # Display
+    re.compile(r'^display-\d$'): [],
+    re.compile(r'^display-\d-fs$'): [],
+    # Margin, padding
+    re.compile(r'^m-(\d|auto)$'): [],
+    re.compile(r'^m(x|s)-\d$'): [],
+    re.compile(r'^m(x|e)-\d$'): [],
+    re.compile(r'^m(y|t)-\d$'): [],
+    re.compile(r'^m(y|b)-\d$'): [],
+    re.compile(r'^(p(x|s)?-?\d+|padding-.+)$'): [],
+    re.compile(r'^(p(x|e)?-?\d+|padding-.+)$'): [],
+    re.compile(r'^(p(y|t)?-?\d+|padding-.+)$'): [],
+    # p0+pb32 appears in Bewise and Graphene
+    re.compile(r'^(p(y|b)?-?\d+|padding-.+)$'): ['p0'],
+    # Font awesome
+    re.compile(r'^fa-\dx$'): [],
+    re.compile(r'^fa-...+'): [],
+    # Rounded
+    re.compile(r'^rounded-.+'): [],
+    # Shadow
+    re.compile(r'^shadow-.+'): [],
+    # Shapes
+    re.compile(r'^o_web_editor_[A-Z].+'): [],
+    # Snippets
+    re.compile(r'^s_.*'): [
+        's_alert_md',
+        's_blockquote_classic',
+        's_carousel_bordered', 's_carousel_default', 's_carousel_rounded',
+        's_dynamic', 's_dynamic_empty', 's_dynamic_snippet_blog_posts',
+        's_blog_posts_effect_marley', 's_blog_post_big_picture',
+        's_col_no_bgcolor', 's_col_no_resize',
+        's_event_upcoming_snippet',
+        's_image_gallery_cover', 's_image_gallery_indicators_arrows_boxed', 's_image_gallery_indicators_arrows_rounded',
+        's_image_gallery_indicators_dots', 's_image_gallery_indicators_rounded', 's_image_gallery_show_indicators',
+        's_newsletter_list', 's_newsletter_subscribe_form',
+        's_parallax_is_fixed', 's_parallax_no_overflow_hidden',
+        's_process_steps_connector_line',
+        's_product_catalog_dish_name', 's_product_catalog_dish_dot_leaders',
+        's_table_of_content_vertical_navbar', 's_table_of_content_navbar_sticky', 's_table_of_content_navbar_wrap',
+        's_timeline_card',
+        's_website_form_custom', 's_website_form_dnone', 's_website_form_field', 's_website_form_input', 's_website_form_mark',
+    ],
+    # Text
+    re.compile(r'^text-(?!(center|end|start|bg-|lg-)).*$'): [
+        'text-break',
+    ],
+    re.compile(r'^text-bg-.*$'): [],
+    re.compile(r'^text-lg-.*$'): [],
+    # Width
+    re.compile(r'^w-\d*$'): [],
+}
+
+
+@tagged('post_install', '-at_install')
+class TestNewPageTemplates(TransactionCase):
+
+    def test_template_names(self):
+        websites_themes = self.env['website'].get_test_themes_websites()
+        for website in websites_themes:
+            views = self.env['ir.ui.view'].search([
+                ('key', 'like', f'{website.theme_id.name}.new_page_template%_s_'),
+            ])
+            if website.theme_id.name != 'theme_default':
+                self.assertGreater(len(views), 10, "Test should have encountered some views in theme %r" % website.name)
+            for view in views:
+                self.assertEqual(view.mode, 'extension', "Theme's new page template customization %r should never be primary" % view.key)
+                name = view.key.split('.')[1]
+                parent_name = view.inherit_id.key.split('.')[1]
+                self.assertEqual(name, parent_name, "Theme's new page template customization %r should use the same name as their parent %r" % (view.key, view.inherit_id.key))
+
+    def test_render_templates(self):
+        errors = []
+        view_ids = set()
+        websites_themes = self.env['website'].get_test_themes_websites()
+        for website in websites_themes:
+            with MockRequest(self.env, website=website):
+                views = self.env['ir.ui.view'].search([
+                    '|', '|',
+                    ('key', 'like', f'{website.theme_id.name}.s_'),
+                    ('key', 'like', f'{website.theme_id.name}.configurator'),
+                    ('key', 'like', f'{website.theme_id.name}.new_page'),
+                ])
+                view_ids.update(views.ids)
+                for view in views:
+                    try:
+                        self.env['ir.qweb']._render(view.id)
+                    except Exception:
+                        errors.append("View %s cannot be rendered" % view.key)
+        _logger.info("Tested %s views", len(view_ids))
+        self.assertGreater(len(view_ids), 1250, "Test should have encountered a lot of views")
+        self.assertFalse(errors, "No error should have been collected")
+
+    def test_render_applied_templates(self):
+        View = self.env['ir.ui.view']
+        errors = []
+        classes_inventory = set()
+        view_count = 0
+
+        def check(theme_name, website):
+            with MockRequest(self.env, website=website):
+                views = View.search([
+                    '|', '|',
+                    ('key', 'in', [
+                        'website.snippets',
+                        'website.new_page_template_groups',
+                    ]),
+                    ('key', 'like', escape_psql('website.configurator_')),
+                    ('key', 'like', escape_psql('website.new_page_template_sections_')),
+                ])
+                for view in views:
+                    try:
+                        # TODO: Improve the perfs of the next line
+                        #       Doesn't seem to be a way to avoid one RECURSIVE
+                        #       SQL Query from `_get_inheriting_views` per view
+                        html_text = self.env['ir.qweb']._render(view.id)
+                        if not html_text:
+                            continue
+                        html_tree = html.fromstring(html_text)
+                        blocks_el = html_tree.xpath("//*[@id='o_scroll']")
+                        if blocks_el:
+                            # Only look at blocks in website.snippets
+                            html_tree = blocks_el[0]
+                        for el in html_tree.xpath('//*[@class]'):
+                            classes = el.attrib['class'].split(' ')
+                            classes_inventory.update(classes)
+                            if len(classes) != len(set(classes)):
+                                errors.append("Using %r, view %r contains duplicate classes: %r" % (theme_name, view.key, classes))
+                            for conflicting_classes in CONFLICTUAL_CLASSES:
+                                conflict = set(classes).intersection(conflicting_classes)
+                                if len(conflict) > 1:
+                                    errors.append("Using %r, view %r contains conflicting classes: %r in %r" % (theme_name, view.key, conflict, classes))
+                            for conflicting_classes_re in CONFLICTUAL_CLASSES_RE:
+                                conflict = {cl for cl in filter(conflicting_classes_re.findall, set(classes))}
+                                white_list = CONFLICTUAL_CLASSES_RE[conflicting_classes_re]
+                                conflict.difference_update(white_list)
+                                if len(conflict) > 1:
+                                    errors.append("Using %r, view %r contains conflicting classes: %r in %r (according to pattern %r)" % (theme_name, view.key, conflict, classes, conflicting_classes_re.pattern))
+                    except Exception:
+                        _logger.error("Using %r, view %r cannot be rendered", theme_name, view.key)
+                        errors.append("Using %r, view %r cannot be rendered" % (theme_name, view.key))
+                return len(views)
+
+        view_count += check('no theme', self.env.ref('website.default_website'))
+        websites_themes = self.env['website'].get_test_themes_websites()
+        for website in websites_themes:
+            view_count += check(website.name, website)
+        _logger.info("Tested %s views", view_count)
+        self.assertGreater(view_count, 2900, "Test should have checked many views")
+        # Use this information to potentially update known possible conflicts.
+        for known_classes in CONFLICTUAL_CLASSES:
+            classes_inventory.difference_update(known_classes)
+        for known_classes in CONFLICTUAL_CLASSES_RE.values():
+            classes_inventory.difference_update(known_classes)
+        for known_classes_re in CONFLICTUAL_CLASSES_RE:
+            classes_inventory = [cl for cl in filter(lambda cl: not known_classes_re.findall(cl), classes_inventory)]
+        _logger.info("Unknown classes encountered: %r", sorted(list(classes_inventory)))
+        self.assertFalse(errors, "No error should have been collected")

--- a/theme_anelusia/views/new_page_template.xml
+++ b/theme_anelusia/views/new_page_template.xml
@@ -27,15 +27,9 @@
 
 <!-- Snippet customization About Pages -->
 
-<template id="new_page_template_about_s_text_block_h1" inherit_id="website.new_page_template_about_s_text_block_h1">
-    <xpath expr="//section" position="attributes">
-        <attribute name="class" add="pb0" remove="pb40" separator=" "/>
-    </xpath>
-</template>
-
 <template id="new_page_template_about_full_1_s_text_block_h1" inherit_id="website.new_page_template_about_full_1_s_text_block_h1">
     <xpath expr="//section" position="attributes">
-        <attribute name="class" add="pb0 pb0 pt40" remove="pb40 pt40" separator=" "/>
+        <attribute name="class" add="pb0" remove="pb40" separator=" "/>
     </xpath>
 </template>
 
@@ -51,9 +45,21 @@
     </xpath>
 </template>
 
+<template id="new_page_template_about_mini_s_cover" inherit_id="website.new_page_template_about_mini_s_cover">
+    <xpath expr="//section" position="attributes">
+        <attribute name="class" remove="pt40 pb40" separator=" "/>
+    </xpath>
+</template>
+
+<template id="new_page_template_about_full_s_numbers" inherit_id="website.new_page_template_about_full_s_numbers">
+    <xpath expr="//section" position="attributes">
+        <attribute name="class" remove="o_cc3" separator=" "/>
+    </xpath>
+</template>
+
 <template id="new_page_template_about_personal_s_numbers" inherit_id="website.new_page_template_about_personal_s_numbers">
     <xpath expr="//section" position="attributes">
-        <attribute name="class" remove="o_half_screen_height" separator=" "/>
+        <attribute name="class" remove="o_cc3 o_half_screen_height" separator=" "/>
     </xpath>
 </template>
 
@@ -65,15 +71,22 @@
 
 <!-- Snippet customization Landing Pages -->
 
-<template id="new_page_template_landing_2_s_cover" inherit_id="website.new_page_template_landing_2_s_cover">
+<template id="new_page_template_landing_0_s_cover" inherit_id="website.new_page_template_landing_0_s_cover">
     <xpath expr="//section" position="attributes">
-        <attribute name="class" add="o_half_screen_height" remove="o_full_screen_height" separator=" "/>
+        <attribute name="class" remove="pt128 pb128" separator=" "/>
+    </xpath>
+</template>
+
+<template id="new_page_template_landing_4_s_cover" inherit_id="website.new_page_template_landing_4_s_cover">
+    <xpath expr="//section" position="attributes">
+        <!-- Added by both theme and new page template -->
+        <attribute name="class" add="o_half_screen_height" remove="o_half_screen_height" separator=" "/>
     </xpath>
 </template>
 
 <template id="new_page_template_landing_2_s_three_columns" inherit_id="website.new_page_template_landing_2_s_three_columns">
     <xpath expr="//section" position="attributes">
-        <attribute name="class" add="o_cc2" remove="o_cc3" separator=" "/>
+        <attribute name="class" add="o_cc2" remove="o_cc1" separator=" "/>
     </xpath>
 </template>
 
@@ -85,21 +98,9 @@
 
 <!-- Snippet customization Gallery Pages -->
 
-<template id="new_page_template_gallery_s_cover" inherit_id="website.new_page_template_gallery_s_cover">
-    <xpath expr="//section" position="attributes">
-        <attribute name="class" add="o_half_screen_height" remove="o_full_screen_height" separator=" "/>
-    </xpath>
-</template>
-
 <!-- Snippet customization Services Pages -->
 
 <!-- Snippet customization Pricing Pages -->
-
-<template id="new_page_template_pricing_s_cover" inherit_id="website.new_page_template_pricing_s_cover">
-    <xpath expr="//section" position="attributes">
-        <attribute name="class" add="o_half_screen_height" remove="o_full_screen_height" separator=" "/>
-    </xpath>
-</template>
 
 <template id="new_page_template_pricing_s_showcase" inherit_id="website.new_page_template_pricing_s_showcase">
     <!-- Remove shape option -->

--- a/theme_anelusia/views/snippets/s_call_to_action.xml
+++ b/theme_anelusia/views/snippets/s_call_to_action.xml
@@ -34,9 +34,6 @@
     <xpath expr="(//p)[2]" position="attributes">
         <attribute name="style">text-align: center;</attribute>
     </xpath>
-    <xpath expr="//a[hasclass('btn')]" position="attributes">
-        <attribute name="class" add="btn-lg" separator=" "/>
-    </xpath>
     <xpath expr="//a[hasclass('btn')]/t" position="replace" mode="inner">
         Discover it
     </xpath>

--- a/theme_anelusia/views/snippets/s_company_team.xml
+++ b/theme_anelusia/views/snippets/s_company_team.xml
@@ -4,7 +4,7 @@
 <template id="s_company_team" inherit_id="website.s_company_team">
     <!-- Section -->
     <xpath expr="section" position="attributes">
-        <attribute name="class" add="pt64 pb64" remove="pt48 pb24" separator=" "/>
+        <attribute name="class" add="pt64 pb64" remove="pt48 pb48" separator=" "/>
     </xpath>
 
     <!-- Team #01 -->

--- a/theme_artists/views/new_page_template.xml
+++ b/theme_artists/views/new_page_template.xml
@@ -42,6 +42,24 @@
     </xpath>
 </template>
 
+<template id="new_page_template_s_comparisons" inherit_id="website.new_page_template_s_comparisons">
+    <xpath expr="(//div[hasclass('card')])[3]" position="attributes">
+        <attribute name="class" add="bg-o-color-2" remove="bg-o-color-1" separator=" "/>
+    </xpath>
+</template>
+
+<template id="new_page_template_s_features_grid" inherit_id="website.new_page_template_s_features_grid">
+    <xpath expr="(//i)[4]" position="attributes">
+        <attribute name="class" add="bg-o-color-2" remove="bg-o-color-1" separator=" "/>
+    </xpath>
+    <xpath expr="(//i)[5]" position="attributes">
+        <attribute name="class" add="bg-o-color-2" remove="bg-o-color-1" separator=" "/>
+    </xpath>
+    <xpath expr="(//i)[6]" position="attributes">
+        <attribute name="class" add="bg-o-color-2" remove="bg-o-color-1" separator=" "/>
+    </xpath>
+</template>
+
 <template id="new_page_template_s_numbers" inherit_id="website.new_page_template_s_numbers">
     <!-- Shape option -->
     <xpath expr="//section" position="attributes">
@@ -76,13 +94,13 @@
 
 <template id="new_page_template_about_s_cover" inherit_id="website.new_page_template_about_s_cover">
     <xpath expr="//section" position="attributes">
-        <attribute name="class" add="o_half_screen_height" remove="o_full_screen_height" separator=" "/>
+        <attribute name="class" add="o_half_screen_height" remove="o_full_screen_height pt40 pb40" separator=" "/>
     </xpath>
 </template>
 
 <template id="new_page_template_about_s_text_block_h1" inherit_id="website.new_page_template_about_s_text_block_h1">
     <xpath expr="//section" position="attributes">
-        <attribute name="class" add="pb0 o_cc5" remove="pb40" separator=" "/>
+        <attribute name="class" add="o_cc5" separator=" "/>
     </xpath>
 </template>
 
@@ -92,9 +110,27 @@
     </xpath>
 </template>
 
+<template id="new_page_template_about_full_s_image_text" inherit_id="website.new_page_template_about_full_s_image_text">
+    <xpath expr="//section" position="attributes">
+        <attribute name="class" remove="pt48" separator=" "/>
+    </xpath>
+</template>
+
+<template id="new_page_template_about_full_s_numbers" inherit_id="website.new_page_template_about_full_s_numbers">
+    <xpath expr="//section" position="attributes">
+        <attribute name="class" remove="o_cc3" separator=" "/>
+    </xpath>
+</template>
+
+<template id="new_page_template_about_full_s_text_image" inherit_id="website.new_page_template_about_full_s_text_image">
+    <xpath expr="//section" position="attributes">
+        <attribute name="class" remove="pb56" separator=" "/>
+    </xpath>
+</template>
+
 <template id="new_page_template_about_full_1_s_text_block_h1" inherit_id="website.new_page_template_about_full_1_s_text_block_h1">
     <xpath expr="//section" position="attributes">
-        <attribute name="class" add="pb0 o_cc4" remove="pb40 o_cc5" separator=" "/>
+        <attribute name="class" add="o_cc4" remove="o_cc5" separator=" "/>
     </xpath>
 </template>
 
@@ -116,9 +152,15 @@
     </xpath>
 </template>
 
+<template id="new_page_template_about_personal_s_numbers" inherit_id="website.new_page_template_about_personal_s_numbers">
+    <xpath expr="//section" position="attributes">
+        <attribute name="class" remove="o_cc3 pt0" separator=" "/>
+    </xpath>
+</template>
+
 <template id="new_page_template_about_personal_s_text_block_h2" inherit_id="website.new_page_template_about_personal_s_text_block_h2">
     <xpath expr="//section" position="attributes">
-        <attribute name="class" add="o_cc5" separator=" "/>
+        <attribute name="class" add="o_cc5" remove="o_cc3" separator=" "/>
     </xpath>
 </template>
 
@@ -130,15 +172,21 @@
     </xpath>
 </template>
 
-<template id="new_page_template_landing_2_s_text_block_h2" inherit_id="website.new_page_template_landing_2_s_text_block_h2">
+<template id="new_page_template_landing_s_text_image" inherit_id="website.new_page_template_landing_s_text_image">
     <xpath expr="//section" position="attributes">
-        <attribute name="class" add="o_cc4" remove="o_cc2" separator=" "/>
+        <attribute name="class" remove="pb56" separator=" "/>
     </xpath>
 </template>
 
-<template id="new_page_template_landing_2_s_three_columns" inherit_id="website.new_page_template_landing_2_s_three_columns">
+<template id="new_page_template_landing_0_s_cover" inherit_id="website.new_page_template_landing_0_s_cover">
     <xpath expr="//section" position="attributes">
-        <attribute name="class" add="o_cc2" remove="o_cc3" separator=" "/>
+        <attribute name="class" remove="pt200 pb200" separator=" "/>
+    </xpath>
+</template>
+
+<template id="new_page_template_landing_2_s_text_block_h2" inherit_id="website.new_page_template_landing_2_s_text_block_h2">
+    <xpath expr="//section" position="attributes">
+        <attribute name="class" add="o_cc4" remove="o_cc2" separator=" "/>
     </xpath>
 </template>
 
@@ -178,6 +226,12 @@
     </xpath>
 </template>
 
+<template id="new_page_template_gallery_s_image_text_2nd" inherit_id="website.new_page_template_gallery_s_image_text_2nd">
+    <xpath expr="//section" position="attributes">
+        <attribute name="class" remove="pt48" separator=" "/>
+    </xpath>
+</template>
+
 <template id="new_page_template_gallery_s_text_block_2nd" inherit_id="website.new_page_template_gallery_s_text_block_2nd">
     <xpath expr="//section" position="attributes">
        <attribute name="class" add="o_cc5" separator=" "/>
@@ -206,6 +260,7 @@
 <template id="new_page_template_services_s_text_image" inherit_id="website.new_page_template_services_s_text_image">
     <!-- Shape option -->
     <xpath expr="//section" position="attributes">
+        <attribute name="class" remove="pb56" separator=" "/>
         <attribute name="data-oe-shape-data">{"shape":"web_editor/Wavy/04"}</attribute>
     </xpath>
     <!-- Shape -->
@@ -226,6 +281,12 @@
     <!-- Shape option -->
     <xpath expr="//section" position="attributes">
         <attribute name="class" add="o_half_screen_height" remove="o_full_screen_height" separator=" "/>
+    </xpath>
+</template>
+
+<template id="new_page_template_pricing_s_image_text_2nd" inherit_id="website.new_page_template_pricing_s_image_text_2nd">
+    <xpath expr="//section" position="attributes">
+        <attribute name="class" remove="pt48" separator=" "/>
     </xpath>
 </template>
 
@@ -263,6 +324,7 @@
 <template id="new_page_template_team_s_text_image" inherit_id="website.new_page_template_team_s_text_image">
     <!-- Shape option -->
     <xpath expr="//section" position="attributes">
+        <attribute name="class" remove="pb56" separator=" "/>
         <attribute name="data-oe-shape-data">{"shape":"web_editor/Wavy/04"}</attribute>
     </xpath>
     <!-- Shape -->

--- a/theme_artists/views/snippets/s_carousel.xml
+++ b/theme_artists/views/snippets/s_carousel.xml
@@ -42,7 +42,7 @@
 
     <!-- Carousel-item #03 -->
     <xpath expr="//div[hasclass('carousel-item')][3]" position="attributes">
-        <attribute name="class" add="o_cc o_cc5 pt152 pb152" remove="pb112 pt112" separator=" "/>
+        <attribute name="class" add="o_cc o_cc5 pt152 pb152" remove="pb128 pt128" separator=" "/>
     </xpath>
     <!-- Shape & filter -->
     <xpath expr="//div[hasclass('carousel-item')][3]//div[hasclass('container')]" position="before">

--- a/theme_artists/views/snippets/s_comparisons.xml
+++ b/theme_artists/views/snippets/s_comparisons.xml
@@ -28,7 +28,7 @@
     </xpath>
     <!-- Card #3 -->
     <xpath expr="(//div[hasclass('card')])[3]" position="attributes">
-        <attribute name="class" add="bg-o-color-1" remove="bg-secondary" separator=" "/>
+        <attribute name="class" add="bg-o-color-1" remove="bg-o-color-2" separator=" "/>
     </xpath>
     <!-- Card #3 - Button -->
     <xpath expr="(//a[hasclass('btn')])[3]" position="attributes">

--- a/theme_artists/views/snippets/s_features.xml
+++ b/theme_artists/views/snippets/s_features.xml
@@ -13,11 +13,11 @@
     </xpath>
     <!-- Feature #01 - Icon -->
     <xpath expr="//i" position="attributes">
-        <attribute name="class" add="bg-o-color-5" remove="bg-primary" separator=" "/>
+        <attribute name="class" add="bg-o-color-5" remove="bg-o-color-1" separator=" "/>
     </xpath>
     <!-- Feature #03 - Icon -->
     <xpath expr="(//i)[3]" position="attributes">
-        <attribute name="class" add="bg-o-color-5" remove="bg-secondary" separator=" "/>
+        <attribute name="class" add="bg-o-color-5" remove="bg-o-color-2" separator=" "/>
     </xpath>
 </template>
 

--- a/theme_artists/views/snippets/s_features_grid.xml
+++ b/theme_artists/views/snippets/s_features_grid.xml
@@ -17,13 +17,13 @@
         <attribute name="class" add="rounded" remove="rounded-circle" separator=" "/>
     </xpath>
     <xpath expr="(//i)[4]" position="attributes">
-        <attribute name="class" add="bg-o-color-1" remove="bg-secondary" separator=" "/>
+        <attribute name="class" add="bg-o-color-1" remove="bg-o-color-2" separator=" "/>
     </xpath>
     <xpath expr="(//i)[5]" position="attributes">
-        <attribute name="class" add="bg-o-color-1" remove="bg-secondary" separator=" "/>
+        <attribute name="class" add="bg-o-color-1" remove="bg-o-color-2" separator=" "/>
     </xpath>
     <xpath expr="(//i)[6]" position="attributes">
-        <attribute name="class" add="bg-o-color-1" remove="bg-secondary" separator=" "/>
+        <attribute name="class" add="bg-o-color-1" remove="bg-o-color-2" separator=" "/>
     </xpath>
 </template>
 

--- a/theme_artists/views/snippets/s_process_steps.xml
+++ b/theme_artists/views/snippets/s_process_steps.xml
@@ -8,10 +8,10 @@
     </xpath>
     <!-- Icons -->
     <xpath expr="//i" position="attributes">
-        <attribute name="class" add="bg-o-color-5" remove="bg-primary" separator=" "/>
+        <attribute name="class" add="bg-o-color-5" remove="bg-o-color-1" separator=" "/>
     </xpath>
     <xpath expr="(//i)[3]" position="attributes">
-        <attribute name="class" add="bg-o-color-5" remove="bg-secondary" separator=" "/>
+        <attribute name="class" add="bg-o-color-5" remove="bg-o-color-2" separator=" "/>
     </xpath>
     <xpath expr="(//i)[4]" position="attributes">
         <attribute name="class" add="bg-o-color-5" remove="bg-o-color-3" separator=" "/>

--- a/theme_artists/views/snippets/s_three_columns.xml
+++ b/theme_artists/views/snippets/s_three_columns.xml
@@ -4,7 +4,7 @@
 <template id="s_three_columns" inherit_id="website.s_three_columns">
     <!-- Section -->
     <xpath expr="//section" position="attributes">
-        <attribute name="class" add="o_cc4 o_colored_level" remove="o_cc2" separator=" "/>
+        <attribute name="class" add="o_cc4" remove="o_cc2" separator=" "/>
     </xpath>
     <!-- Column #1 -->
     <xpath expr="//div[hasclass('card')]" position="attributes">

--- a/theme_avantgarde/views/customizations.xml
+++ b/theme_avantgarde/views/customizations.xml
@@ -164,7 +164,7 @@
 <template id="s_call_to_action" inherit_id="website.s_call_to_action" name="Avantgarde s_call_to_action">
 
     <xpath expr="//section" position="attributes">
-        <attribute name="class" add="o_cc o_cc3 o_half_screen_height pt0" remove="pt48" separator=" "/>
+        <attribute name="class" add="o_half_screen_height pt0" remove="pt48" separator=" "/>
     </xpath>
     <xpath expr="//h3" position="replace">
         <h3 style="text-align: right;"><b>Since 1992</b> creating around the world.</h3>
@@ -183,9 +183,6 @@
     </xpath>
     <xpath expr="//div[hasclass('col-lg-4')]/p" position="attributes">
         <attribute name="style" add="text-align: left;" remove="text-align: right;" separator=";"/>
-    </xpath>
-    <xpath expr="//a[hasclass('btn')]" position="attributes">
-        <attribute name="class" add="btn-lg" separator=" "/>
     </xpath>
 </template>
 

--- a/theme_aviato/views/new_page_template.xml
+++ b/theme_aviato/views/new_page_template.xml
@@ -28,9 +28,21 @@
     </xpath>
 </template>
 
+<template id="new_page_template_about_full_s_image_text" inherit_id="website.new_page_template_about_full_s_image_text">
+    <xpath expr="//section" position="attributes">
+        <attribute name="class" remove="pb56" separator=" "/>
+    </xpath>
+</template>
+
 <template id="new_page_template_about_full_s_numbers" inherit_id="website.new_page_template_about_full_s_numbers">
     <xpath expr="//section" position="attributes">
         <attribute name="class" remove="o_cc2" separator=" "/>
+    </xpath>
+</template>
+
+<template id="new_page_template_about_mini_s_cover" inherit_id="website.new_page_template_about_mini_s_cover">
+    <xpath expr="//section" position="attributes">
+        <attribute name="class" remove="pb40 pt40" separator=" "/>
     </xpath>
 </template>
 
@@ -41,6 +53,12 @@
 </template>
 
 <!-- Snippet customization Landing Pages -->
+
+<template id="new_page_template_landing_0_s_cover" inherit_id="website.new_page_template_landing_0_s_cover">
+    <xpath expr="//section" position="attributes">
+        <attribute name="class" remove="pt192 pb192" separator=" "/>
+    </xpath>
+</template>
 
 <template id="new_page_template_landing_2_s_cover" inherit_id="website.new_page_template_landing_2_s_cover">
     <xpath expr="//section" position="attributes">  
@@ -90,6 +108,12 @@
     </xpath>
 </template>
 
+<template id="new_page_template_gallery_s_image_text_2nd" inherit_id="website.new_page_template_gallery_s_image_text_2nd">
+    <xpath expr="//section" position="attributes">
+        <attribute name="class" remove="pb56" separator=" "/>
+    </xpath>
+</template>
+
 <!-- Snippet customization Services Pages -->
 
 <!-- Snippet customization Pricing Pages -->
@@ -100,6 +124,12 @@
     </xpath>
     <xpath expr="//div[hasclass('container')]" position="before">
         <div class="o_we_shape o_web_editor_Wavy_21" style="background-image: url('/web_editor/shape/web_editor/Wavy/21.svg?c2=o-color-4&amp;flip=y'); background-position: 50% 100%;"/>
+    </xpath>
+</template>
+
+<template id="new_page_template_pricing_s_image_text_2nd" inherit_id="website.new_page_template_pricing_s_image_text_2nd">
+    <xpath expr="//section" position="attributes">
+        <attribute name="class" remove="pb56" separator=" "/>
     </xpath>
 </template>
 

--- a/theme_beauty/views/new_page_template.xml
+++ b/theme_beauty/views/new_page_template.xml
@@ -41,7 +41,7 @@
 
 <template id="new_page_template_s_cover" inherit_id="website.new_page_template_s_cover">
     <xpath expr="//section" position="attributes">
-        <attribute name="class" add="o_half_screen_height o_cc5" remove="o_full_screen_height" separator=" "/>
+        <attribute name="class" add="o_half_screen_height" remove="o_full_screen_height" separator=" "/>
     </xpath>
 </template>
 
@@ -60,12 +60,6 @@
     <xpath expr="//div[hasclass('o_we_shape')]" position="replace"/>
 </template>
 
-<template id="new_page_template_s_picture_only" inherit_id="website.new_page_template_s_picture_only" primary="True">
-    <xpath expr="//section" position="attributes">
-        <attribute name="class" add="o_cc3" remove="o_cc1" separator=" "/>
-    </xpath>
-</template>
-
 <!-- Snippet customization Basic Pages -->
 
 <template id="new_page_template_basic_2_s_text_block_h1" inherit_id="website.new_page_template_basic_2_s_text_block_h1">
@@ -76,9 +70,9 @@
 
 <!-- Snippet customization About Pages -->
 
-<template id="new_page_template_about_s_cover" inherit_id="website.new_page_template_about_s_cover">
+<template id="new_page_template_about_full_s_numbers" inherit_id="website.new_page_template_about_full_s_numbers">
     <xpath expr="//section" position="attributes">
-        <attribute name="class" add="o_half_screen_height" remove="o_full_screen_height" separator=" "/>
+        <attribute name="class" remove="o_cc3" separator=" "/>
     </xpath>
 </template>
 
@@ -88,9 +82,9 @@
     </xpath>
 </template>
 
-<template id="new_page_template_about_full_s_numbers" inherit_id="website.new_page_template_about_full_s_numbers">
+<template id="new_page_template_about_personal_s_numbers" inherit_id="website.new_page_template_about_personal_s_numbers">
     <xpath expr="//section" position="attributes">
-        <attribute name="class" add="o_cc4" remove="o_cc3" separator=" "/>
+        <attribute name="class" remove="o_cc3" separator=" "/>
     </xpath>
 </template>
 
@@ -105,18 +99,19 @@
     </xpath>
 </template>
 
-<template id="new_page_template_landing_2_s_cover" inherit_id="website.new_page_template_landing_2_s_cover">
-    <xpath expr="//section" position="attributes">
-        <attribute name="class" add="o_half_screen_height" remove="o_full_screen_height" separator=" "/>
-    </xpath>
-</template>
-
 <template id="new_page_template_landing_3_s_call_to_action" inherit_id="website.new_page_template_landing_3_s_call_to_action">
     <xpath expr="//section" position="attributes">
         <attribute name="data-oe-shape-data">{"shape":"web_editor/Rainy/05_001","flip":[]}</attribute>
     </xpath>
     <xpath expr="//div[hasclass('container')]" position="before">
         <div class="o_we_shape o_web_editor_Rainy_05_001"/>
+    </xpath>
+</template>
+
+<template id="new_page_template_landing_4_s_cover" inherit_id="website.new_page_template_landing_4_s_cover">
+    <xpath expr="//section" position="attributes">
+        <!-- Added on all new page template s_cover by theme and on generic landing 4 -->
+        <attribute name="class" add="o_half_screen_height" remove="o_half_screen_height" separator=" "/>
     </xpath>
 </template>
 

--- a/theme_beauty/views/snippets/s_company_team.xml
+++ b/theme_beauty/views/snippets/s_company_team.xml
@@ -4,7 +4,7 @@
 <template id="s_company_team" inherit_id="website.s_company_team">
     <!-- Section -->
     <xpath expr="//section" position="attributes">
-        <attribute name="class" add="o_cc o_cc4 pt80 pb80" separator=" "/>
+        <attribute name="class" add="o_cc o_cc4 pt80 pb80" remove="pb48 pt48" separator=" "/>
     </xpath>
     <!-- Titles -->
     <xpath expr="(//div[hasclass('col-lg-8')])[1]/h4" position="replace" mode="inner">

--- a/theme_bewise/views/customizations.xml
+++ b/theme_bewise/views/customizations.xml
@@ -213,10 +213,6 @@
     <xpath expr="//div[hasclass('col-lg-9')]/p" position="replace" mode="inner">
         Join them and increase your chances to get hired.
     </xpath>
-    <!-- Button -->
-    <xpath expr="//a[hasclass('btn')]" position="attributes">
-        <attribute name="class" add="btn-lg" separator=" "/>
-    </xpath>
 </template>
 
 <!-- ======== TEAM ======== -->
@@ -329,13 +325,13 @@
 <template id="s_features" inherit_id="website.s_features" name="Be Wise s_features">
     <!-- Icons -->
     <xpath expr="//i" position="attributes">
-        <attribute name="class" add="bg-o-color-4" remove="bg-primary" separator=" "/>
+        <attribute name="class" add="bg-o-color-4" remove="bg-o-color-1" separator=" "/>
     </xpath>
     <xpath expr="(//i)[2]" position="attributes">
         <attribute name="class" add="bg-o-color-4" remove="bg-o-color-5" separator=" "/>
     </xpath>
     <xpath expr="(//i)[3]" position="attributes">
-        <attribute name="class" add="bg-o-color-4" remove="bg-secondary" separator=" "/>
+        <attribute name="class" add="bg-o-color-4" remove="bg-o-color-2" separator=" "/>
     </xpath>
 </template>
 
@@ -417,13 +413,13 @@
 <template id="s_features_grid" inherit_id="website.s_features_grid" name="Be Wise s_features_grid">
     <!-- Icons -->
     <xpath expr="//i" position="attributes">
-        <attribute name="class" add="bg-o-color-2" remove="fa-2x bg-primary" separator=" "/>
+        <attribute name="class" add="bg-o-color-2" remove="fa-2x bg-o-color-1" separator=" "/>
     </xpath>
     <xpath expr="(//i)[2]" position="attributes">
-        <attribute name="class" add="bg-o-color-2" remove="fa-2x bg-primary" separator=" "/>
+        <attribute name="class" add="bg-o-color-2" remove="fa-2x bg-o-color-1" separator=" "/>
     </xpath>
     <xpath expr="(//i)[3]" position="attributes">
-        <attribute name="class" add="bg-o-color-2" remove="fa-2x bg-primary" separator=" "/>
+        <attribute name="class" add="bg-o-color-2" remove="fa-2x bg-o-color-1" separator=" "/>
     </xpath>
     <xpath expr="(//i)[4]" position="attributes">
         <attribute name="class" add="rounded-circle" remove="fa-2x rounded" separator=" "/>

--- a/theme_bewise/views/new_page_template.xml
+++ b/theme_bewise/views/new_page_template.xml
@@ -51,9 +51,24 @@
     </xpath>
 </template>
 
+<template id="new_page_template_about_full_s_numbers" inherit_id="website.new_page_template_about_full_s_numbers">
+    <xpath expr="//section" position="attributes">
+        <!-- Added by both theme and new page template -->
+        <attribute name="class" add="o_cc3" remove="o_cc3" separator=" "/>
+    </xpath>
+</template>
+
+<template id="new_page_template_about_mini_s_cover" inherit_id="website.new_page_template_about_mini_s_cover">
+    <xpath expr="//section" position="attributes">
+        <attribute name="class" remove="pt40 pb40" separator=" "/>
+    </xpath>
+</template>
+
 <template id="new_page_template_about_personal_s_numbers" inherit_id="website.new_page_template_about_personal_s_numbers">
     <!-- Remove shape option -->
     <xpath expr="//section" position="attributes">
+        <!-- Added by both theme and new page template -->
+        <attribute name="class" add="o_cc3" remove="o_cc3" separator=" "/>
         <attribute name="data-oe-shape-data"/>
     </xpath>
     <!-- Remove shape -->
@@ -61,6 +76,12 @@
 </template>
 
 <!-- Snippet customization Landing Pages -->
+
+<template id="new_page_template_landing_0_s_cover" inherit_id="website.new_page_template_landing_0_s_cover">
+    <xpath expr="//section" position="attributes">
+        <attribute name="class" remove="pt200 pb200" separator=" "/>
+    </xpath>
+</template>
 
 <template id="new_page_template_landing_1_s_banner" inherit_id="website.new_page_template_landing_1_s_banner">
     <!-- Shape option -->

--- a/theme_bistro/views/new_page_template.xml
+++ b/theme_bistro/views/new_page_template.xml
@@ -24,6 +24,18 @@
     </xpath>
 </template>
 
+<template id="new_page_template_s_text_block_h1" inherit_id="website.new_page_template_s_text_block_h1">
+    <xpath expr="//section" position="attributes">
+        <attribute name="class" remove="pb0" separator=" "/>
+    </xpath>
+</template>
+
+<template id="new_page_template_s_text_block_h2" inherit_id="website.new_page_template_s_text_block_h2">
+    <xpath expr="//section" position="attributes">
+        <attribute name="class" remove="pb0" separator=" "/>
+    </xpath>
+</template>
+
 <template id="new_page_template_s_text_block_h2_contact" inherit_id="website.new_page_template_s_text_block_h2_contact">
     <xpath expr="//section" position="attributes">
         <attribute name="class" remove="pb40 pb80" separator=" "/>
@@ -32,12 +44,17 @@
 
 <!-- Snippet customization Basic Pages -->
 
+<template id="new_page_template_basic_2_s_picture" inherit_id="website.new_page_template_basic_2_s_picture">
+    <xpath expr="//section" position="attributes">
+        <attribute name="class" add="pb0" separator=" "/>
+    </xpath>
+</template>
+
 <template id="new_page_template_basic_2_s_text_block_h1" inherit_id="website.new_page_template_basic_2_s_text_block_h1">
     <xpath expr="//section" position="attributes">
         <attribute name="class" add="o_cc3" remove="o_cc2" separator=" "/>
     </xpath>
 </template>
-
 
 <!-- Snippet customization About Pages -->
 
@@ -66,13 +83,43 @@
 
 <template id="new_page_template_about_s_text_block_h1" inherit_id="website.new_page_template_about_s_text_block_h1">
     <xpath expr="//section" position="attributes">
-        <attribute name="class" remove="pb80" separator=" "/>
+        <attribute name="class" add="pb0" remove="pb80" separator=" "/>
+    </xpath>
+</template>
+
+<template id="new_page_template_about_full_s_numbers" inherit_id="website.new_page_template_about_full_s_numbers">
+    <xpath expr="//section" position="attributes">
+        <attribute name="class" remove="o_cc3" separator=" "/>
+    </xpath>
+</template>
+
+<template id="new_page_template_about_full_s_picture" inherit_id="website.new_page_template_about_full_s_picture">
+    <xpath expr="//section" position="attributes">
+        <attribute name="class" add="pb0" separator=" "/>
+    </xpath>
+</template>
+
+<template id="new_page_template_about_full_s_image_text" inherit_id="website.new_page_template_about_full_s_image_text">
+    <xpath expr="//section" position="attributes">
+        <attribute name="class" remove="pt48 pb56" separator=" "/>
+    </xpath>
+</template>
+
+<template id="new_page_template_about_full_s_text_block_h1" inherit_id="website.new_page_template_about_full_s_text_block_h1">
+    <xpath expr="//section" position="attributes">
+        <attribute name="class" remove="pb40" separator=" "/>
+    </xpath>
+</template>
+
+<template id="new_page_template_about_full_s_text_image" inherit_id="website.new_page_template_about_full_s_text_image">
+    <xpath expr="//section" position="attributes">
+        <attribute name="class" remove="pt56 pb56" separator=" "/>
     </xpath>
 </template>
 
 <template id="new_page_template_about_full_1_s_text_block_h1" inherit_id="website.new_page_template_about_full_1_s_text_block_h1">
     <xpath expr="//section" position="attributes">
-        <attribute name="class" add="pb40 pb80" remove="pb40" separator=" "/>
+        <attribute name="class" add="pb80" remove="pb40" separator=" "/>
     </xpath>
 </template>
 
@@ -90,13 +137,19 @@
 
 <template id="new_page_template_about_map_s_text_block_h1" inherit_id="website.new_page_template_about_map_s_text_block_h1">
     <xpath expr="//section" position="attributes">
-        <attribute name="class" add="pb80" separator=" "/>
+        <attribute name="class" add="pb80" remove="pb0" separator=" "/>
+    </xpath>
+</template>
+
+<template id="new_page_template_about_mini_s_picture_only" inherit_id="website.new_page_template_about_mini_s_picture_only">
+    <xpath expr="//section" position="attributes">
+        <attribute name="class" add="pb0" separator=" "/>
     </xpath>
 </template>
 
 <template id="new_page_template_about_mini_s_text_block_2nd" inherit_id="website.new_page_template_about_mini_s_text_block_2nd">
     <xpath expr="//section" position="attributes">
-        <attribute name="class" remove="pt80" separator=" "/>
+        <attribute name="class" add="pt40" remove="pt80" separator=" "/>
     </xpath>
 </template>
 
@@ -111,17 +164,23 @@
 
 <template id="new_page_template_about_personal_s_numbers" inherit_id="website.new_page_template_about_personal_s_numbers">
     <xpath expr="//section" position="attributes">
-        <attribute name="class" add="o_cc3" remove="o_cc5" separator=" "/>
+        <attribute name="class" remove="o_cc5 pt0" separator=" "/>
     </xpath>
 </template>
 
 <template id="new_page_template_about_personal_s_text_block_h2" inherit_id="website.new_page_template_about_personal_s_text_block_h2">
     <xpath expr="//section" position="attributes">
-        <attribute name="class" remove="pb80" separator=" "/>
+        <attribute name="class" add="pb0" remove="pb80" separator=" "/>
     </xpath>
 </template>
 
 <!-- Snippet customization Landing Pages -->
+
+<template id="new_page_template_landing_s_text_image" inherit_id="website.new_page_template_landing_s_text_image">
+    <xpath expr="//section" position="attributes">
+        <attribute name="class" remove="pt56 pb56" separator=" "/>
+    </xpath>
+</template>
 
 <template id="new_page_template_landing_0_s_cover" inherit_id="website.new_page_template_landing_0_s_cover">
     <!-- Shape option -->
@@ -148,7 +207,7 @@
 
 <template id="new_page_template_landing_2_s_text_block_h2" inherit_id="website.new_page_template_landing_2_s_text_block_h2">
     <xpath expr="//section" position="attributes">
-        <attribute name="class" add="o_cc1 bg-200" remove="o_cc2 pb80" separator=" "/>
+        <attribute name="class" add="o_cc1 pb0 bg-200" remove="o_cc2 pb80" separator=" "/>
     </xpath>
 </template>
 
@@ -160,7 +219,7 @@
 
 <template id="new_page_template_landing_3_s_text_block_h2" inherit_id="website.new_page_template_landing_3_s_text_block_h2">
     <xpath expr="//section" position="attributes">
-        <attribute name="class" add="o_cc1 bg-200" remove="o_cc2 pb80" separator=" "/>
+        <attribute name="class" add="o_cc1 pb0 bg-200" remove="o_cc2 pb80" separator=" "/>
     </xpath>
 </template>
 
@@ -183,7 +242,7 @@
 
 <template id="new_page_template_landing_4_s_text_block_h2" inherit_id="website.new_page_template_landing_4_s_text_block_h2">
     <xpath expr="//section" position="attributes">
-        <attribute name="class" add="pb40" remove="pb40" separator=" "/>
+        <attribute name="class" remove="pb40" separator=" "/>
     </xpath>
 </template>
 
@@ -201,17 +260,35 @@
     </xpath>
 </template>
 
+<template id="new_page_template_gallery_s_image_text_2nd" inherit_id="website.new_page_template_gallery_s_image_text_2nd">
+    <xpath expr="//section" position="attributes">
+        <attribute name="class" remove="pt48 pb56" separator=" "/>
+    </xpath>
+</template>
+
+<template id="new_page_template_gallery_2_s_picture_only" inherit_id="website.new_page_template_gallery_2_s_picture_only">
+    <xpath expr="//section" position="attributes">
+        <attribute name="class" add="pb0" separator=" "/>
+    </xpath>
+</template>
+
 <!-- Snippet customization Services Pages -->
 
 <template id="new_page_template_services_s_text_block_h1" inherit_id="website.new_page_template_services_s_text_block_h1">
     <xpath expr="//section" position="attributes">
-        <attribute name="class" remove="pb80" separator=" "/>
+        <attribute name="class" add="pb0" remove="pb80" separator=" "/>
     </xpath>
 </template>
 
 <template id="new_page_template_services_s_text_block_h2" inherit_id="website.new_page_template_services_s_text_block_h2">
     <xpath expr="//section" position="attributes">
-        <attribute name="class" remove="pb80" separator=" "/>
+        <attribute name="class" add="pb0" remove="pb80" separator=" "/>
+    </xpath>
+</template>
+
+<template id="new_page_template_services_s_text_image" inherit_id="website.new_page_template_services_s_text_image">
+    <xpath expr="//section" position="attributes">
+        <attribute name="class" remove="pt56 pb56" separator=" "/>
     </xpath>
 </template>
 
@@ -235,29 +312,47 @@
     </xpath>
 </template>
 
+<template id="new_page_template_pricing_s_image_text_2nd" inherit_id="website.new_page_template_pricing_s_image_text_2nd">
+    <xpath expr="//section" position="attributes">
+        <attribute name="class" remove="pt48 pb56" separator=" "/>
+    </xpath>
+</template>
+
 <template id="new_page_template_pricing_s_text_block_h1" inherit_id="website.new_page_template_pricing_s_text_block_h1">
     <xpath expr="//section" position="attributes">
-        <attribute name="class" remove="pb80" separator=" "/>
+        <attribute name="class" add="pb0" remove="pb80" separator=" "/>
     </xpath>
 </template>
 
 <template id="new_page_template_pricing_s_text_block_h2" inherit_id="website.new_page_template_pricing_s_text_block_h2">
     <xpath expr="//section" position="attributes">
-        <attribute name="class" remove="pb80" separator=" "/>
+        <attribute name="class" add="pb0" remove="pb80" separator=" "/>
     </xpath>
 </template>
 
 <template id="new_page_template_pricing_5_s_text_block_h1" inherit_id="website.new_page_template_pricing_5_s_text_block_h1">
     <xpath expr="//section" position="attributes">
-        <attribute name="class" add="pb80" separator=" "/>
+        <attribute name="class" add="pb80" remove="pb0" separator=" "/>
     </xpath>
 </template>
 
 <!-- Snippet customization Team Pages -->
 
+<template id="new_page_template_team_s_picture" inherit_id="website.new_page_template_team_s_picture">
+    <xpath expr="//section" position="attributes">
+        <attribute name="class" add="pb0" separator=" "/>
+    </xpath>
+</template>
+
 <template id="new_page_template_team_s_text_block_h1" inherit_id="website.new_page_template_team_s_text_block_h1">
     <xpath expr="//section" position="attributes">
         <attribute name="class" remove="pb40" separator=" "/>
+    </xpath>
+</template>
+
+<template id="new_page_template_team_s_text_image" inherit_id="website.new_page_template_team_s_text_image">
+    <xpath expr="//section" position="attributes">
+        <attribute name="class" remove="pt56 pb56" separator=" "/>
     </xpath>
 </template>
 

--- a/theme_bistro/views/snippets/s_numbers.xml
+++ b/theme_bistro/views/snippets/s_numbers.xml
@@ -4,7 +4,7 @@
 <template id="s_numbers" inherit_id="website.s_numbers">
     <!-- Section -->
     <xpath expr="//section" position="attributes">
-        <attribute name="class" add="o_cc5 pt80 pb80" remove="o_cc2 pt32 pb32" separator=" "/>
+        <attribute name="class" add="o_cc5 pt80 pb80" remove="o_cc2 pt24 pb24" separator=" "/>
     </xpath>
 </template>
 

--- a/theme_bistro/views/snippets/s_product_catalog.xml
+++ b/theme_bistro/views/snippets/s_product_catalog.xml
@@ -5,7 +5,7 @@
     <!-- Section -->
     <xpath expr="//section" position="attributes">
         <attribute name="style"/>
-        <attribute name="class" add="s_parallax parallax s_parallax_is_fixed o_cc o_cc5 pt120 pb104" remove="pt48 pb32" separator=" "/>
+        <attribute name="class" add="parallax s_parallax_is_fixed o_cc o_cc5 pt120 pb104" remove="pt48 pb32" separator=" "/>
         <attribute name="data-scroll-background-ratio">1</attribute>
     </xpath>
     <xpath expr="//*[hasclass('container')]" position="before">

--- a/theme_bistro/views/snippets/s_quotes_carousel.xml
+++ b/theme_bistro/views/snippets/s_quotes_carousel.xml
@@ -12,9 +12,6 @@
         <attribute name="class" add="pt120 pb120" remove="pt80 pb80" separator=" "/>
         <attribute name="style">background-image: none;</attribute>
     </xpath>
-    <xpath expr="//blockquote[1]" position="attributes">
-        <attribute name="class" add="mx-auto" remove="me-auto" separator=" "/>
-    </xpath>
     <xpath expr="//p[1]" position="replace" mode="inner">
         Cosy and friendly, good atmosphere and super food. Especially the spiced fruit crumble.
     </xpath>

--- a/theme_bookstore/views/new_page_template.xml
+++ b/theme_bookstore/views/new_page_template.xml
@@ -72,23 +72,34 @@
     </xpath>
 </template>
 
+<template id="new_page_template_about_full_s_image_text" inherit_id="website.new_page_template_about_full_s_image_text">
+    <xpath expr="//section" position="attributes">
+        <attribute name="class" remove="pb56 pt48" separator=" "/>
+    </xpath>
+</template>
+
+<template id="new_page_template_about_full_s_numbers" inherit_id="website.new_page_template_about_full_s_numbers">
+    <xpath expr="//section" position="attributes">
+        <attribute name="class" add="o_cc2" remove="o_cc1 o_cc3" separator=" "/>
+    </xpath>
+</template>
+
+<template id="new_page_template_about_full_s_text_image" inherit_id="website.new_page_template_about_full_s_text_image">
+    <xpath expr="//section" position="attributes">
+        <attribute name="class" remove="pb56 pt56" separator=" "/>
+    </xpath>
+</template>
+
 <template id="new_page_template_about_full_1_s_text_block_h1" inherit_id="website.new_page_template_about_full_1_s_text_block_h1">
     <xpath expr="//section" position="attributes">
         <attribute name="class" remove="o_cc2" separator=" "/>
     </xpath>
 </template>
 
-<template id="new_page_template_about_full_s_numbers" inherit_id="website.new_page_template_about_full_s_numbers">
-    <!-- Shape option -->
-    <xpath expr="//section" position="attributes">
-        <attribute name="class" add="o_cc2" remove="o_cc3" separator=" "/>
-    </xpath>
-</template>
-
 <template id="new_page_template_about_map_s_numbers" inherit_id="website.new_page_template_about_map_s_numbers">
     <!-- Shape option -->
     <xpath expr="//section" position="attributes">
-        <attribute name="class" add="o_cc2" remove="o_cc3" separator=" "/>
+        <attribute name="class" add="o_cc2" remove="o_cc1" separator=" "/>
     </xpath>
 </template>
 
@@ -96,6 +107,7 @@
 <template id="new_page_template_about_personal_s_numbers" inherit_id="website.new_page_template_about_personal_s_numbers">
     <!-- Remove shape option -->
     <xpath expr="//section" position="attributes">
+        <attribute name="class" remove="o_cc1 pt0" separator=" "/>
         <attribute name="data-oe-shape-data"/>
     </xpath>
     <!-- Remove shape -->
@@ -109,6 +121,12 @@
 </template>
 
 <!-- Snippet customization Landing Pages -->
+
+<template id="new_page_template_landing_s_text_image" inherit_id="website.new_page_template_landing_s_text_image">
+    <xpath expr="//section" position="attributes">
+        <attribute name="class" remove="pb56 pt56" separator=" "/>
+    </xpath>
+</template>
 
 <template id="new_page_template_landing_2_s_cover" inherit_id="website.new_page_template_landing_2_s_cover">
     <!-- Section -->
@@ -138,7 +156,19 @@
     </xpath>
 </template>
 
+<template id="new_page_template_gallery_s_image_text_2nd" inherit_id="website.new_page_template_gallery_s_image_text_2nd">
+    <xpath expr="//section" position="attributes">
+        <attribute name="class" remove="pb56 pt48" separator=" "/>
+    </xpath>
+</template>
+
 <!-- Snippet customization Services Pages -->
+
+<template id="new_page_template_services_s_text_image" inherit_id="website.new_page_template_services_s_text_image">
+    <xpath expr="//section" position="attributes">
+        <attribute name="class" remove="pb56 pt56" separator=" "/>
+    </xpath>
+</template>
 
 <template id="new_page_template_services_1_s_text_block_h1" inherit_id="website.new_page_template_services_1_s_text_block_h1">
     <xpath expr="//section" position="attributes">
@@ -155,6 +185,18 @@
     </xpath>
 </template>
 
+<template id="new_page_template_pricing_s_image_text_2nd" inherit_id="website.new_page_template_pricing_s_image_text_2nd">
+    <xpath expr="//section" position="attributes">
+        <attribute name="class" remove="pb56 pt48" separator=" "/>
+    </xpath>
+</template>
+
 <!-- Snippet customization Team Pages -->
+
+<template id="new_page_template_team_s_text_image" inherit_id="website.new_page_template_team_s_text_image">
+    <xpath expr="//section" position="attributes">
+        <attribute name="class" remove="pb56 pt56" separator=" "/>
+    </xpath>
+</template>
 
 </odoo>

--- a/theme_bookstore/views/snippets/s_masonry_block.xml
+++ b/theme_bookstore/views/snippets/s_masonry_block.xml
@@ -22,7 +22,6 @@
     <!-- Little block #2 -->
     <!-- Main div -->
     <xpath expr="//div[hasclass('col-lg-3')][2]" position="attributes">
-        <attribute name="class" add="o_cc o_cc1" remove="bg-200" separator=" "/>
         <attribute name="data-oe-shape-data">{"shape":"web_editor/Airy/02","flip":[]}</attribute>
     </xpath>
     <xpath expr="//div[hasclass('col-lg-3')][2]/h3" position="before">
@@ -40,7 +39,7 @@
     <!-- Little block #3 -->
     <!-- Main div -->
     <xpath expr="//div[hasclass('col-lg-3')][3]" position="attributes">
-        <attribute name="class" add="o_cc o_cc5" remove="bg-200" separator=" "/>
+        <attribute name="class" add="o_cc5" remove="bg-200 o_cc4" separator=" "/>
         <attribute name="data-oe-shape-data">{"shape":"web_editor/Rainy/04","flip":[]}</attribute>
     </xpath>
     <xpath expr="//div[hasclass('col-lg-3')][3]/h3" position="before">

--- a/theme_buzzy/views/new_page_template.xml
+++ b/theme_buzzy/views/new_page_template.xml
@@ -66,6 +66,12 @@
     <xpath expr="//div[hasclass('o_we_shape')]" position="replace"/>
 </template>
 
+<template id="new_page_template_s_features" inherit_id="website.new_page_template_s_features">
+    <xpath expr="//div[hasclass('row')]//div[3]//i" position="attributes">
+        <attribute name="class" add="bg-o-color-2" remove="bg-o-color-1" separator=" "/>
+    </xpath>
+</template>
+
 <template id="new_page_template_s_product_catalog" inherit_id="website.new_page_template_s_product_catalog">
     <!-- Remove shape option -->
     <xpath expr="//section" position="attributes">
@@ -83,6 +89,21 @@
     <!-- Shape -->
     <xpath expr="//div[hasclass('container')]" position="before">
         <div class="o_we_shape o_web_editor_Blocks_03"/>
+    </xpath>
+</template>
+
+<template id="new_page_template_s_timeline" inherit_id="website.new_page_template_s_timeline">
+    <xpath expr="//i" position="attributes">
+        <attribute name="class" add="bg-o-color-2" remove="bg-o-color-1" separator=" "/>
+    </xpath>
+    <xpath expr="(//i)[2]" position="attributes">
+        <attribute name="class" add="bg-o-color-2" remove="bg-o-color-1" separator=" "/>
+    </xpath>
+    <xpath expr="(//i)[3]" position="attributes">
+        <attribute name="class" add="bg-o-color-2" remove="bg-o-color-1" separator=" "/>
+    </xpath>
+    <xpath expr="(//i)[4]" position="attributes">
+        <attribute name="class" add="bg-o-color-2" remove="bg-o-color-1" separator=" "/>
     </xpath>
 </template>
 
@@ -104,6 +125,13 @@
 </template>
 
 <!-- Snippet customization Basic Pages -->
+
+<template id="new_page_template_basic_2_s_text_block_h1" inherit_id="website.new_page_template_basic_2_s_text_block_h1">
+    <xpath expr="//section" position="attributes">
+        <!-- Added by both theme and new page template -->
+        <attribute name="class" add="o_cc2" remove="o_cc2" separator=" "/>
+    </xpath>
+</template>
 
 <!-- Snippet customization About Pages -->
 
@@ -128,7 +156,7 @@
 <template id="new_page_template_about_s_text_block_h1" inherit_id="website.new_page_template_about_s_text_block_h1">
     <!-- Shape option -->
     <xpath expr="//section" position="attributes">
-        <attribute name="class" add="o_cc4 pt80 pb80" remove="o_cc2 pb0" separator=" "/>
+        <attribute name="class" add="o_cc4 pt80 pb80" remove="o_cc2 pt40 pb40" separator=" "/>
         <attribute name="data-oe-shape-data">{"shape":"web_editor/Airy/13_001","flip":[]}</attribute>
     </xpath>
     <!-- Shape -->
@@ -143,26 +171,50 @@
     </xpath>
 </template>
 
-<template id="new_page_template_about_full_1_s_text_block_h1" inherit_id="website.new_page_template_about_full_1_s_text_block_h1">
+<template id="new_page_template_about_full_s_image_text" inherit_id="website.new_page_template_about_full_s_image_text">
     <xpath expr="//section" position="attributes">
-        <attribute name="class" add="pt40" remove="o_cc2 pb0 pb40 pb40 pt40" separator=" "/>
+        <attribute name="class" remove="pt48 pb56" separator=" "/>
+    </xpath>
+</template>
+
+<template id="new_page_template_about_full_s_numbers" inherit_id="website.new_page_template_about_full_s_numbers">
+    <xpath expr="//section" position="attributes">
+        <attribute name="class" remove="o_cc3" separator=" "/>
+    </xpath>
+</template>
+
+<template id="new_page_template_about_full_s_text_image" inherit_id="website.new_page_template_about_full_s_text_image">
+    <xpath expr="//section" position="attributes">
+        <attribute name="class" remove="pt56 pb56" separator=" "/>
     </xpath>
 </template>
 
 <template id="new_page_template_about_full_s_text_block_h1" inherit_id="website.new_page_template_about_full_s_text_block_h1">
     <xpath expr="//section" position="attributes">
-        <attribute name="class" add="pb40 pb40 pt40" separator=" "/>
+        <attribute name="class" remove="pb0 pb40 pt40" separator=" "/>
+    </xpath>
+</template>
+
+<template id="new_page_template_about_full_1_s_text_block_h1" inherit_id="website.new_page_template_about_full_1_s_text_block_h1">
+    <xpath expr="//section" position="attributes">
+        <attribute name="class" remove="pb40" separator=" "/>
     </xpath>
 </template>
 
 <template id="new_page_template_about_map_s_text_block_h1" inherit_id="website.new_page_template_about_map_s_text_block_h1">
     <!-- Remove shape option -->
     <xpath expr="//section" position="attributes">
-        <attribute name="class" add="o_cc2 pb0" remove="o_cc4 pb80 pt80" separator=" "/>
+        <attribute name="class" add="o_cc2 pt40" remove="o_cc4 pb80 pt80" separator=" "/>
         <attribute name="data-oe-shape-data"/>
     </xpath>
     <!-- Remove shape -->
     <xpath expr="//div[hasclass('o_we_shape')]" position="replace"/>
+</template>
+
+<template id="new_page_template_about_mini_s_cover" inherit_id="website.new_page_template_about_mini_s_cover">
+    <xpath expr="//section" position="attributes">
+        <attribute name="class" remove="pt40 pb40" separator=" "/>
+    </xpath>
 </template>
 
 <template id="new_page_template_about_mini_s_text_block_h2" inherit_id="website.new_page_template_about_mini_s_text_block_h2">
@@ -174,6 +226,7 @@
 <template id="new_page_template_about_personal_s_numbers" inherit_id="website.new_page_template_about_personal_s_numbers">
     <!-- Remove shape option -->
     <xpath expr="//section" position="attributes">
+        <attribute name="class" remove="o_cc3 pt0" separator=" "/>
         <attribute name="data-oe-shape-data"/>
     </xpath>
     <!-- Remove shape -->
@@ -182,7 +235,8 @@
 
 <template id="new_page_template_about_personal_s_text_block_h2" inherit_id="website.new_page_template_about_personal_s_text_block_h2">
     <xpath expr="//section" position="attributes">
-        <attribute name="class" add="o_cc4" remove="o_cc3" separator=" "/>
+        <!-- o_cc defined in both theme and new page template -->
+        <attribute name="class" add="o_cc o_cc4" remove="o_cc o_cc2 o_cc3" separator=" "/>
     </xpath>
 </template>
 
@@ -195,6 +249,12 @@
     </xpath>
     <!-- Remove shape -->
     <xpath expr="//div[hasclass('o_we_shape')]" position="replace"/>
+</template>
+
+<template id="new_page_template_landing_s_text_image" inherit_id="website.new_page_template_landing_s_text_image">
+    <xpath expr="//section" position="attributes">
+        <attribute name="class" remove="pt56 pb56" separator=" "/>
+    </xpath>
 </template>
 
 <template id="new_page_template_landing_s_text_cover" inherit_id="website.new_page_template_landing_s_text_cover">
@@ -217,6 +277,7 @@
 <template id="new_page_template_landing_0_s_cover" inherit_id="website.new_page_template_landing_0_s_cover">
     <!-- Remove shape option -->
     <xpath expr="//section" position="attributes">
+        <attribute name="class" remove="pt112 pb112" separator=" "/>
         <attribute name="data-oe-shape-data"/>
     </xpath>
     <!-- Remove shape -->
@@ -227,6 +288,20 @@
     <!-- Shape option -->
     <xpath expr="//section" position="attributes">
         <attribute name="class" add="o_half_screen_height" remove="o_full_screen_height" separator=" "/>
+    </xpath>
+</template>
+
+<template id="new_page_template_landing_2_s_text_block_h2" inherit_id="website.new_page_template_landing_2_s_text_block_h2">
+    <xpath expr="//section" position="attributes">
+        <!-- Added by both theme and new page template -->
+        <attribute name="class" add="o_cc2" remove="o_cc2" separator=" "/>
+    </xpath>
+</template>
+
+<template id="new_page_template_landing_3_s_text_block_h2" inherit_id="website.new_page_template_landing_3_s_text_block_h2">
+    <xpath expr="//section" position="attributes">
+        <!-- Added by both theme and new page template -->
+        <attribute name="class" add="o_cc2" remove="o_cc2" separator=" "/>
     </xpath>
 </template>
 
@@ -262,7 +337,7 @@
 <template id="new_page_template_gallery_s_text_block_h2" inherit_id="website.new_page_template_gallery_s_text_block_h2">
     <!-- Shape option -->
     <xpath expr="//section" position="attributes">
-        <attribute name="class" add="o_cc4 pt80 pb80" remove="o_cc2 pb0" separator=" "/>
+        <attribute name="class" add="o_cc4 pt80 pb80" remove="o_cc2 pt40 pb0" separator=" "/>
         <attribute name="data-oe-shape-data">{"shape":"web_editor/Airy/13_001","flip":[]}</attribute>
     </xpath>
     <!-- Shape -->
@@ -271,11 +346,23 @@
     </xpath>
 </template>
 
+<template id="new_page_template_gallery_s_image_text_2nd" inherit_id="website.new_page_template_gallery_s_image_text_2nd">
+    <xpath expr="//section" position="attributes">
+       <attribute name="class" remove="pt48 pb56" separator=" "/>
+    </xpath>
+</template>
+
 <!-- Snippet customization Services Pages -->
 
 <template id="new_page_template_services_s_text_cover" inherit_id="website.new_page_template_services_s_text_cover">
     <xpath expr="//section" position="attributes">
         <attribute name="class" add="o_cc2" separator=" "/>
+    </xpath>
+</template>
+
+<template id="new_page_template_services_s_text_image" inherit_id="website.new_page_template_services_s_text_image">
+    <xpath expr="//section" position="attributes">
+        <attribute name="class" remove="pt56 pb56" separator=" "/>
     </xpath>
 </template>
 
@@ -288,7 +375,19 @@
     </xpath>
 </template>
 
+<template id="new_page_template_pricing_s_image_text_2nd" inherit_id="website.new_page_template_pricing_s_image_text_2nd">
+    <xpath expr="//section" position="attributes">
+        <attribute name="class" remove="pt48 pb56" separator=" "/>
+    </xpath>
+</template>
+
 <!-- Snippet customization Team Pages -->
+
+<template id="new_page_template_team_s_text_image" inherit_id="website.new_page_template_team_s_text_image">
+    <xpath expr="//section" position="attributes">
+        <attribute name="class" remove="pt56 pb56" separator=" "/>
+    </xpath>
+</template>
 
 <template id="new_page_template_team_0_s_text_block_h1" inherit_id="website.new_page_template_team_0_s_text_block_h1">
     <xpath expr="//section" position="attributes">

--- a/theme_buzzy/views/snippets/s_comparisons.xml
+++ b/theme_buzzy/views/snippets/s_comparisons.xml
@@ -22,7 +22,7 @@
         <attribute name="class" add="pt88" remove="pt32" separator=" "/>
     </xpath>
     <xpath expr="//div[hasclass('row')]//div[3]/div" position="attributes">
-        <attribute name="class" add="shadow bg-o-color-5" remove="bg-secondary" separator=" "/>
+        <attribute name="class" add="shadow bg-o-color-5" remove="bg-o-color-2" separator=" "/>
     </xpath>
 </template>
 

--- a/theme_buzzy/views/snippets/s_features.xml
+++ b/theme_buzzy/views/snippets/s_features.xml
@@ -17,7 +17,7 @@
     </xpath>
     <!-- Feature #3 - Icon -->
     <xpath expr="//div[hasclass('row')]//div[3]//i" position="attributes">
-        <attribute name="class" add="bg-o-color-1" remove="bg-secondary" separator=" "/>
+        <attribute name="class" add="bg-o-color-1" remove="bg-o-color-2" separator=" "/>
     </xpath>
 </template>
 

--- a/theme_buzzy/views/snippets/s_media_list.xml
+++ b/theme_buzzy/views/snippets/s_media_list.xml
@@ -2,10 +2,6 @@
 <odoo>
 
 <template id="s_media_list" inherit_id="website.s_media_list">
-    <!-- Section -->
-    <xpath expr="//section" position="attributes">
-        <attribute name="class" add="o_colored_level" separator=" "/>
-    </xpath>
     <!-- Media item #1 -->
     <xpath expr="//div[hasclass('s_media_list_item')]/div" position="attributes">
         <attribute name="class" add="o_cc4" remove="o_cc1" separator=" "/>

--- a/theme_buzzy/views/snippets/s_process_steps.xml
+++ b/theme_buzzy/views/snippets/s_process_steps.xml
@@ -17,7 +17,7 @@
     </xpath>
     <!-- Icon #3 -->
     <xpath expr="(//i)[3]" position="attributes">
-        <attribute name="class" add="bg-o-color-1" remove="bg-secondary" separator=" "/>
+        <attribute name="class" add="bg-o-color-1" remove="bg-o-color-2" separator=" "/>
     </xpath>
     <!-- Icon #4 -->
     <xpath expr="(//i)[4]" position="attributes">

--- a/theme_buzzy/views/snippets/s_three_columns.xml
+++ b/theme_buzzy/views/snippets/s_three_columns.xml
@@ -2,11 +2,6 @@
 <odoo>
 
 <template id="s_three_columns" inherit_id="website.s_three_columns">
-    <!-- Section -->
-    <xpath expr="//section" position="attributes">
-        <attribute name="class" add="o_colored_level" separator=" "/>
-    </xpath>
-
     <!-- Column #1 -->
     <!-- Img -->
     <xpath expr="//div[hasclass('card')]//img" position="attributes">

--- a/theme_buzzy/views/snippets/s_timeline.xml
+++ b/theme_buzzy/views/snippets/s_timeline.xml
@@ -8,19 +8,19 @@
     </xpath>
     <!-- Icon #1 -->
     <xpath expr="//i" position="attributes">
-        <attribute name="class" add="bg-o-color-1" remove="bg-secondary" separator=" "/>
+        <attribute name="class" add="bg-o-color-1" remove="bg-o-color-2" separator=" "/>
     </xpath>
     <!-- Icon #2 -->
     <xpath expr="(//i)[2]" position="attributes">
-        <attribute name="class" add="bg-o-color-1" remove="bg-secondary" separator=" "/>
+        <attribute name="class" add="bg-o-color-1" remove="bg-o-color-2" separator=" "/>
     </xpath>
     <!-- Icon #3 -->
     <xpath expr="(//i)[3]" position="attributes">
-        <attribute name="class" add="bg-o-color-1" remove="bg-secondary" separator=" "/>
+        <attribute name="class" add="bg-o-color-1" remove="bg-o-color-2" separator=" "/>
     </xpath>
     <!-- Icon #4 -->
     <xpath expr="(//i)[4]" position="attributes">
-        <attribute name="class" add="bg-o-color-1" remove="bg-secondary" separator=" "/>
+        <attribute name="class" add="bg-o-color-1" remove="bg-o-color-2" separator=" "/>
     </xpath>
 </template>
 

--- a/theme_clean/views/new_page_template.xml
+++ b/theme_clean/views/new_page_template.xml
@@ -55,7 +55,8 @@
 
 <template id="new_page_template_about_full_1_s_text_block_h1" inherit_id="website.new_page_template_about_full_1_s_text_block_h1">
     <xpath expr="//section" position="attributes">
-        <attribute name="class" add="pb40 pb40" remove="pb40" separator=" "/>
+        <!-- Defined in both theme and new page template -->
+        <attribute name="class" add="pb40" remove="pb40" separator=" "/>
     </xpath>
 </template>
 
@@ -65,16 +66,40 @@
     </xpath>
 </template>
 
+<template id="new_page_template_about_full_s_image_text" inherit_id="website.new_page_template_about_full_s_image_text">
+    <xpath expr="//section" position="attributes">
+        <attribute name="class" remove="pt48 pb56" separator=" "/>
+    </xpath>
+</template>
+
+<template id="new_page_template_about_full_s_numbers" inherit_id="website.new_page_template_about_full_s_numbers">
+    <xpath expr="//section" position="attributes">
+        <attribute name="class" remove="o_cc3" separator=" "/>
+    </xpath>
+</template>
+
 <template id="new_page_template_about_personal_s_numbers" inherit_id="website.new_page_template_about_personal_s_numbers">
     <xpath expr="//section" position="attributes">
-        <attribute name="class" add="o_cc3" remove="o_cc4" separator=" "/>
+        <attribute name="class" remove="o_cc4 pt0" separator=" "/>
         <attribute name="data-oe-shape-data"/>
     </xpath>
     <!-- Remove shape -->
     <xpath expr="//div[hasclass('o_we_shape')]" position="replace"/>
 </template>
 
+<template id="new_page_template_about_full_s_text_image" inherit_id="website.new_page_template_about_full_s_text_image">
+    <xpath expr="//section" position="attributes">
+        <attribute name="class" remove="pt56 pb56" separator=" "/>
+    </xpath>
+</template>
+
 <!-- Snippet customization Landing Pages -->
+
+<template id="new_page_template_landing_s_text_image" inherit_id="website.new_page_template_landing_s_text_image">
+    <xpath expr="//section" position="attributes">
+        <attribute name="class" remove="pt56 pb56" separator=" "/>
+    </xpath>
+</template>
 
 <template id="new_page_template_landing_2_s_cover" inherit_id="website.new_page_template_landing_2_s_cover">
     <!-- Shape option -->
@@ -114,7 +139,19 @@
     </xpath>
 </template>
 
+<template id="new_page_template_gallery_s_image_text_2nd" inherit_id="website.new_page_template_gallery_s_image_text_2nd">
+    <xpath expr="//section" position="attributes">
+        <attribute name="class" remove="pt48 pb56" separator=" "/>
+    </xpath>
+</template>
+
 <!-- Snippet customization Services Pages -->
+
+<template id="new_page_template_services_s_text_image" inherit_id="website.new_page_template_services_s_text_image">
+    <xpath expr="//section" position="attributes">
+        <attribute name="class" remove="pt56 pb56" separator=" "/>
+    </xpath>
+</template>
 
 <template id="new_page_template_services_1_s_text_block_h1" inherit_id="website.new_page_template_services_1_s_text_block_h1">
     <xpath expr="//section" position="attributes">
@@ -136,6 +173,18 @@
     </xpath>
 </template>
 
+<template id="new_page_template_pricing_s_image_text_2nd" inherit_id="website.new_page_template_pricing_s_image_text_2nd">
+    <xpath expr="//section" position="attributes">
+        <attribute name="class" remove="pt48 pb56" separator=" "/>
+    </xpath>
+</template>
+
 <!-- Snippet customization Team Pages -->
+
+<template id="new_page_template_team_s_text_image" inherit_id="website.new_page_template_team_s_text_image">
+    <xpath expr="//section" position="attributes">
+        <attribute name="class" remove="pt56 pb56" separator=" "/>
+    </xpath>
+</template>
 
 </odoo>

--- a/theme_clean/views/snippets/s_features.xml
+++ b/theme_clean/views/snippets/s_features.xml
@@ -8,7 +8,7 @@
     </xpath>
     <!-- First column : icon -->
     <xpath expr="//div[hasclass('row')]//div//i" position="attributes">
-        <attribute name="class" add="bg-o-color-4 fa-shield" remove="bg-primary fa-gear" separator=" "/>
+        <attribute name="class" add="bg-o-color-4 fa-shield" remove="bg-o-color-1 fa-gear" separator=" "/>
     </xpath>
     <!-- First column : title -->
     <xpath expr="//div[hasclass('row')]//div//h3" position="replace" mode="inner">
@@ -24,7 +24,7 @@
     </xpath>
     <!-- Third column : icon -->
     <xpath expr="//div[hasclass('row')]//div[3]//i" position="attributes">
-        <attribute name="class" add="fa-star bg-o-color-2" remove="fa-leaf" separator=" "/>
+        <attribute name="class" add="fa-star" remove="fa-leaf" separator=" "/>
     </xpath>
     <!-- Third column : title -->
     <xpath expr="//div[hasclass('row')]//div[3]//h3" position="replace" mode="inner">

--- a/theme_clean/views/snippets/s_quotes_carousel.xml
+++ b/theme_clean/views/snippets/s_quotes_carousel.xml
@@ -4,7 +4,6 @@
 <template id="s_quotes_carousel" inherit_id="website.s_quotes_carousel">
     <!-- Section -->
     <xpath expr="//div[hasclass('carousel-item')]" position="attributes">
-        <attribute name="class" add="oe_img_bg o_bg_img_center" separator=" "/>
         <attribute name="style">background-image: url('/web/image/website.s_quotes_carousel_demo_image_3'); background-position: 50% 50%;</attribute>
     </xpath>
 </template>

--- a/theme_cobalt/views/new_page_template.xml
+++ b/theme_cobalt/views/new_page_template.xml
@@ -68,13 +68,31 @@
     </xpath>
 </template>
 
+<template id="new_page_template_about_full_s_image_text" inherit_id="website.new_page_template_about_full_s_image_text">
+    <xpath expr="//section" position="attributes">
+        <attribute name="class" remove="pt48 pb56" separator=" "/>
+    </xpath>
+</template>
+
 <template id="new_page_template_about_full_s_numbers" inherit_id="website.new_page_template_about_full_s_numbers">
     <xpath expr="//section" position="attributes">
         <attribute name="class" add="o_cc2" remove="o_cc3" separator=" "/>
     </xpath>
 </template>
 
+<template id="new_page_template_about_full_s_text_image" inherit_id="website.new_page_template_about_full_s_text_image">
+    <xpath expr="//section" position="attributes">
+        <attribute name="class" remove="pt56 pb56" separator=" "/>
+    </xpath>
+</template>
+
 <!-- Snippet customization Landing Pages -->
+
+<template id="new_page_template_landing_s_text_image" inherit_id="website.new_page_template_landing_s_text_image">
+    <xpath expr="//section" position="attributes">
+        <attribute name="class" remove="pt56 pb56" separator=" "/>
+    </xpath>
+</template>
 
 <template id="new_page_template_landing_1_s_banner" inherit_id="website.new_page_template_landing_1_s_banner">
     <xpath expr="//section" position="attributes">
@@ -99,7 +117,19 @@
     </xpath>
 </template>
 
+<template id="new_page_template_gallery_s_image_text_2nd" inherit_id="website.new_page_template_gallery_s_image_text_2nd">
+    <xpath expr="//section" position="attributes">
+        <attribute name="class" remove="pt48 pb56" separator=" "/>
+    </xpath>
+</template>
+
 <!-- Snippet customization Services Pages -->
+
+<template id="new_page_template_services_s_text_image" inherit_id="website.new_page_template_services_s_text_image">
+    <xpath expr="//section" position="attributes">
+        <attribute name="class" remove="pt56 pb56" separator=" "/>
+    </xpath>
+</template>
 
 <template id="new_page_template_services_1_s_text_block_h1" inherit_id="website.new_page_template_services_1_s_text_block_h1">
     <xpath expr="//section" position="attributes">
@@ -115,7 +145,19 @@
     </xpath>
 </template>
 
+<template id="new_page_template_pricing_s_image_text_2nd" inherit_id="website.new_page_template_pricing_s_image_text_2nd">
+    <xpath expr="//section" position="attributes">
+        <attribute name="class" remove="pt48 pb56" separator=" "/>
+    </xpath>
+</template>
+
 <!-- Snippet customization Team Pages -->
+
+<template id="new_page_template_team_s_text_image" inherit_id="website.new_page_template_team_s_text_image">
+    <xpath expr="//section" position="attributes">
+        <attribute name="class" remove="pt56 pb56" separator=" "/>
+    </xpath>
+</template>
 
 <template id="new_page_template_team_s_text_block_h1" inherit_id="website.new_page_template_team_s_text_block_h1">
     <xpath expr="//section" position="attributes">

--- a/theme_enark/views/new_page_template.xml
+++ b/theme_enark/views/new_page_template.xml
@@ -51,15 +51,47 @@
 
 <template id="new_page_template_about_full_s_numbers" inherit_id="website.new_page_template_about_full_s_numbers">
     <xpath expr="//section" position="attributes">
-        <attribute name="class" add="o_cc2" remove="o_cc3" separator=" "/>
+        <attribute name="class" add="o_cc2" remove="o_cc1 o_cc3" separator=" "/>
+    </xpath>
+</template>
+
+<template id="new_page_template_about_full_s_text_image" inherit_id="website.new_page_template_about_full_s_text_image">
+    <xpath expr="//section" position="attributes">
+        <attribute name="class" remove="pt56 pb56" separator=" "/>
+    </xpath>
+</template>
+
+<template id="new_page_template_about_personal_s_numbers" inherit_id="website.new_page_template_about_personal_s_numbers">
+    <xpath expr="//section" position="attributes">
+        <!-- pt0 is defined by both theme and new page template -->
+        <attribute name="class" add="pt0" remove="o_cc1 pt0" separator=" "/>
     </xpath>
 </template>
 
 <!-- Snippet customization Landing Pages -->
 
+<template id="new_page_template_landing_s_text_image" inherit_id="website.new_page_template_landing_s_text_image">
+    <xpath expr="//section" position="attributes">
+        <attribute name="class" remove="pt56 pb56" separator=" "/>
+    </xpath>
+</template>
+
+<template id="new_page_template_landing_5_s_banner" inherit_id="website.new_page_template_landing_5_s_banner">
+    <xpath expr="//section" position="attributes">
+        <!-- Defined by both theme and new page template -->
+        <attribute name="class" add="o_full_screen_height" remove="o_full_screen_height" separator=" "/>
+    </xpath>
+</template>
+
 <!-- Snippet customization Gallery Pages -->
 
 <!-- Snippet customization Services Pages -->
+
+<template id="new_page_template_services_s_text_image" inherit_id="website.new_page_template_services_s_text_image">
+    <xpath expr="//section" position="attributes">
+        <attribute name="class" remove="pt56 pb56" separator=" "/>
+    </xpath>
+</template>
 
 <template id="new_page_template_services_1_s_text_block_h1" inherit_id="website.new_page_template_services_1_s_text_block_h1">
     <xpath expr="//section" position="attributes">
@@ -70,6 +102,12 @@
 <!-- Snippet customization Pricing Pages -->
 
 <!-- Snippet customization Team Pages -->
+
+<template id="new_page_template_team_s_text_image" inherit_id="website.new_page_template_team_s_text_image">
+    <xpath expr="//section" position="attributes">
+        <attribute name="class" remove="pt56 pb56" separator=" "/>
+    </xpath>
+</template>
 
 <template id="new_page_template_team_1_s_text_block_h1" inherit_id="website.new_page_template_team_1_s_text_block_h1">
     <xpath expr="//section" position="attributes">

--- a/theme_graphene/views/customizations.xml
+++ b/theme_graphene/views/customizations.xml
@@ -62,7 +62,7 @@
         <attribute name="class" add="col-lg-5 offset-lg-1" remove="col-lg-6" separator=" "/>
     </xpath>
     <xpath expr="//a[hasclass('btn')]" position="attributes">
-        <attribute name="class" add="btn-lg btn-secondary" remove="btn-primary" separator=" "/>
+        <attribute name="class" add="btn-lg" remove="btn-primary" separator=" "/>
     </xpath>
 </template>
 
@@ -291,7 +291,7 @@
         Put your people at the heart of your marketing with tools that help you get to know your audience <br/>and see who you should be talking to.
     </xpath>
     <xpath expr="//img" position="attributes">
-        <attribute name="class" add="p-0 border-0" separator=" " />
+        <attribute name="class" add="p-0 border-0" remove="padding-large" separator=" " />
     </xpath>
 </template>
 

--- a/theme_graphene/views/new_page_template.xml
+++ b/theme_graphene/views/new_page_template.xml
@@ -60,6 +60,12 @@
     </xpath>
 </template>
 
+<template id="new_page_template_about_full_s_text_image" inherit_id="website.new_page_template_about_full_s_text_image">
+    <xpath expr="//section" position="attributes">
+        <attribute name="class" remove="pt0 pb56" separator=" "/>
+    </xpath>
+</template>
+
 <template id="new_page_template_about_full_1_s_text_block_h1" inherit_id="website.new_page_template_about_full_1_s_text_block_h1">
     <xpath expr="//section" position="attributes">
         <attribute name="class" add="o_cc2" separator=" "/>
@@ -69,6 +75,12 @@
 <template id="new_page_template_about_full_1_s_text_block_h2" inherit_id="website.new_page_template_about_full_1_s_text_block_h2">
     <xpath expr="//section" position="attributes">
         <attribute name="class" add="o_cc2" separator=" "/>
+    </xpath>
+</template>
+
+<template id="new_page_template_about_mini_s_cover" inherit_id="website.new_page_template_about_mini_s_cover">
+    <xpath expr="//section" position="attributes">
+        <attribute name="class" remove="pt40 pb40" separator=" "/>
     </xpath>
 </template>
 
@@ -86,7 +98,7 @@
 
 <template id="new_page_template_about_personal_s_numbers" inherit_id="website.new_page_template_about_personal_s_numbers">
     <xpath expr="//section" position="attributes">
-        <attribute name="class" add="o_cc5" remove="o_cc3 parallax" separator=" "/>
+        <attribute name="class" add="o_cc5" remove="o_cc3 parallax pt0" separator=" "/>
         <attribute name="style" remove="background-image: none;" separator=" "/>
     </xpath>
     <xpath expr="//div" position="attributes">
@@ -104,10 +116,17 @@
 
 <template id="new_page_template_landing_s_text_image" inherit_id="website.new_page_template_landing_s_text_image">
     <xpath expr="//section" position="attributes">
+        <attribute name="class" remove="pt0 pb56" separator=" "/>
         <attribute name="data-oe-shape-data">{"shape":"web_editor/Origins/02_001","flip":["x","y"]}</attribute>
     </xpath>
     <xpath expr="//section/div[hasclass('container')]" position="before">
         <div class="o_we_shape o_web_editor_Origins_02_001 o_second_extra_shape_mapping" style="background-image: url('/web_editor/shape/web_editor/Origins/02_001.svg?c4=o-color-3&amp;c5=rgba%280%2C%200%2C%200%2C%200%29&amp;flip=xy'); background-position: 50% 0%;"/>
+    </xpath>
+</template>
+
+<template id="new_page_template_landing_0_s_cover" inherit_id="website.new_page_template_landing_0_s_cover">
+    <xpath expr="//section" position="attributes">
+        <attribute name="class" remove="pt160 pb240" separator=" "/>
     </xpath>
 </template>
 
@@ -132,6 +151,12 @@
 </template>
 
 <!-- Snippet customization Services Pages -->
+
+<template id="new_page_template_services_s_text_image" inherit_id="website.new_page_template_services_s_text_image">
+    <xpath expr="//section" position="attributes">
+        <attribute name="class" remove="pt0 pb56" separator=" "/>
+    </xpath>
+</template>
 
 <!-- Snippet customization Pricing Pages -->
 
@@ -179,6 +204,12 @@
 <template id="new_page_template_team_s_text_block_h1" inherit_id="website.new_page_template_team_s_text_block_h1">
     <xpath expr="//section" position="attributes">
         <attribute name="class" add="o_cc2" separator=" "/>
+    </xpath>
+</template>
+
+<template id="new_page_template_team_s_text_image" inherit_id="website.new_page_template_team_s_text_image">
+    <xpath expr="//section" position="attributes">
+        <attribute name="class" remove="pt0 pb56" separator=" "/>
     </xpath>
 </template>
 

--- a/theme_kea/views/new_page_template.xml
+++ b/theme_kea/views/new_page_template.xml
@@ -56,7 +56,7 @@
 
 <template id="new_page_template_basic_s_features" inherit_id="website.new_page_template_basic_s_features">
     <xpath expr="//section" position="attributes">
-        <attribute name="class" add="o_cc3" separator=" "/>
+        <attribute name="class" add="o_cc3" remove="o_cc2" separator=" "/>
     </xpath>
 </template>
 
@@ -132,7 +132,13 @@
 
 <template id="new_page_template_about_full_s_numbers" inherit_id="website.new_page_template_about_full_s_numbers">
     <xpath expr="//section" position="attributes">
-        <attribute name="class" add="o_cc2" remove="o_cc3" separator=" "/>
+        <attribute name="class" add="o_cc2 pt24" remove="o_cc3 pt0" separator=" "/>
+    </xpath>
+</template>
+
+<template id="new_page_template_about_full_s_text_image" inherit_id="website.new_page_template_about_full_s_text_image">
+    <xpath expr="//section" position="attributes">
+        <attribute name="class" remove="pt56" separator=" "/>
     </xpath>
 </template>
 
@@ -153,11 +159,19 @@
     </xpath>
 </template>
 
+<template id="new_page_template_about_personal_s_numbers" inherit_id="website.new_page_template_about_personal_s_numbers">
+    <xpath expr="//section" position="attributes">
+        <!-- Added by both theme and new page template -->
+        <attribute name="class" add="pt0" remove="pt0" separator=" "/>
+    </xpath>
+</template>
+
 <!-- Snippet customization Landing Pages -->
 
 <template id="new_page_template_landing_s_text_image" inherit_id="website.new_page_template_landing_s_text_image">
     <!-- Shape option -->
     <xpath expr="//section" position="attributes">
+        <attribute name="class" remove="pt56" separator=" "/>
         <attribute name="data-oe-shape-data">{"shape":"web_editor/Wavy/22","flip":["x"]}</attribute>
     </xpath>
     <!-- Shape -->
@@ -194,6 +208,12 @@
 
 <!-- Snippet customization Services Pages -->
 
+<template id="new_page_template_services_s_text_image" inherit_id="website.new_page_template_services_s_text_image">
+    <xpath expr="//section" position="attributes">
+        <attribute name="class" remove="pt56" separator=" "/>
+    </xpath>
+</template>
+
 <!-- Snippet customization Pricing Pages -->
 
 <template id="new_page_template_pricing_s_cover" inherit_id="website.new_page_template_pricing_s_cover">
@@ -224,5 +244,11 @@
 </template>
 
 <!-- Snippet customization Team Pages -->
+
+<template id="new_page_template_team_s_text_image" inherit_id="website.new_page_template_team_s_text_image">
+    <xpath expr="//section" position="attributes">
+        <attribute name="class" remove="pt56" separator=" "/>
+    </xpath>
+</template>
 
 </odoo>

--- a/theme_kea/views/snippets/s_features.xml
+++ b/theme_kea/views/snippets/s_features.xml
@@ -8,7 +8,7 @@
     </xpath>
     <!-- Column #01 -->
     <xpath expr="//div[hasclass('row')]/div[1]" position="attributes">
-        <attribute name="class" add="o_cc o_cc1 pt48 pb48" separator=" "/>
+        <attribute name="class" add="o_cc o_cc1 pt48 pb48" remove="pt32 pb32" separator=" "/>
     </xpath>
     <xpath expr="//div[hasclass('row')]/div[1]/i" position="replace">
         <i class="fa fa-2x fa-image bg-o-color-1 m-3 rounded-circle"/>
@@ -21,7 +21,7 @@
     </xpath>
     <!-- Column #02 -->
     <xpath expr="//div[hasclass('row')]/div[2]" position="attributes">
-        <attribute name="class" add="o_cc o_cc1 pt48 pb48" separator=" "/>
+        <attribute name="class" add="o_cc o_cc1 pt48 pb48" remove="pt32 pb32" separator=" "/>
     </xpath>
     <xpath expr="//div[hasclass('row')]/div[2]/i" position="replace">
         <i class="fa fa-2x fa-eye bg-o-color-5 m-3 rounded-circle"/>
@@ -34,7 +34,7 @@
     </xpath>
     <!-- Column #03 -->
     <xpath expr="//div[hasclass('row')]/div[3]" position="attributes">
-        <attribute name="class" add="o_cc o_cc1 pt48 pb48" separator=" "/>
+        <attribute name="class" add="o_cc o_cc1 pt48 pb48" remove="pt32 pb32" separator=" "/>
     </xpath>
     <xpath expr="//div[hasclass('row')]/div[3]/i" position="attributes">
         <attribute name="class" add="fa-2x fa-microphone rounded-circle" remove="fa-3x fa-leaf rounded" separator=" "/>

--- a/theme_kea/views/snippets/s_media_list.xml
+++ b/theme_kea/views/snippets/s_media_list.xml
@@ -4,7 +4,7 @@
 <template id="s_media_list" inherit_id="website.s_media_list">
     <!-- Section -->
     <xpath expr="//section" position="attributes">
-        <attribute name="class" add="o_cc2 pt64 pb64" remove="o_cc1 pt32 pb32" separator=" "/>
+        <attribute name="class" add="pt64 pb64" remove="pt32 pb32" separator=" "/>
         <attribute name="data-oe-shape-data">{"shape":"web_editor/Floats/01","flip":[]}</attribute>
     </xpath>
     <!-- Shape -->

--- a/theme_kea/views/snippets/s_numbers.xml
+++ b/theme_kea/views/snippets/s_numbers.xml
@@ -4,7 +4,7 @@
 <template id="s_numbers" inherit_id="website.s_numbers">
     <!-- Section -->
     <xpath expr="//section" position="attributes">
-        <attribute name="class" add="o_cc o_cc2 pt0 pb48" remove="pt24 pb24" separator=" "/>
+        <attribute name="class" add="pt0 pb48" remove="pt24 pb24" separator=" "/>
     </xpath>
     <!-- Replace h6 by paragraphs -->
     <xpath expr="//h6" position="replace" mode="inner">

--- a/theme_kiddo/views/new_page_template.xml
+++ b/theme_kiddo/views/new_page_template.xml
@@ -14,6 +14,8 @@
 <template id="new_page_template_s_picture_only" inherit_id="website.new_page_template_s_picture_only">
     <!-- Section -->
     <xpath expr="//section" position="attributes">
+        <!-- Added by both theme and new page template -->
+        <attribute name="class" add="o_colored_level" remove="o_colored_level" separator=" "/>
         <attribute name="data-oe-shape-data">{"shape":"web_editor/Origins/16","flip":["x"]}</attribute>
     </xpath>
     <!-- Shape -->
@@ -36,6 +38,8 @@
 <template id="new_page_template_basic_s_picture" inherit_id="website.new_page_template_basic_s_picture">
     <!-- Section -->
     <xpath expr="//section" position="attributes">
+        <!-- Added by both theme and new page template -->
+        <attribute name="class" add="o_colored_level" remove="o_colored_level" separator=" "/>
         <attribute name="data-oe-shape-data">{"shape":"web_editor/Origins/16","flip":["x"]}</attribute>
     </xpath>
     <!-- Shape -->
@@ -81,6 +85,8 @@
 <template id="new_page_template_about_s_picture" inherit_id="website.new_page_template_about_s_picture">
     <!-- Section -->
     <xpath expr="//section" position="attributes">
+        <!-- Added by both theme and new page template -->
+        <attribute name="class" add="o_colored_level" remove="o_colored_level" separator=" "/>
         <attribute name="data-oe-shape-data">{"shape":"web_editor/Origins/16","flip":["x"]}</attribute>
     </xpath>
     <!-- Shape -->
@@ -106,9 +112,21 @@
     </xpath>
 </template>
 
+<template id="new_page_template_about_full_s_image_text" inherit_id="website.new_page_template_about_full_s_image_text">
+    <xpath expr="//section" position="attributes">
+        <attribute name="class" remove="pt48 pb56" separator=" "/>
+    </xpath>
+</template>
+
 <template id="new_page_template_about_full_s_numbers" inherit_id="website.new_page_template_about_full_s_numbers">
     <xpath expr="//section" position="attributes">
         <attribute name="class" add="o_cc2" remove="o_cc3" separator=" "/>
+    </xpath>
+</template>
+
+<template id="new_page_template_about_full_s_text_image" inherit_id="website.new_page_template_about_full_s_text_image">
+    <xpath expr="//section" position="attributes">
+        <attribute name="class" remove="pt56 pb56" separator=" "/>
     </xpath>
 </template>
 
@@ -135,6 +153,12 @@
     </xpath>
 </template>
 
+<template id="new_page_template_landing_s_text_image" inherit_id="website.new_page_template_landing_s_text_image">
+    <xpath expr="//section" position="attributes">
+        <attribute name="class" remove="pt56 pb56" separator=" "/>
+    </xpath>
+</template>
+
 <template id="new_page_template_landing_1_s_banner" inherit_id="website.new_page_template_landing_1_s_banner">
     <!-- Shape option -->
     <xpath expr="//section" position="attributes">
@@ -150,12 +174,6 @@
     <!-- Section -->
     <xpath expr="//section" position="attributes">
         <attribute name="class" add="o_half_screen_height" remove="o_full_screen_height" separator=" "/>
-    </xpath>
-</template>
-
-<template id="new_page_template_landing_2_s_text_block_h2" inherit_id="website.new_page_template_landing_2_s_text_block_h2">
-    <xpath expr="//section" position="attributes">
-        <attribute name="class" add="o_cc2" separator=" "/>
     </xpath>
 </template>
 
@@ -190,6 +208,13 @@
     <xpath expr="//div[hasclass('o_we_shape')]" position="replace"/>
 </template>
 
+<template id="new_page_template_landing_5_s_banner" inherit_id="website.new_page_template_landing_5_s_banner">
+    <xpath expr="//section" position="attributes">
+        <!-- Added both by theme and new page template -->
+        <attribute name="class" add="o_full_screen_height" remove="o_full_screen_height" separator=" "/>
+    </xpath>
+</template>
+
 <!-- Snippet customization Gallery Pages -->
 
 <template id="new_page_template_gallery_s_banner" inherit_id="website.new_page_template_gallery_s_banner">
@@ -222,6 +247,7 @@
 <template id="new_page_template_gallery_s_image_text_2nd" inherit_id="website.new_page_template_gallery_s_image_text_2nd">
     <!-- Remove shape option -->
     <xpath expr="//section" position="attributes">
+        <attribute name="class" remove="pt48 pb56" separator=" "/>
         <attribute name="data-oe-shape-data"/>
     </xpath>
     <!-- Remove shape -->
@@ -238,6 +264,12 @@
 </template>
 
 <!-- Snippet customization Services Pages -->
+
+<template id="new_page_template_services_s_text_image" inherit_id="website.new_page_template_services_s_text_image">
+    <xpath expr="//section" position="attributes">
+        <attribute name="class" remove="pt56 pb56" separator=" "/>
+    </xpath>
+</template>
 
 <!-- Snippet customization Pricing Pages -->
 
@@ -260,6 +292,7 @@
 <template id="new_page_template_pricing_s_image_text_2nd" inherit_id="website.new_page_template_pricing_s_image_text_2nd">
     <!-- Remove shape option -->
     <xpath expr="//section" position="attributes">
+        <attribute name="class" remove="pt48 pb56" separator=" "/>
         <attribute name="data-oe-shape-data"/>
     </xpath>
     <!-- Remove shape -->
@@ -277,9 +310,16 @@
 
 <!-- Snippet customization Team Pages -->
 
+<template id="new_page_template_team_s_picture" inherit_id="website.new_page_template_team_s_picture">
+    <xpath expr="//section" position="attributes">
+        <!-- Added by both theme and new page template -->
+        <attribute name="class" add="o_colored_level" remove="o_colored_level" separator=" "/>
+    </xpath>
+</template>
+
 <template id="new_page_template_team_s_image_text" inherit_id="website.new_page_template_team_s_image_text">
     <xpath expr="//section" position="attributes">
-        <attribute name="class" add="pt32" remove="pt232" separator=" "/>
+        <attribute name="class" remove="pt232" separator=" "/>
         <attribute name="data-oe-shape-data"/>
     </xpath>
     <!-- Remove shape -->
@@ -288,7 +328,7 @@
 
 <template id="new_page_template_team_s_image_text_2nd" inherit_id="website.new_page_template_team_s_image_text_2nd">
     <xpath expr="//section" position="attributes">
-        <attribute name="class" add="pt32" remove="pt232" separator=" "/>
+        <attribute name="class" remove="pt32" separator=" "/>
         <attribute name="data-oe-shape-data"/>
     </xpath>
     <!-- Remove shape -->
@@ -303,7 +343,7 @@
 
 <template id="new_page_template_team_s_text_image" inherit_id="website.new_page_template_team_s_text_image">
     <xpath expr="//section" position="attributes">
-        <attribute name="class" add="pb32" remove="pb232" separator=" "/>
+        <attribute name="class" remove="pb56 pt56" separator=" "/>
         <attribute name="data-oe-shape-data"/>
     </xpath>
     <!-- Remove shape -->

--- a/theme_loftspace/views/new_page_template.xml
+++ b/theme_loftspace/views/new_page_template.xml
@@ -55,6 +55,12 @@
     </xpath>
 </template>
 
+<template id="new_page_template_s_features_grid" inherit_id="website.new_page_template_s_features_grid">
+    <xpath expr="(//i)[5]" position="attributes">
+        <attribute name="class" add="bg-o-color-2" remove="bg-o-color-1" separator=" "/>
+    </xpath>
+</template>
+
 <template id="new_page_template_s_product_catalog" inherit_id="website.new_page_template_s_product_catalog">
     <!-- Remove shape option -->
     <xpath expr="//section" position="attributes">
@@ -104,6 +110,24 @@
     </xpath>
 </template>
 
+<template id="new_page_template_about_full_s_image_text" inherit_id="website.new_page_template_about_full_s_image_text">
+    <xpath expr="//section" position="attributes">
+        <attribute name="class" remove="pt48 pb56" separator=" "/>
+    </xpath>
+</template>
+
+<template id="new_page_template_about_full_s_numbers" inherit_id="website.new_page_template_about_full_s_numbers">
+    <xpath expr="//section" position="attributes">
+        <attribute name="class" remove="o_cc3" separator=" "/>
+    </xpath>
+</template>
+
+<template id="new_page_template_about_full_s_text_image" inherit_id="website.new_page_template_about_full_s_text_image">
+    <xpath expr="//section" position="attributes">
+        <attribute name="class" remove="pt56 pb56" separator=" "/>
+    </xpath>
+</template>
+
 <template id="new_page_template_about_full_1_s_text_block_h1" inherit_id="website.new_page_template_about_full_1_s_text_block_h1">
     <xpath expr="//section" position="attributes">
         <attribute name="class" add="o_cc2" separator=" "/>
@@ -119,6 +143,18 @@
     <xpath expr="//div[hasclass('o_we_shape')]" position="replace"/>
 </template>
 
+<template id="new_page_template_about_mini_s_cover" inherit_id="website.new_page_template_about_mini_s_cover">
+    <xpath expr="//section" position="attributes">
+        <attribute name="class" remove="pt40" separator=" "/>
+    </xpath>
+</template>
+
+<template id="new_page_template_about_personal_s_numbers" inherit_id="website.new_page_template_about_personal_s_numbers">
+    <xpath expr="//section" position="attributes">
+        <attribute name="class" remove="o_cc3 pt0" separator=" "/>
+    </xpath>
+</template>
+
 <template id="new_page_template_about_personal_s_text_block_h2" inherit_id="website.new_page_template_about_personal_s_text_block_h2">
     <xpath expr="//section" position="attributes">
         <attribute name="class" add="o_cc5" remove="o_cc3" separator=" "/>
@@ -126,6 +162,18 @@
 </template>
 
 <!-- Snippet customization Landing Pages -->
+
+<template id="new_page_template_landing_s_text_image" inherit_id="website.new_page_template_landing_s_text_image">
+    <xpath expr="//section" position="attributes">
+        <attribute name="class" remove="pt56 pb56" separator=" "/>
+    </xpath>
+</template>
+
+<template id="new_page_template_landing_0_s_cover" inherit_id="website.new_page_template_landing_0_s_cover">
+    <xpath expr="//section" position="attributes">
+        <attribute name="class" remove="pt232" separator=" "/>
+    </xpath>
+</template>
 
 <template id="new_page_template_landing_1_s_banner" inherit_id="website.new_page_template_landing_1_s_banner">
     <!-- Shape option -->
@@ -177,6 +225,7 @@
 <template id="new_page_template_gallery_s_image_text_2nd" inherit_id="website.new_page_template_gallery_s_image_text_2nd">
     <!-- Remove shape option -->
     <xpath expr="//section" position="attributes">
+        <attribute name="class" remove="pt48 pb56" separator=" "/>
         <attribute name="data-oe-shape-data"/>
     </xpath>
     <!-- Remove shape -->
@@ -193,6 +242,18 @@
 </template>
 
 <!-- Snippet customization Services Pages -->
+
+<template id="new_page_template_services_s_image_text" inherit_id="website.new_page_template_services_s_image_text">
+    <xpath expr="//section" position="attributes">
+        <attribute name="class" remove="pt48 pb56" separator=" "/>
+    </xpath>
+</template>
+
+<template id="new_page_template_services_s_text_image" inherit_id="website.new_page_template_services_s_text_image">
+    <xpath expr="//section" position="attributes">
+        <attribute name="class" remove="pt56 pb56" separator=" "/>
+    </xpath>
+</template>
 
 <!-- Snippet customization Pricing Pages -->
 
@@ -215,6 +276,7 @@
 <template id="new_page_template_pricing_s_image_text_2nd" inherit_id="website.new_page_template_pricing_s_image_text_2nd">
     <!-- Remove shape option -->
     <xpath expr="//section" position="attributes">
+        <attribute name="class" remove="pt48 pb56" separator=" "/>
         <attribute name="data-oe-shape-data"/>
     </xpath>
     <!-- Remove shape -->
@@ -235,6 +297,12 @@
 <template id="new_page_template_team_s_text_block_h1" inherit_id="website.new_page_template_team_s_text_block_h1">
     <xpath expr="//section" position="attributes">
         <attribute name="class" add="o_cc2"  separator=" "/>
+    </xpath>
+</template>
+
+<template id="new_page_template_team_s_text_image" inherit_id="website.new_page_template_team_s_text_image">
+    <xpath expr="//section" position="attributes">
+        <attribute name="class" remove="pt56 pb56" separator=" "/>
     </xpath>
 </template>
 

--- a/theme_loftspace/views/snippets/s_comparisons.xml
+++ b/theme_loftspace/views/snippets/s_comparisons.xml
@@ -16,7 +16,7 @@
     </xpath>
     <!-- Card #3 -->
     <xpath expr="(//div[hasclass('card')])[3]" position="attributes">
-        <attribute name="class" add="bg-o-color-3" remove="bg-secondary" separator=" "/>
+        <attribute name="class" add="bg-o-color-3" remove="bg-o-color-2" separator=" "/>
     </xpath>
 </template>
 

--- a/theme_loftspace/views/snippets/s_features.xml
+++ b/theme_loftspace/views/snippets/s_features.xml
@@ -4,7 +4,7 @@
 <template id="s_features" inherit_id="website.s_features">
     <!-- First column : icon -->
     <xpath expr="//div[hasclass('row')]//div//i" position="attributes">
-        <attribute name="class" add="bg-o-color-3" remove="bg-primary" separator=" "/>
+        <attribute name="class" add="bg-o-color-3" remove="bg-o-color-1" separator=" "/>
     </xpath>
     <!-- Second column : icon -->
     <xpath expr="//div[hasclass('row')]//div[2]//i" position="attributes">
@@ -12,7 +12,7 @@
     </xpath>
     <!-- Third column : icon -->
     <xpath expr="//div[hasclass('row')]//div[3]//i" position="attributes">
-        <attribute name="class" add="bg-o-color-3" remove="bg-secondary" separator=" "/>
+        <attribute name="class" add="bg-o-color-3" remove="bg-o-color-2" separator=" "/>
     </xpath>
 </template>
 

--- a/theme_loftspace/views/snippets/s_features_grid.xml
+++ b/theme_loftspace/views/snippets/s_features_grid.xml
@@ -4,7 +4,7 @@
 <template id="s_features_grid" inherit_id="website.s_features_grid">
     <!-- Item #2 -->
     <xpath expr="(//i)[2]" position="attributes">
-        <attribute name="class" add="bg-o-color-2" remove="bg-primary" separator=" "/>
+        <attribute name="class" add="bg-o-color-2" remove="bg-o-color-1" separator=" "/>
     </xpath>
     <!-- Item #4 -->
     <xpath expr="(//i)[4]" position="attributes">
@@ -12,7 +12,7 @@
     </xpath>
     <!-- Item #5 -->
     <xpath expr="(//i)[5]" position="attributes">
-        <attribute name="class" add="rounded-circle bg-o-color-1" remove="rounded bg-secondary" separator=" "/>
+        <attribute name="class" add="rounded-circle bg-o-color-1" remove="rounded bg-o-color-2" separator=" "/>
     </xpath>
     <!-- Item #6 -->
     <xpath expr="(//i)[6]" position="attributes">

--- a/theme_loftspace/views/snippets/s_media_list.xml
+++ b/theme_loftspace/views/snippets/s_media_list.xml
@@ -2,10 +2,6 @@
 <odoo>
 
 <template id="s_media_list" inherit_id="website.s_media_list">
-    <!-- Section -->
-    <xpath expr="//section" position="attributes">
-        <attribute name="class" add="o_colored_level" separator=" "/>
-    </xpath>
     <!-- Media List Item #1 -->
     <xpath expr="//div[hasclass('s_media_list_item')]//div[hasclass('row')]" position="attributes">
         <attribute name="style">border-radius: 3px !important; box-shadow: 0px 0px 5px 0px rgba(0, 0, 0, 0.05) !important;</attribute>

--- a/theme_loftspace/views/snippets/s_three_columns.xml
+++ b/theme_loftspace/views/snippets/s_three_columns.xml
@@ -4,7 +4,7 @@
 <template id="s_three_columns" inherit_id="website.s_three_columns">
     <!-- Section -->
     <xpath expr="//section" position="attributes">
-        <attribute name="class" add="pt96 pb96 o_colored_level" remove="pt32 pb32 bg-200" separator=" "/>
+        <attribute name="class" add="pt96 pb96" remove="pt32 pb32 bg-200" separator=" "/>
     </xpath>
     <!-- Column #1 -->
     <xpath expr="//div[hasclass('card')]" position="attributes">

--- a/theme_monglia/views/customizations.xml
+++ b/theme_monglia/views/customizations.xml
@@ -179,7 +179,7 @@
 <!-- ======== CALL TO ACTION ======== -->
 <template id="s_call_to_action" inherit_id="website.s_call_to_action" name="Monglia s_call_to_action">
     <xpath expr="//section" position="attributes">
-        <attribute name="class" add="o_cc o_cc4" separator=" "/>
+        <attribute name="class" add="o_cc4" remove="o_cc3" separator=" "/>
     </xpath>
     <xpath expr="//h3" position="replace">
         <h3 style="text-align: left;"><b>APPLY FOR OUR V.I.P. CARD</b></h3>
@@ -195,7 +195,7 @@
 <!-- ======== 3-COLUMNS ======== -->
 <template id="s_three_columns" inherit_id="website.s_three_columns">
     <xpath expr="//section" position="attributes">
-        <attribute name="class" add="pb0 o_cc o_cc5" remove="pb32" separator=" "/>
+        <attribute name="class" add="pb0 o_cc5" remove="pb32 o_cc2" separator=" "/>
     </xpath>
     <xpath expr="//h3" position="replace" mode="inner">
         Wilson Holt

--- a/theme_monglia/views/new_page_template.xml
+++ b/theme_monglia/views/new_page_template.xml
@@ -30,7 +30,8 @@
 
 <template id="new_page_template_basic_2_s_text_block_h1" inherit_id="website.new_page_template_basic_2_s_text_block_h1">
     <xpath expr="//section" position="attributes">
-        <attribute name="class" add="o_cc2" remove="o_cc5" separator=" "/>
+        <!-- o_cc2 is added by both theme and new page template -->
+        <attribute name="class" add="o_cc2" remove="o_cc2 o_cc5" separator=" "/>
     </xpath>
 </template>
 
@@ -57,13 +58,13 @@
 
 <template id="new_page_template_about_full_1_s_text_block_h1" inherit_id="website.new_page_template_about_full_1_s_text_block_h1">
     <xpath expr="//section" position="attributes">
-        <attribute name="class" remove="o_cc2" separator=" "/>
+        <attribute name="class" add="pt40" remove="o_cc2 pt0" separator=" "/>
     </xpath>
 </template>
 
-<template id="new_page_template_about_full_1_s_text_block_h2" inherit_id="website.new_page_template_about_full_1_s_text_block_h2">
+<template id="new_page_template_about_full_s_image_text" inherit_id="website.new_page_template_about_full_s_image_text">
     <xpath expr="//section" position="attributes">
-        <attribute name="class" add="o_cc2" separator=" "/>
+        <attribute name="class" remove="pt48 pb56" separator=" "/>
     </xpath>
 </template>
 
@@ -73,8 +74,16 @@
     </xpath>
 </template>
 
+<template id="new_page_template_about_full_s_text_block_h1" inherit_id="website.new_page_template_about_full_s_text_block_h1">
+    <xpath expr="//section" position="attributes">
+        <attribute name="class" remove="o_cc2" separator=" "/>
+    </xpath>
+</template>
+
 <template id="new_page_template_about_full_s_text_image" inherit_id="website.new_page_template_about_full_s_text_image">
     <xpath expr="//section" position="attributes">
+        <!-- pt56 added by both theme and new page template -->
+        <attribute name="class" add="pt56" remove="pt56 pb40" separator=" "/>
         <attribute name="data-oe-shape-data">{"shape":"web_editor/Blocks/04","flip":["y"]}</attribute>
     </xpath>
     <xpath expr="//div[hasclass('container')]" position="before">
@@ -95,6 +104,9 @@
 </template>
 
 <template id="new_page_template_about_mini_s_text_block_2nd" inherit_id="website.new_page_template_about_mini_s_text_block_2nd">
+    <xpath expr="//section" position="attributes">
+        <attribute name="class" add="pt40" remove="pt0" separator=" "/>
+    </xpath>
     <xpath expr="//p" position="attributes">
         <attribute name="style" remove="font-size:36px;" separator=" "/>
     </xpath>
@@ -102,7 +114,8 @@
 
 <template id="new_page_template_about_personal_s_text_block_h2" inherit_id="website.new_page_template_about_personal_s_text_block_h2">
     <xpath expr="//section" position="attributes">
-        <attribute name="class" add="o_cc3" remove="o_cc5" separator=" "/>
+        <!-- o_cc3 is added by both theme and new page template -->
+        <attribute name="class" add="o_cc3" remove="o_cc3 o_cc5" separator=" "/>
     </xpath>
 </template>
 
@@ -110,6 +123,8 @@
 
 <template id="new_page_template_landing_s_text_image" inherit_id="website.new_page_template_landing_s_text_image">
     <xpath expr="//section" position="attributes">
+        <!-- pt56 is added by both theme and new page template -->
+        <attribute name="class" add="pt56" remove="pt56 pb40" separator=" "/>
         <attribute name="data-oe-shape-data">{"shape":"web_editor/Blocks/04","flip":["y"]}</attribute>
     </xpath>
     <xpath expr="//div[hasclass('container')]" position="before">
@@ -121,6 +136,31 @@
     <!-- Section -->
     <xpath expr="//section" position="attributes">
         <attribute name="class" add="o_half_screen_height" remove="o_full_screen_height" separator=" "/>
+    </xpath>
+</template>
+
+<template id="new_page_template_landing_2_s_text_block_h2" inherit_id="website.new_page_template_landing_2_s_text_block_h2">
+    <xpath expr="//section" position="attributes">
+        <attribute name="class" remove="o_cc2" separator=" "/>
+    </xpath>
+</template>
+
+<template id="new_page_template_landing_3_s_text_block_h2" inherit_id="website.new_page_template_landing_3_s_text_block_h2">
+    <xpath expr="//section" position="attributes">
+        <attribute name="class" remove="o_cc2" separator=" "/>
+    </xpath>
+</template>
+
+<template id="new_page_template_landing_4_s_text_block_h2" inherit_id="website.new_page_template_landing_4_s_text_block_h2">
+    <xpath expr="//section" position="attributes">
+        <attribute name="class" add="pt40" remove="pt0" separator=" "/>
+    </xpath>
+</template>
+
+<template id="new_page_template_landing_5_s_banner" inherit_id="website.new_page_template_landing_5_s_banner">
+    <xpath expr="//section" position="attributes">
+        <!-- Added both by theme and new page template -->
+        <attribute name="class" add="o_full_screen_height" remove="o_full_screen_height" separator=" "/>
     </xpath>
 </template>
 
@@ -139,14 +179,39 @@
     </xpath>
 </template>
 
+<template id="new_page_template_gallery_s_image_text_2nd" inherit_id="website.new_page_template_gallery_s_image_text_2nd">
+    <xpath expr="//section" position="attributes">
+        <attribute name="class" remove="pt48 pb56" separator=" "/>
+    </xpath>
+</template>
+
+<template id="new_page_template_gallery_2_s_text_block_2nd" inherit_id="website.new_page_template_gallery_2_s_text_block_2nd">
+    <xpath expr="//section" position="attributes">
+        <attribute name="class" add="pt40" remove="pt0" separator=" "/>
+    </xpath>
+</template>
+
 <!-- Snippet customization Services Pages -->
 
 <template id="new_page_template_services_s_text_image" inherit_id="website.new_page_template_services_s_text_image">
     <xpath expr="//section" position="attributes">
+        <attribute name="class" remove="pt56 pb56" separator=" "/>
         <attribute name="data-oe-shape-data">{"shape":"web_editor/Blocks/04","flip":["y"]}</attribute>
     </xpath>
     <xpath expr="//div[hasclass('container')]" position="before">
         <div class="o_we_shape o_web_editor_Blocks_04 o_second_extra_shape_mapping" style="background-image: url('/web_editor/shape/web_editor/Blocks/04.svg?c1=o-color-1&amp;c2=o-color-2&amp;c3=o-color-3&amp;c5=o-color-5&amp;flip=y'); background-position: 50% 0%;"/>
+    </xpath>
+</template>
+
+<template id="new_page_template_services_0_s_text_block_2nd" inherit_id="website.new_page_template_services_0_s_text_block_2nd">
+    <xpath expr="//section" position="attributes">
+        <attribute name="class" add="pt40" remove="pt0" separator=" "/>
+    </xpath>
+</template>
+
+<template id="new_page_template_services_2_s_text_image" inherit_id="website.new_page_template_services_2_s_text_image">
+    <xpath expr="//section" position="attributes">
+        <attribute name="class" add="pt56 pb56" remove="pb40" separator=" "/>
     </xpath>
 </template>
 
@@ -165,11 +230,25 @@
     </xpath>
 </template>
 
+<template id="new_page_template_pricing_s_image_text_2nd" inherit_id="website.new_page_template_pricing_s_image_text_2nd">
+    <xpath expr="//section" position="attributes">
+        <attribute name="class" remove="pt48 pb56" separator=" "/>
+    </xpath>
+</template>
+
+<template id="new_page_template_pricing_0_s_text_block_2nd" inherit_id="website.new_page_template_pricing_0_s_text_block_2nd">
+    <xpath expr="//section" position="attributes">
+        <attribute name="class" add="pt40" remove="pt0" separator=" "/>
+    </xpath>
+</template>
+
+
 <!-- Snippet customization Team Pages -->
 
 <template id="new_page_template_team_s_text_image" inherit_id="website.new_page_template_team_s_text_image">
     <!-- Shape option -->
     <xpath expr="//section" position="attributes">
+        <attribute name="class" remove="pt56 pb56" separator=" "/>
         <attribute name="data-oe-shape-data">{"shape":"web_editor/Floats/13","flip":["y"]}</attribute>
     </xpath>
     <!-- Shape -->
@@ -187,6 +266,12 @@
 <template id="new_page_template_team_1_s_text_block_h1" inherit_id="website.new_page_template_team_1_s_text_block_h1">
     <xpath expr="//section" position="attributes">
         <attribute name="class" add="pb0" remove="pb40" separator=" "/>
+    </xpath>
+</template>
+
+<template id="new_page_template_team_1_s_text_image" inherit_id="website.new_page_template_team_1_s_text_image">
+    <xpath expr="//section" position="attributes">
+        <attribute name="class" add="pt56 pb56" remove="pb40" separator=" "/>
     </xpath>
 </template>
 

--- a/theme_nano/views/new_page_template.xml
+++ b/theme_nano/views/new_page_template.xml
@@ -54,6 +54,18 @@
     </xpath>
 </template>
 
+<template id="new_page_template_s_text_block_h1" inherit_id="website.new_page_template_s_text_block_h1">
+    <xpath expr="//section" position="attributes">
+        <attribute name="class" add="o_cc5" remove="o_cc1 pb0" separator=" "/>
+    </xpath>
+</template>
+
+<template id="new_page_template_s_text_block_h2" inherit_id="website.new_page_template_s_text_block_h2">
+    <xpath expr="//section" position="attributes">
+        <attribute name="class" add="o_cc5" remove="o_cc1 pb0" separator=" "/>
+    </xpath>
+</template>
+
 <template id="new_page_template_s_text_block_h2_contact" inherit_id="website.new_page_template_s_text_block_h2_contact">
     <xpath expr="//section" position="attributes">
         <attribute name="class" remove="pb40 pb96" separator=" "/>
@@ -67,13 +79,13 @@
 
 <template id="new_page_template_basic_s_text_block_h1" inherit_id="website.new_page_template_basic_s_text_block_h1">
     <xpath expr="//section" position="attributes">
-        <attribute name="class" add="o_cc5 pb40" remove="pb96 o_cc1" separator=" "/>
+        <attribute name="class" add="pb40" remove="pb96" separator=" "/>
     </xpath>
 </template>
 
 <template id="new_page_template_basic_2_s_text_block_h1" inherit_id="website.new_page_template_basic_2_s_text_block_h1">
     <xpath expr="//section" position="attributes">
-        <attribute name="class" add="o_cc1 pb96" remove="pb40 o_cc5" separator=" "/>
+        <attribute name="class" add="pb96" remove="pb0 pb40 o_cc5" separator=" "/>
     </xpath>
 </template>
 
@@ -98,7 +110,7 @@
 
 <template id="new_page_template_about_s_text_block_h1" inherit_id="website.new_page_template_about_s_text_block_h1">
     <xpath expr="//section" position="attributes">
-        <attribute name="class" add="o_cc5" remove="pb96" separator=" "/>
+        <attribute name="class" remove="pb96" separator=" "/>
     </xpath>
 </template>
 
@@ -110,19 +122,32 @@
 
 <template id="new_page_template_about_full_1_s_text_block_h1" inherit_id="website.new_page_template_about_full_1_s_text_block_h1">
     <xpath expr="//section" position="attributes">
-        <attribute name="class" add="o_cc5 pb0" remove="o_cc5 pb40 pt40" separator=" "/>
+        <attribute name="class" add="pb0" remove="pb40 pt40" separator=" "/>
     </xpath>
 </template>
 
 <template id="new_page_template_about_full_1_s_text_block_h2" inherit_id="website.new_page_template_about_full_1_s_text_block_h2">
     <xpath expr="//section" position="attributes">
-        <attribute name="class" remove="pb96" separator=" "/>
+        <attribute name="class" add="o_cc1" remove="o_cc5 pb96" separator=" "/>
+    </xpath>
+</template>
+
+<template id="new_page_template_about_full_s_image_text" inherit_id="website.new_page_template_about_full_s_image_text">
+    <xpath expr="//section" position="attributes">
+        <!-- pt48 added by both theme and new page template -->
+        <attribute name="class" add="pt48" remove="pt48 pb48" separator=" "/>
     </xpath>
 </template>
 
 <template id="new_page_template_about_full_s_text_block_h1" inherit_id="website.new_page_template_about_full_s_text_block_h1">
     <xpath expr="//section" position="attributes">
-        <attribute name="class" add="pt40" remove="pb0" separator=" "/>
+        <attribute name="class" add="pb0" separator=" "/>
+    </xpath>
+</template>
+
+<template id="new_page_template_about_full_s_text_image" inherit_id="website.new_page_template_about_full_s_text_image">
+    <xpath expr="//section" position="attributes">
+        <attribute name="class" remove="pt48 pb48" separator=" "/>
     </xpath>
 </template>
 
@@ -139,18 +164,33 @@
 </template>
 
 <template id="new_page_template_about_map_s_text_block_h1" inherit_id="website.new_page_template_about_map_s_text_block_h1">
+    <xpath expr="//section" position="attributes">
+        <attribute name="class" add="pb0" separator=" "/>
+    </xpath>
     <xpath expr="//h1" position="replace" mode="inner">About Us</xpath>
 </template>
 
 <template id="new_page_template_about_map_s_text_block_h2" inherit_id="website.new_page_template_about_map_s_text_block_h2">
     <xpath expr="//section" position="attributes">
-        <attribute name="class" add="pb40" remove="pb96" separator=" "/>
+        <attribute name="class" add="o_cc1 pb40" remove="o_cc5 pb96" separator=" "/>
+    </xpath>
+</template>
+
+<template id="new_page_template_about_mini_s_cover" inherit_id="website.new_page_template_about_mini_s_cover">
+    <xpath expr="//section" position="attributes">
+        <attribute name="class" remove="pt40 pb40" separator=" "/>
+    </xpath>
+</template>
+
+<template id="new_page_template_about_mini_s_text_block_2nd" inherit_id="website.new_page_template_about_mini_s_text_block_2nd">
+    <xpath expr="//section" position="attributes">
+        <attribute name="class" add="pt40" separator=" "/>
     </xpath>
 </template>
 
 <template id="new_page_template_about_mini_s_text_block_h2" inherit_id="website.new_page_template_about_mini_s_text_block_h2">
     <xpath expr="//section" position="attributes">
-        <attribute name="class" add="pb0" remove="pb96" separator=" "/>
+        <attribute name="class" add="o_cc1 pb0" remove="o_cc5 pb96" separator=" "/>
     </xpath>
     <xpath expr="//*[hasclass('container')]" position="attributes">
         <attribute name="class" add="o_container_small" remove="container" separator=" "/>
@@ -165,13 +205,14 @@
 
 <template id="new_page_template_about_personal_s_text_block_h2" inherit_id="website.new_page_template_about_personal_s_text_block_h2">
     <xpath expr="//section" position="attributes">
-        <attribute name="class" add="o_cc2 pb40 pt40" remove="o_cc3 pb96 pt96" separator=" "/>
+        <!-- o_cc is defined in both theme and new page template -->
+        <attribute name="class" add="o_cc o_cc2 pb40 pt40" remove="o_cc o_cc3 o_cc5 pb0 pb96 pt96" separator=" "/>
     </xpath>
 </template>
 
 <template id="new_page_template_about_timeline_s_text_block_h2" inherit_id="website.new_page_template_about_timeline_s_text_block_h2">
     <xpath expr="//section" position="attributes">
-        <attribute name="class" add="o_cc5 pb40" remove="pb96" separator=" "/>
+        <attribute name="class" add="pb40" remove="pb96" separator=" "/>
     </xpath>
 </template>
 
@@ -186,9 +227,16 @@
     <xpath expr="//div[hasclass('o_we_shape')]" position="replace"/>
 </template>
 
+<template id="new_page_template_landing_s_text_image" inherit_id="website.new_page_template_landing_s_text_image">
+    <xpath expr="//section" position="attributes">
+        <attribute name="class" remove="pt48 pb48" separator=" "/>
+    </xpath>
+</template>
+
 <template id="new_page_template_landing_0_s_cover" inherit_id="website.new_page_template_landing_0_s_cover">
     <!-- Shape option -->
     <xpath expr="//section" position="attributes">
+        <attribute name="class" remove="pt200 pb200" separator=" "/>
         <attribute name="data-oe-shape-data">{"shape":"web_editor/Bold/12_001","flip":["x"]}</attribute>
     </xpath>
     <xpath expr="//*[hasclass('container')]" position="before">
@@ -209,13 +257,13 @@
 
 <template id="new_page_template_landing_2_s_text_block_h2" inherit_id="website.new_page_template_landing_2_s_text_block_h2">
     <xpath expr="//section" position="attributes">
-        <attribute name="class" add="o_cc5" remove="pb96 o_cc2" separator=" "/>
+        <attribute name="class" add="pb0" remove="pb96 o_cc2" separator=" "/>
     </xpath>
 </template>
 
 <template id="new_page_template_landing_3_s_text_block_h2" inherit_id="website.new_page_template_landing_3_s_text_block_h2">
     <xpath expr="//section" position="attributes">
-        <attribute name="class" add="o_cc5" remove="pb96 o_cc2" separator=" "/>
+        <attribute name="class" add="pb0" remove="pb96 o_cc2" separator=" "/>
     </xpath>
 </template>
 
@@ -231,7 +279,7 @@
 
 <template id="new_page_template_landing_4_s_text_block_h2" inherit_id="website.new_page_template_landing_4_s_text_block_h2">
     <xpath expr="//section" position="attributes">
-        <attribute name="class" add="o_cc5 pb40" remove="pb40 pb96" separator=" "/>
+        <attribute name="class" add="pb40" remove="pb40 pb96" separator=" "/>
     </xpath>
 </template>
 
@@ -248,6 +296,13 @@
     </xpath>
 </template>
 
+<template id="new_page_template_gallery_s_image_text_2nd" inherit_id="website.new_page_template_gallery_s_image_text_2nd">
+    <xpath expr="//section" position="attributes">
+        <!-- pt48 is defined by both theme and new page template -->
+        <attribute name="class" add="pt48" remove="pt40 pt48 pb48" separator=" "/>
+    </xpath>
+</template>
+
 <template id="new_page_template_gallery_s_media_list" inherit_id="website.new_page_template_gallery_s_media_list">
     <xpath expr="//section" position="attributes">
         <attribute name="class" add="o_cc1" remove="o_cc2" separator=" "/>
@@ -256,7 +311,7 @@
 
 <template id="new_page_template_gallery_s_text_block_h2" inherit_id="website.new_page_template_gallery_s_text_block_h2">
     <xpath expr="//section" position="attributes">
-        <attribute name="class" add="o_cc5" remove="pb96" separator=" "/>
+        <attribute name="class" add="pb0" remove="pb96" separator=" "/>
     </xpath>
 </template>
 
@@ -264,19 +319,31 @@
 
 <template id="new_page_template_services_s_text_block_h1" inherit_id="website.new_page_template_services_s_text_block_h1">
     <xpath expr="//section" position="attributes">
-        <attribute name="class" remove="pb96" separator=" "/>
+        <attribute name="class" add="o_cc1 pb0" remove="o_cc5 pb96" separator=" "/>
     </xpath>
 </template>
 
 <template id="new_page_template_services_s_text_block_h2" inherit_id="website.new_page_template_services_s_text_block_h2">
     <xpath expr="//section" position="attributes">
-        <attribute name="class" remove="pb96" separator=" "/>
+        <attribute name="class" add="o_cc1 pb0" remove="o_cc5 pb96" separator=" "/>
     </xpath>
 </template>
 
 <template id="new_page_template_services_s_text_cover" inherit_id="website.new_page_template_services_s_text_cover">
     <xpath expr="//section" position="attributes">
         <attribute name="class" add="o_cc5" separator=" "/>
+    </xpath>
+</template>
+
+<template id="new_page_template_services_s_text_image" inherit_id="website.new_page_template_services_s_text_image">
+    <xpath expr="//section" position="attributes">
+        <attribute name="class" remove="pt48 pb48" separator=" "/>
+    </xpath>
+</template>
+
+<template id="new_page_template_services_3_s_parallax" inherit_id="website.new_page_template_services_3_s_parallax">
+    <xpath expr="//section" position="attributes">
+        <attribute name="class" remove="pt48 pb48" separator=" "/>
     </xpath>
 </template>
 
@@ -299,21 +366,34 @@
     </xpath>
 </template>
 
+<template id="new_page_template_pricing_s_image_text_2nd" inherit_id="website.new_page_template_pricing_s_image_text_2nd">
+    <xpath expr="//section" position="attributes">
+        <!-- Defined by both theme and new page template -->
+        <attribute name="class" add="pt48" remove="pt48" separator=" "/>
+    </xpath>
+</template>
+
 <template id="new_page_template_pricing_s_text_block_h1" inherit_id="website.new_page_template_pricing_s_text_block_h1">
     <xpath expr="//section" position="attributes">
-        <attribute name="class" remove="pb96" separator=" "/>
+        <attribute name="class" add="pb0 o_cc1" remove="o_cc5 pb96" separator=" "/>
     </xpath>
 </template>
 
 <template id="new_page_template_pricing_s_text_block_h2" inherit_id="website.new_page_template_pricing_s_text_block_h2">
     <xpath expr="//section" position="attributes">
-        <attribute name="class" remove="pb96" separator=" "/>
+        <attribute name="class" add="pb0 o_cc1" remove="o_cc5 pb96" separator=" "/>
+    </xpath>
+</template>
+
+<template id="new_page_template_pricing_4_s_image_text_2nd" inherit_id="website.new_page_template_pricing_4_s_image_text_2nd">
+    <xpath expr="//section" position="attributes">
+        <attribute name="class" remove="pt40 pb48" separator=" "/>
     </xpath>
 </template>
 
 <template id="new_page_template_pricing_5_s_text_block_h1" inherit_id="website.new_page_template_pricing_5_s_text_block_h1">
     <xpath expr="//section" position="attributes">
-        <attribute name="class" add="pb96" separator=" "/>
+        <attribute name="class" add="pb96" remove="pb0" separator=" "/>
     </xpath>
 </template>
 
@@ -321,7 +401,13 @@
 
 <template id="new_page_template_team_s_text_block_h1" inherit_id="website.new_page_template_team_s_text_block_h1">
     <xpath expr="//section" position="attributes">
-        <attribute name="class" add="o_cc5" remove="pb96" separator=" "/>
+        <attribute name="class" remove="pb96" separator=" "/>
+    </xpath>
+</template>
+
+<template id="new_page_template_team_s_text_image" inherit_id="website.new_page_template_team_s_text_image">
+    <xpath expr="//section" position="attributes">
+        <attribute name="class" remove="pt48 pb48" separator=" "/>
     </xpath>
 </template>
 
@@ -339,13 +425,13 @@
 
 <template id="new_page_template_team_2_s_text_block_h1" inherit_id="website.new_page_template_team_2_s_text_block_h1">
     <xpath expr="//section" position="attributes">
-        <attribute name="class" remove="o_cc5 pb0" separator=" "/>
+        <attribute name="class" add="o_cc1" remove="o_cc5 pb0" separator=" "/>
     </xpath>
 </template>
 
 <template id="new_page_template_team_3_s_text_block_h1" inherit_id="website.new_page_template_team_3_s_text_block_h1">
     <xpath expr="//section" position="attributes">
-        <attribute name="class" remove="o_cc5 pb40" separator=" "/>
+        <attribute name="class" add="o_cc1" remove="o_cc5 pb40" separator=" "/>
     </xpath>
 </template>
 

--- a/theme_notes/views/new_page_template.xml
+++ b/theme_notes/views/new_page_template.xml
@@ -72,6 +72,13 @@
     <xpath expr="//div[hasclass('o_we_shape')]" position="replace"/>
 </template>
 
+<template id="new_page_template_s_quotes_carousel" inherit_id="website.new_page_template_s_quotes_carousel">
+    <xpath expr="//section" position="attributes">
+        <!-- o_cc is added by both theme and new page template -->
+        <attribute name="class" add="o_cc" remove="o_cc o_cc1" separator=" "/>
+    </xpath>
+</template>
+
 <!-- Snippet customization Basic Pages -->
 
 <!-- Needed because it is removed for basic -->
@@ -119,21 +126,28 @@
     </xpath>
 </template>
 
+<template id="new_page_template_about_full_s_image_text" inherit_id="website.new_page_template_about_full_s_image_text">
+    <xpath expr="//section" position="attributes">
+        <attribute name="class" remove="pt48 pb56" separator=" "/>
+    </xpath>
+</template>
+
 <template id="new_page_template_about_full_s_numbers" inherit_id="website.new_page_template_about_full_s_numbers">
     <xpath expr="//section" position="attributes">
-        <attribute name="class" add="o_cc2" remove="o_cc3" separator=" "/>
+        <attribute name="class" add="o_cc o_cc2 pt24 pb24" remove="o_cc3 pt0 pb0" separator=" "/>
     </xpath>
 </template>
 
 <template id="new_page_template_about_full_s_text_block_h1" inherit_id="website.new_page_template_about_full_s_text_block_h1">
     <xpath expr="//section" position="attributes">
-        <attribute name="class" add="pb40 pb40 pt40" remove="o_cc2 pb0" separator=" "/>
+        <attribute name="class" add="pb40" remove="o_cc2 pb0" separator=" "/>
     </xpath>
 </template>
 
 <template id="new_page_template_about_full_s_text_image" inherit_id="website.new_page_template_about_full_s_text_image">
     <!-- Shape option -->
     <xpath expr="//section" position="attributes">
+        <attribute name="class" remove="pt56 pb56" separator=" "/>
         <attribute name="data-oe-shape-data">{"shape":"web_editor/Wavy/11","flip":["x"]}</attribute>
     </xpath>
 </template>
@@ -141,6 +155,13 @@
 <template id="new_page_template_about_map_s_text_block_h1" inherit_id="website.new_page_template_about_map_s_text_block_h1">
     <xpath expr="//section" position="attributes">
         <attribute name="class" remove="o_cc2" separator=" "/>
+    </xpath>
+</template>
+
+<template id="new_page_template_about_personal_s_numbers" inherit_id="website.new_page_template_about_personal_s_numbers">
+    <xpath expr="//section" position="attributes">
+        <!-- pt0 is defined by both theme and new page template -->
+        <attribute name="class" add="o_cc pt0" remove="pt0" separator=" "/>
     </xpath>
 </template>
 
@@ -153,6 +174,7 @@
 <template id="new_page_template_landing_s_text_image" inherit_id="website.new_page_template_landing_s_text_image">
     <!-- Shape option -->
     <xpath expr="//section" position="attributes">
+        <attribute name="class" remove="pt56 pb56" separator=" "/>
         <attribute name="data-oe-shape-data">{"shape":"web_editor/Wavy/11","flip":["x"]}</attribute>
     </xpath>
 </template>
@@ -212,11 +234,18 @@
     </xpath>
 </template>
 
+<template id="new_page_template_gallery_s_image_text_2nd" inherit_id="website.new_page_template_gallery_s_image_text_2nd">
+    <xpath expr="//section" position="attributes">
+        <attribute name="class" remove="pt48 pb56" separator=" "/>
+    </xpath>
+</template>
+
 <!-- Snippet customization Services Pages -->
 
 <template id="new_page_template_services_s_text_image" inherit_id="website.new_page_template_services_s_text_image">
     <!-- Shape option -->
     <xpath expr="//section" position="attributes">
+        <attribute name="class" remove="pt56 pb56" separator=" "/>
         <attribute name="data-oe-shape-data">{"shape":"web_editor/Wavy/11","flip":["x"]}</attribute>
     </xpath>
 </template>
@@ -241,11 +270,18 @@
     </xpath>
 </template>
 
+<template id="new_page_template_pricing_s_image_text_2nd" inherit_id="website.new_page_template_pricing_s_image_text_2nd">
+    <xpath expr="//section" position="attributes">
+        <attribute name="class" remove="pt48 pb56" separator=" "/>
+    </xpath>
+</template>
+
 <!-- Snippet customization Team Pages -->
 
 <template id="new_page_template_team_s_text_image" inherit_id="website.new_page_template_team_s_text_image">
     <!-- Shape option -->
     <xpath expr="//section" position="attributes">
+        <attribute name="class" remove="pt56 pb56" separator=" "/>
         <attribute name="data-oe-shape-data">{"shape":"web_editor/Wavy/11","flip":["x"]}</attribute>
     </xpath>
 </template>

--- a/theme_odoo_experts/views/new_page_template.xml
+++ b/theme_odoo_experts/views/new_page_template.xml
@@ -33,19 +33,6 @@
     </xpath>
 </template>
 
-<template id="new_page_template_s_picture_only" inherit_id="website.new_page_template_s_picture_only" primary="True">
-    <xpath expr="//a" position="replace"/>
-    <!-- Shape option -->
-    <xpath expr="//section" position="attributes">
-        <attribute name="class" add="o_cc2" remove="o_cc3" separator=" "/>
-        <attribute name="data-oe-shape-data">{"shape":"web_editor/Wavy/08","flip":["y"]}</attribute>
-    </xpath>
-    <!-- Shape -->
-    <xpath expr="//div[hasclass('container')]" position="before">
-        <div class="o_we_shape o_web_editor_Wavy_08" style="background-image: url('/web_editor/shape/web_editor/Wavy/08.svg?c2=o-color-3&amp;flip=y'); background-position: 50% 100%;"/>
-    </xpath>
-</template>
-
 <template id="new_page_template_s_product_catalog" inherit_id="website.new_page_template_s_product_catalog">
     <!-- Remove shape option -->
     <xpath expr="//section" position="attributes">
@@ -90,7 +77,7 @@
     <xpath expr="//a" position="replace"/>
     <!-- Shape option -->
     <xpath expr="//section" position="attributes">
-        <attribute name="class" add="o_cc2" remove="o_cc3" separator=" "/>
+        <attribute name="class" add="o_cc2" remove="o_cc1" separator=" "/>
         <attribute name="data-oe-shape-data">{"shape":"web_editor/Wavy/08","flip":["y"]}</attribute>
     </xpath>
     <!-- Shape -->
@@ -117,7 +104,7 @@
     <xpath expr="//a" position="replace"/>
     <!-- Shape option -->
     <xpath expr="//section" position="attributes">
-        <attribute name="class" add="o_cc2" remove="o_cc3" separator=" "/>
+        <attribute name="class" add="o_cc2" remove="o_cc1" separator=" "/>
         <attribute name="data-oe-shape-data">{"shape":"web_editor/Wavy/08","flip":["y"]}</attribute>
     </xpath>
     <!-- Shape -->
@@ -132,6 +119,24 @@
     </xpath>
 </template>
 
+<template id="new_page_template_about_full_s_numbers" inherit_id="website.new_page_template_about_full_s_numbers">
+    <xpath expr="//section" position="attributes">
+        <attribute name="class" remove="o_cc3" separator=" "/>
+    </xpath>
+</template>
+
+<template id="new_page_template_about_full_s_text_image" inherit_id="website.new_page_template_about_full_s_text_image">
+    <xpath expr="//section" position="attributes">
+        <attribute name="class" remove="pt56 pb56" separator=" "/>
+    </xpath>
+</template>
+
+<template id="new_page_template_about_personal_s_numbers" inherit_id="website.new_page_template_about_personal_s_numbers">
+    <xpath expr="//section" position="attributes">
+        <attribute name="class" remove="o_cc3 pt0" separator=" "/>
+    </xpath>
+</template>
+
 <template id="new_page_template_about_personal_s_text_block_h2" inherit_id="website.new_page_template_about_personal_s_text_block_h2">
     <xpath expr="//section" position="attributes">
         <attribute name="class" remove="o_cc3" separator=" "/>
@@ -139,6 +144,12 @@
 </template>
 
 <!-- Snippet customization Landing Pages -->
+
+<template id="new_page_template_landing_s_text_image" inherit_id="website.new_page_template_landing_s_text_image">
+    <xpath expr="//section" position="attributes">
+        <attribute name="class" remove="pt56 pb56" separator=" "/>
+    </xpath>
+</template>
 
 <template id="new_page_template_landing_2_s_cover" inherit_id="website.new_page_template_landing_2_s_cover">
     <xpath expr="//section" position="attributes">
@@ -156,6 +167,12 @@
 
 <!-- Snippet customization Services Pages -->
 
+<template id="new_page_template_services_s_text_image" inherit_id="website.new_page_template_services_s_text_image">
+    <xpath expr="//section" position="attributes">
+        <attribute name="class" remove="pt56 pb56" separator=" "/>
+    </xpath>
+</template>
+
 <!-- Snippet customization Pricing Pages -->
 
 <template id="new_page_template_pricing_s_cover" inherit_id="website.new_page_template_pricing_s_cover">
@@ -169,6 +186,12 @@
 <template id="new_page_template_team_s_text_block_h1" inherit_id="website.new_page_template_team_s_text_block_h1">
     <xpath expr="//section" position="attributes">
         <attribute name="class" add="o_cc2" separator=" "/>
+    </xpath>
+</template>
+
+<template id="new_page_template_team_s_text_image" inherit_id="website.new_page_template_team_s_text_image">
+    <xpath expr="//section" position="attributes">
+        <attribute name="class" remove="pt56 pb56" separator=" "/>
     </xpath>
 </template>
 

--- a/theme_odoo_experts/views/snippets/s_comparisons.xml
+++ b/theme_odoo_experts/views/snippets/s_comparisons.xml
@@ -14,14 +14,14 @@
         <attribute name="class" add="bg-o-color-1" remove="bg-o-color-5" separator=" "/>
     </xpath>
     <xpath expr="(//div[hasclass('card')])[2]//a[hasclass('btn')]" position="attributes">
-        <attribute name="class" add="btn-secondary" remove="bg-primary" separator=" "/>
+        <attribute name="class" add="btn-secondary" remove="btn-primary" separator=" "/>
     </xpath>
     <!-- Box #03 -->
     <xpath expr="//div[hasclass('row')]//div[3]" position="attributes">
         <attribute name="class" add="pt80" remove="pt32" separator=" "/>
     </xpath>
     <xpath expr="(//div[hasclass('card')])[3]" position="attributes">
-        <attribute name="class" add="bg-o-color-3" remove="bg-secondary" separator=" "/>
+        <attribute name="class" add="bg-o-color-3" remove="bg-o-color-2" separator=" "/>
     </xpath>
 </template>
 

--- a/theme_odoo_experts/views/snippets/s_media_list.xml
+++ b/theme_odoo_experts/views/snippets/s_media_list.xml
@@ -4,7 +4,7 @@
 <template id="s_media_list" inherit_id="website.s_media_list">
     <!-- Section -->
     <xpath expr="//section" position="attributes">
-        <attribute name="class" add="pt120 pb120 o_cc4 o_colored_level" remove="pt32 pb32 o_cc2" separator=" "/>
+        <attribute name="class" add="pt120 pb120 o_cc4" remove="pt32 pb32 o_cc2" separator=" "/>
     </xpath>
 
     <!-- Row #1 -->

--- a/theme_odoo_experts/views/snippets/s_three_columns.xml
+++ b/theme_odoo_experts/views/snippets/s_three_columns.xml
@@ -4,7 +4,7 @@
 <template id="s_three_columns" inherit_id="website.s_three_columns">
     <!-- Section -->
     <xpath expr="//section" position="attributes">
-        <attribute name="class" add="pt72 pb72 o_colored_level" remove="pt32 pb32" separator=" "/>
+        <attribute name="class" add="pt72 pb72" remove="pt32 pb32" separator=" "/>
         <attribute name="data-oe-shape-data">{"shape":"web_editor/Floats/04","flip":[]}</attribute>
     </xpath>
     <!-- Shape -->

--- a/theme_orchid/views/new_page_template.xml
+++ b/theme_orchid/views/new_page_template.xml
@@ -107,6 +107,7 @@
 <template id="new_page_template_about_full_s_image_text" inherit_id="website.new_page_template_about_full_s_image_text">
     <!-- Shape option -->
     <xpath expr="//section" position="attributes">
+        <attribute name="class" remove="pb56" separator=" "/>
         <attribute name="data-oe-shape-data">{"shape":"web_editor/Wavy/04","flip":["x"]}</attribute>
     </xpath>
     <!-- Shape -->
@@ -115,9 +116,22 @@
     </xpath>
 </template>
 
+<template id="new_page_template_about_full_s_numbers" inherit_id="website.new_page_template_about_full_s_numbers">
+    <xpath expr="//section" position="attributes">
+        <!-- Defined in both theme and new page template -->
+        <attribute name="class" add="o_cc3" remove="o_cc3" separator=" "/>
+    </xpath>
+</template>
+
 <template id="new_page_template_about_full_s_text_block_h1" inherit_id="website.new_page_template_about_full_s_text_block_h1">
     <xpath expr="//section" position="attributes">
-        <attribute name="class" add="o_cc2 pb40 pb40 pt40" remove="pb0" separator=" "/>
+        <attribute name="class" add="o_cc2 pb40" remove="pb0" separator=" "/>
+    </xpath>
+</template>
+
+<template id="new_page_template_about_full_s_text_image" inherit_id="website.new_page_template_about_full_s_text_image">
+    <xpath expr="//section" position="attributes">
+        <attribute name="class" remove="pt56 pb56" separator=" "/>
     </xpath>
 </template>
 
@@ -139,6 +153,13 @@
     </xpath>
 </template>
 
+<template id="new_page_template_about_personal_s_numbers" inherit_id="website.new_page_template_about_personal_s_numbers">
+    <xpath expr="//section" position="attributes">
+        <!-- Defined in both theme and new page template -->
+        <attribute name="class" add="o_cc3" remove="o_cc3" separator=" "/>
+    </xpath>
+</template>
+
 <!-- Snippet customization Landing Pages -->
 
 <template id="new_page_template_landing_s_showcase" inherit_id="website.new_page_template_landing_s_showcase">
@@ -150,6 +171,7 @@
 <template id="new_page_template_landing_s_text_image" inherit_id="website.new_page_template_landing_s_text_image">
     <!-- Remove shape option -->
     <xpath expr="//section" position="attributes">
+        <attribute name="class" remove="pt56 pb56" separator=" "/>
         <attribute name="data-oe-shape-data"/>
     </xpath>
     <!-- Remove shape -->
@@ -201,6 +223,13 @@
     </xpath>
 </template>
 
+<template id="new_page_template_landing_4_s_cover" inherit_id="website.new_page_template_landing_4_s_cover">
+    <xpath expr="//section" position="attributes">
+        <!-- o_half_screen_height is defined by both theme and new page template -->
+        <attribute name="class" add="o_half_screen_height" remove="o_half_screen_height" separator=" "/>
+    </xpath>
+</template>
+
 <!-- Snippet customization Gallery Pages -->
 
 <template id="new_page_template_gallery_s_cover" inherit_id="website.new_page_template_gallery_s_cover">
@@ -225,6 +254,12 @@
     </xpath>
 </template>
 
+<template id="new_page_template_gallery_s_image_text_2nd" inherit_id="website.new_page_template_gallery_s_image_text_2nd">
+    <xpath expr="//section" position="attributes">
+        <attribute name="class" remove="pb56" separator=" "/>
+    </xpath>
+</template>
+
 <!-- Snippet customization Services Pages -->
 
 <template id="new_page_template_services_s_image_text" inherit_id="website.new_page_template_services_s_image_text">
@@ -235,6 +270,12 @@
     <!-- Shape -->
     <xpath expr="//div[hasclass('container')]" position="before">
         <div class="o_we_shape o_web_editor_Wavy_04" style="background-image: url('/web_editor/shape/web_editor/Wavy/04.svg?c1=o-color-1&amp;c5=o-color-1&amp;flip=x'); background-position: 50% 100%;"/>
+    </xpath>
+</template>
+
+<template id="new_page_template_services_s_text_image" inherit_id="website.new_page_template_services_s_text_image">
+    <xpath expr="//section" position="attributes">
+        <attribute name="class" remove="pt56 pb56" separator=" "/>
     </xpath>
 </template>
 
@@ -262,11 +303,18 @@
     </xpath>
 </template>
 
+<template id="new_page_template_pricing_s_image_text_2nd" inherit_id="website.new_page_template_pricing_s_image_text_2nd">
+    <xpath expr="//section" position="attributes">
+        <attribute name="class" remove="pb56" separator=" "/>
+    </xpath>
+</template>
+
 <!-- Snippet customization Team Pages -->
 
 <template id="new_page_template_team_s_text_image" inherit_id="website.new_page_template_team_s_text_image">
     <!-- Remove shape option -->
     <xpath expr="//section" position="attributes">
+        <attribute name="class" remove="pt56 pb56" separator=" "/>
         <attribute name="data-oe-shape-data"/>
     </xpath>
     <!-- Remove shape -->

--- a/theme_paptic/views/customizations.xml
+++ b/theme_paptic/views/customizations.xml
@@ -218,7 +218,7 @@
 <!-- ==== Three Columns ===== -->
 <template id="s_three_columns" inherit_id="website.s_three_columns" name="Paptic s_three_columns">
     <xpath expr="//section" position="attributes">
-        <attribute name="class" remove="pt32 pb32 o_cc2" add="pt120 pb120 o_cc3 o_colored_level" separator=" "/>
+        <attribute name="class" remove="pt32 pb32 o_cc2" add="pt120 pb120 o_cc3" separator=" "/>
     </xpath>
     <xpath expr="//div[hasclass('row')]" position="before">
         <h3 style="text-align: center;"><font style="background-image: linear-gradient(135deg, var(--o-color-1) 0%, var(--o-color-3) 100%);" class="text-gradient">SUCCESS STORIES</font></h3>
@@ -391,7 +391,7 @@
         <attribute name="class" add="o_cc o_cc2" separator=" "/>
     </xpath>
     <xpath expr="//div[hasclass('col-lg-4')][3]/i" position="attributes">
-        <attribute name="class" add="bg-o-color-3" remove="bg-secondary" separator=" "/>
+        <attribute name="class" add="bg-o-color-3" remove="bg-o-color-2" separator=" "/>
     </xpath>
 </template>
 
@@ -433,15 +433,15 @@
 <template id="s_features_grid" inherit_id="website.s_features_grid" name="Paptic s_features_grid">
     <!-- Icon #4 -->
     <xpath expr="(//i)[4]" position="attributes">
-        <attribute name="class" add="rounded-circle bg-o-color-3" remove="rounded bg-secondary" separator=" "/>
+        <attribute name="class" add="rounded-circle bg-o-color-3" remove="rounded bg-o-color-2" separator=" "/>
     </xpath>
     <!-- Icon #5 -->
     <xpath expr="(//i)[5]" position="attributes">
-        <attribute name="class" add="rounded-circle bg-o-color-3" remove="rounded bg-secondary" separator=" "/>
+        <attribute name="class" add="rounded-circle bg-o-color-3" remove="rounded bg-o-color-2" separator=" "/>
     </xpath>
     <!-- Icon #6 -->
     <xpath expr="(//i)[6]" position="attributes">
-        <attribute name="class" add="rounded-circle bg-o-color-3" remove="rounded bg-secondary" separator=" "/>
+        <attribute name="class" add="rounded-circle bg-o-color-3" remove="rounded bg-o-color-2" separator=" "/>
     </xpath>
 </template>
 

--- a/theme_paptic/views/new_page_template.xml
+++ b/theme_paptic/views/new_page_template.xml
@@ -118,6 +118,7 @@
 
 <template id="new_page_template_about_full_s_image_text" inherit_id="website.new_page_template_about_full_s_image_text">
     <xpath expr="//section" position="attributes">
+        <attribute name="class" remove="pt48 pb16" separator=" "/>
         <attribute name="data-oe-shape-data">{"shape":"web_editor/Origins/02_001","flip":["y"]}</attribute>
     </xpath>
     <xpath expr="//section/div" position="before">
@@ -125,11 +126,41 @@
     </xpath>
 </template>
 
+<template id="new_page_template_about_full_s_text_image" inherit_id="website.new_page_template_about_full_s_text_image">
+    <xpath expr="//section" position="attributes">
+        <attribute name="class" remove="pt56 pb56" separator=" "/>
+    </xpath>
+</template>
+
+<template id="new_page_template_about_full_s_numbers" inherit_id="website.new_page_template_about_full_s_numbers">
+    <xpath expr="//section" position="attributes">
+        <attribute name="class" remove="o_cc3" separator=" "/>
+    </xpath>
+</template>
+
+<template id="new_page_template_about_personal_s_numbers" inherit_id="website.new_page_template_about_personal_s_numbers">
+    <xpath expr="//section" position="attributes">
+        <attribute name="class" remove="o_cc3 pt0" separator=" "/>
+    </xpath>
+</template>
+
+<template id="new_page_template_about_mini_s_cover" inherit_id="website.new_page_template_about_mini_s_cover">
+    <xpath expr="//section" position="attributes">
+        <attribute name="class" remove="pt40 pb0" separator=" "/>
+    </xpath>
+</template>
+
 <!-- Snippet customization Landing Pages -->
 
 <template id="new_page_template_landing_s_text_image" inherit_id="website.new_page_template_landing_s_text_image">
     <xpath expr="//section" position="attributes">
-        <attribute name="class" remove="o_cc3" separator=" "/>
+        <attribute name="class" remove="o_cc3 pt56 pb56" separator=" "/>
+    </xpath>
+</template>
+
+<template id="new_page_template_landing_0_s_cover" inherit_id="website.new_page_template_landing_0_s_cover">
+    <xpath expr="//section" position="attributes">
+        <attribute name="class" remove="pt192 pb0" separator=" "/>
     </xpath>
 </template>
 
@@ -175,6 +206,12 @@
     </xpath>
 </template>
 
+<template id="new_page_template_gallery_s_image_text_2nd" inherit_id="website.new_page_template_gallery_s_image_text_2nd">
+    <xpath expr="//section" position="attributes">
+        <attribute name="class" remove="pt48 pb16" separator=" "/>
+    </xpath>
+</template>
+
 <template id="new_page_template_gallery_s_media_list" inherit_id="website.new_page_template_gallery_s_media_list">
     <xpath expr="//section" position="attributes">
         <attribute name="class" remove="o_cc3" separator=" "/>
@@ -189,6 +226,12 @@
     </xpath>
     <xpath expr="//section/div" position="before">
         <div class="o_we_shape o_web_editor_Origins_02_001" style="background-image: url('/web_editor/shape/web_editor/Origins/02_001.svg?c4=o-color-4&amp;c5=o-color-2&amp;flip=y'); background-position: 50% 0%;"></div>
+    </xpath>
+</template>
+
+<template id="new_page_template_services_s_text_image" inherit_id="website.new_page_template_services_s_text_image">
+    <xpath expr="//section" position="attributes">
+        <attribute name="class" remove="pt56 pb56" separator=" "/>
     </xpath>
 </template>
 
@@ -213,6 +256,12 @@
     </xpath>
 </template>
 
+<template id="new_page_template_pricing_s_image_text_2nd" inherit_id="website.new_page_template_pricing_s_image_text_2nd">
+    <xpath expr="//section" position="attributes">
+        <attribute name="class" remove="pt48 pb16" separator=" "/>
+    </xpath>
+</template>
+
 <!-- Snippet customization Team Pages -->
 
 <template id="new_page_template_team_s_image_text" inherit_id="website.new_page_template_team_s_image_text">
@@ -224,6 +273,12 @@
 <template id="new_page_template_team_s_image_text_2nd" inherit_id="website.new_page_template_team_s_image_text_2nd">
     <xpath expr="//section" position="attributes">
         <attribute name="class" add="pt16" remove="pt160" separator=" "/>
+    </xpath>
+</template>
+
+<template id="new_page_template_team_s_text_image" inherit_id="website.new_page_template_team_s_text_image">
+    <xpath expr="//section" position="attributes">
+        <attribute name="class" remove="pt56 pb56" separator=" "/>
     </xpath>
 </template>
 

--- a/theme_real_estate/views/new_page_template.xml
+++ b/theme_real_estate/views/new_page_template.xml
@@ -20,9 +20,21 @@
     <xpath expr="//div[hasclass('o_we_shape')]" position="replace"/>
 </template>
 
+<template id="new_page_template_s_text_block_h1" inherit_id="website.new_page_template_s_text_block_h1">
+    <xpath expr="//section" position="attributes">
+        <attribute name="class" remove="pb0" separator=" "/>
+    </xpath>
+</template>
+
+<template id="new_page_template_s_text_block_h2" inherit_id="website.new_page_template_s_text_block_h2">
+    <xpath expr="//section" position="attributes">
+        <attribute name="class" remove="pb0" separator=" "/>
+    </xpath>
+</template>
+
 <template id="new_page_template_s_text_block_h2_contact" inherit_id="website.new_page_template_s_text_block_h2_contact">
     <xpath expr="//section" position="attributes">
-        <attribute name="class" remove="o_cc4" separator=" "/>
+        <attribute name="class" remove="o_cc4 pb40" separator=" "/>
     </xpath>
 </template>
 
@@ -61,13 +73,20 @@
 
 <template id="new_page_template_about_full_1_s_text_block_h1" inherit_id="website.new_page_template_about_full_1_s_text_block_h1">
     <xpath expr="//section" position="attributes">
-        <attribute name="class" add="o_cc3" remove="o_cc4" separator=" "/>
+        <attribute name="class" add="o_cc3" remove="o_cc4 pb40" separator=" "/>
     </xpath>
 </template>
 
 <template id="new_page_template_about_full_1_s_text_block_h2" inherit_id="website.new_page_template_about_full_1_s_text_block_h2">
     <xpath expr="//section" position="attributes">
-        <attribute name="class" remove="o_cc4" separator=" "/>
+        <attribute name="class" remove="o_cc4 pb40" separator=" "/>
+    </xpath>
+</template>
+
+<template id="new_page_template_about_full_s_image_text" inherit_id="website.new_page_template_about_full_s_image_text">
+    <xpath expr="//section" position="attributes">
+        <!-- pt48 is defined by both theme and new page template -->
+        <attribute name="class" add="pt48" remove="pt48 pb48" separator=" "/>
     </xpath>
 </template>
 
@@ -77,13 +96,38 @@
     </xpath>
 </template>
 
+<template id="new_page_template_about_full_s_text_image" inherit_id="website.new_page_template_about_full_s_text_image">
+    <xpath expr="//section" position="attributes">
+        <attribute name="class" remove="pt48 pb0" separator=" "/>
+    </xpath>
+</template>
+
+<template id="new_page_template_about_mini_s_text_block_h2_contact" inherit_id="website.new_page_template_about_mini_s_text_block_h2_contact">
+    <xpath expr="//section" position="attributes">
+        <attribute name="class" remove="pb40" separator=" "/>
+    </xpath>
+</template>
+
 <template id="new_page_template_about_personal_s_numbers" inherit_id="website.new_page_template_about_personal_s_numbers">
     <xpath expr="//section" position="attributes">
-        <attribute name="class" add="o_cc4" remove="o_cc3" separator=" "/>
+        <attribute name="class" add="o_cc4" remove="o_cc1 o_cc3 pt0" separator=" "/>
+    </xpath>
+</template>
+
+<template id="new_page_template_about_personal_s_text_block_h2" inherit_id="website.new_page_template_about_personal_s_text_block_h2">
+    <xpath expr="//section" position="attributes">
+        <!-- o_cc is defined by theme and new page template -->
+        <attribute name="class" add="o_cc" remove="o_cc o_cc3" separator=" "/>
     </xpath>
 </template>
 
 <!-- Snippet customization Landing Pages -->
+
+<template id="new_page_template_landing_s_text_image" inherit_id="website.new_page_template_landing_s_text_image">
+    <xpath expr="//section" position="attributes">
+        <attribute name="class" remove="pt48 pb0" separator=" "/>
+    </xpath>
+</template>
 
 <template id="new_page_template_landing_1_s_banner" inherit_id="website.new_page_template_landing_1_s_banner">
     <!-- Shape option -->
@@ -98,13 +142,19 @@
 
 <template id="new_page_template_landing_2_s_text_block_h2" inherit_id="website.new_page_template_landing_2_s_text_block_h2">
     <xpath expr="//section" position="attributes">
-        <attribute name="class" add="o_cc3" remove="o_cc4" separator=" "/>
+        <attribute name="class" add="o_cc3" remove="o_cc2 o_cc4 pb40" separator=" "/>
     </xpath>
 </template>
 
 <template id="new_page_template_landing_3_s_text_block_h2" inherit_id="website.new_page_template_landing_3_s_text_block_h2">
     <xpath expr="//section" position="attributes">
-        <attribute name="class" add="o_cc3" remove="o_cc4" separator=" "/>
+        <attribute name="class" add="o_cc3" remove="o_cc2 o_cc4" separator=" "/>
+    </xpath>
+</template>
+
+<template id="new_page_template_landing_4_s_text_block_h2" inherit_id="website.new_page_template_landing_4_s_text_block_h2">
+    <xpath expr="//section" position="attributes">
+        <attribute name="class" remove="pb40" separator=" "/>
     </xpath>
 </template>
 
@@ -121,6 +171,13 @@
     </xpath>
 </template>
 
+<template id="new_page_template_gallery_s_image_text_2nd" inherit_id="website.new_page_template_gallery_s_image_text_2nd">
+    <xpath expr="//section" position="attributes">
+        <!-- pt48 is defined by both theme and new page template -->
+        <attribute name="class" add="pt48" remove="pt48 pb48" separator=" "/>
+    </xpath>
+</template>
+
 <template id="new_page_template_gallery_s_text_block_h2" inherit_id="website.new_page_template_gallery_s_text_block_h2">
     <xpath expr="//section" position="attributes">
         <attribute name="class" remove="o_cc4" separator=" "/>
@@ -129,25 +186,50 @@
 
 <!-- Snippet customization Services Pages -->
 
+<template id="new_page_template_services_s_text_block_h1" inherit_id="website.new_page_template_services_s_text_block_h1">
+    <xpath expr="//section" position="attributes">
+        <attribute name="class" remove="pb40" separator=" "/>
+    </xpath>
+</template>
+
+<template id="new_page_template_services_s_text_image" inherit_id="website.new_page_template_services_s_text_image">
+    <xpath expr="//section" position="attributes">
+        <attribute name="class" remove="pt48 pb0" separator=" "/>
+    </xpath>
+</template>
+
 <template id="new_page_template_services_0_s_three_columns" inherit_id="website.new_page_template_services_0_s_three_columns">
     <xpath expr="//section" position="attributes">
         <attribute name="class" add="o_cc4" remove="o_cc3" separator=" "/>
     </xpath>
 </template>
 
+<template id="new_page_template_services_3_s_text_block_h1" inherit_id="website.new_page_template_services_3_s_text_block_h1">
+    <xpath expr="//section" position="attributes">
+        <attribute name="class" remove="pb40" separator=" "/>
+    </xpath>
+</template>
+
 <!-- Snippet customization Pricing Pages -->
+
+<template id="new_page_template_pricing_s_image_text_2nd" inherit_id="website.new_page_template_pricing_s_image_text_2nd">
+    <xpath expr="//section" position="attributes">
+        <!-- pt48 is defined in both theme and new page template -->
+        <attribute name="class" add="pt48" remove="pt48 pb48" separator=" "/>
+    </xpath>
+</template>
 
 <!-- Snippet customization Team Pages -->
 
 <template id="new_page_template_team_s_text_block_h1" inherit_id="website.new_page_template_team_s_text_block_h1">
     <xpath expr="//section" position="attributes">
-        <attribute name="class" add="o_cc3" remove="o_cc4" separator=" "/>
+        <attribute name="class" add="o_cc3" remove="o_cc4 pb40" separator=" "/>
     </xpath>
 </template>
 
-<template id="new_page_template_team_0_s_text_block_h1" inherit_id="website.new_page_template_team_0_s_text_block_h1">
+<template id="new_page_template_team_s_text_image" inherit_id="website.new_page_template_team_s_text_image">
     <xpath expr="//section" position="attributes">
-        <attribute name="class" add="pb0" remove="pb40" separator=" "/>
+        <attribute name="class" remove="pt48 pb0" separator=" "/>
     </xpath>
 </template>
 
@@ -165,7 +247,7 @@
 
 <template id="new_page_template_team_2_s_text_block_h1" inherit_id="website.new_page_template_team_2_s_text_block_h1">
     <xpath expr="//section" position="attributes">
-        <attribute name="class" add="o_cc4 pb40" remove="o_cc3 pb0" separator=" "/>
+        <attribute name="class" add="o_cc4" remove="o_cc3 pb0" separator=" "/>
     </xpath>
 </template>
 

--- a/theme_real_estate/views/snippets/s_image_text.xml
+++ b/theme_real_estate/views/snippets/s_image_text.xml
@@ -4,7 +4,7 @@
 <template id="s_image_text" inherit_id="website.s_image_text">
     <!-- Section -->
     <xpath expr="//section" position="attributes">
-        <attribute name="class" add="o_cc o_cc1 pb48 pt48" remove="pb32 pb32" separator=" "/>
+        <attribute name="class" add="o_cc o_cc1 pb48 pt48" remove="pb32 pt32" separator=" "/>
     </xpath>
 
     <!-- Title -->

--- a/theme_real_estate/views/snippets/s_text_block.xml
+++ b/theme_real_estate/views/snippets/s_text_block.xml
@@ -4,7 +4,7 @@
 <template id="s_text_block" inherit_id="website.s_text_block">
     <!-- Section/span -->
     <xpath expr="//section" position="attributes">
-        <attribute name="class" add="o_cc o_cc4 pb56 pt56" remove="pt96 pb96" separator=" "/>
+        <attribute name="class" add="o_cc o_cc4 pb56 pt56" remove="pt40 pb40" separator=" "/>
     </xpath>
     <xpath expr="//p" position="replace" mode="inner">
         We are <b>Odoo Travel Agency</b>, dedicated to making your vacation dreams come true! Overwhelmed with too many choices on the internet? We offer you answers, support, advice, and itineraries that will amaze you with their <b>thoroughness and thoughtfulness</b>.

--- a/theme_treehouse/views/new_page_template.xml
+++ b/theme_treehouse/views/new_page_template.xml
@@ -33,6 +33,12 @@
     </xpath>
 </template>
 
+<template id="new_page_template_about_full_s_image_text" inherit_id="website.new_page_template_about_full_s_image_text">
+    <xpath expr="//section" position="attributes">
+        <attribute name="class" remove="pt48 pb56" separator=" "/>
+    </xpath>
+</template>
+
 <template id="new_page_template_about_full_s_numbers" inherit_id="website.new_page_template_about_full_s_numbers">
     <xpath expr="//section" position="attributes">
         <attribute name="class" add="o_cc2" remove="o_cc3" separator=" "/>
@@ -40,13 +46,31 @@
 </template>
 
 <template id="new_page_template_about_full_s_text_image" inherit_id="website.new_page_template_about_full_s_text_image">
+    <xpath expr="//section" position="attributes">
+        <attribute name="class" remove="pt56 pb56" separator=" "/>
+    </xpath>
     <xpath expr="//p" position="replace"/>
+</template>
+
+<template id="new_page_template_about_mini_s_cover" inherit_id="website.new_page_template_about_mini_s_cover">
+    <xpath expr="//section" position="attributes">
+        <attribute name="class" remove="pt40 pb40" separator=" "/>
+    </xpath>
 </template>
 
 <!-- Snippet customization Landing Pages -->
 
 <template id="new_page_template_landing_s_text_image" inherit_id="website.new_page_template_landing_s_text_image">
+    <xpath expr="//section" position="attributes">
+        <attribute name="class" remove="pt56 pb56" separator=" "/>
+    </xpath>
     <xpath expr="//p" position="replace"/>
+</template>
+
+<template id="new_page_template_landing_0_s_cover" inherit_id="website.new_page_template_landing_0_s_cover">
+    <xpath expr="//section" position="attributes">
+        <attribute name="class" remove="pt160 pb160" separator=" "/>
+    </xpath>
 </template>
 
 <template id="new_page_template_landing_2_s_cover" inherit_id="website.new_page_template_landing_2_s_cover">
@@ -84,6 +108,12 @@
     </xpath>
 </template>
 
+<template id="new_page_template_gallery_s_image_text_2nd" inherit_id="website.new_page_template_gallery_s_image_text_2nd">
+    <xpath expr="//section" position="attributes">
+        <attribute name="class" remove="pt48 pb56" separator=" "/>
+    </xpath>
+</template>
+
 <!-- Snippet customization Services Pages -->
 
 <template id="new_page_template_services_s_text_block_h2" inherit_id="website.new_page_template_services_s_text_block_h2">
@@ -93,6 +123,9 @@
 </template>
 
 <template id="new_page_template_services_s_text_image" inherit_id="website.new_page_template_services_s_text_image">
+    <xpath expr="//section" position="attributes">
+        <attribute name="class" remove="pt56 pb56" separator=" "/>
+    </xpath>
     <xpath expr="//p" position="replace"/>
 </template>
 
@@ -101,6 +134,12 @@
 <template id="new_page_template_pricing_s_cover" inherit_id="website.new_page_template_pricing_s_cover">
     <xpath expr="//section" position="attributes">
         <attribute name="class" add="o_half_screen_height" remove="o_full_screen_height" separator=" "/>
+    </xpath>
+</template>
+
+<template id="new_page_template_pricing_s_image_text_2nd" inherit_id="website.new_page_template_pricing_s_image_text_2nd">
+    <xpath expr="//section" position="attributes">
+        <attribute name="class" remove="pt48 pb56" separator=" "/>
     </xpath>
 </template>
 
@@ -125,6 +164,9 @@
 <!-- Snippet customization Team Pages -->
 
 <template id="new_page_template_team_s_text_image" inherit_id="website.new_page_template_team_s_text_image">
+    <xpath expr="//section" position="attributes">
+        <attribute name="class" remove="pb56 pt56" separator=" "/>
+    </xpath>
     <xpath expr="//p" position="replace"/>
 </template>
 

--- a/theme_vehicle/views/customizations.xml
+++ b/theme_vehicle/views/customizations.xml
@@ -300,27 +300,27 @@
     </xpath>
     <!-- Item #1 -->
     <xpath expr="//i" position="attributes">
-        <attribute name="class" add="rounded-0 bg-o-color-3 text-o-color-1" remove="rounded-circle bg-primary" separator=" "/>
+        <attribute name="class" add="rounded-0 bg-o-color-3 text-o-color-1" remove="rounded-circle bg-o-color-1" separator=" "/>
     </xpath>
     <!-- Item #2 -->
     <xpath expr="(//i)[2]" position="attributes">
-        <attribute name="class" add="rounded-0 bg-o-color-3 text-o-color-1" remove="rounded-circle bg-primary" separator=" "/>
+        <attribute name="class" add="rounded-0 bg-o-color-3 text-o-color-1" remove="rounded-circle bg-o-color-1" separator=" "/>
     </xpath>
         <!-- Item #3 -->
     <xpath expr="(//i)[3]" position="attributes">
-        <attribute name="class" add="rounded-0 bg-o-color-3 text-o-color-1" remove="rounded-circle bg-primary" separator=" "/>
+        <attribute name="class" add="rounded-0 bg-o-color-3 text-o-color-1" remove="rounded-circle bg-o-color-1" separator=" "/>
     </xpath>
     <!-- Item #4 -->
     <xpath expr="(//i)[4]" position="attributes">
-        <attribute name="class" add="rounded-0 bg-o-color-3 text-o-color-2" remove="rounded bg-secondary" separator=" "/>
+        <attribute name="class" add="rounded-0 bg-o-color-3 text-o-color-2" remove="rounded bg-o-color-2" separator=" "/>
     </xpath>
     <!-- Item #5 -->
     <xpath expr="(//i)[5]" position="attributes">
-        <attribute name="class" add="rounded-0 bg-o-color-3 text-o-color-2" remove="rounded bg-secondary" separator=" "/>
+        <attribute name="class" add="rounded-0 bg-o-color-3 text-o-color-2" remove="rounded bg-o-color-2" separator=" "/>
     </xpath>
     <!-- Item #6 -->
     <xpath expr="(//i)[6]" position="attributes">
-        <attribute name="class" add="rounded-0 bg-o-color-3 text-o-color-2" remove="rounded bg-secondary" separator=" "/>
+        <attribute name="class" add="rounded-0 bg-o-color-3 text-o-color-2" remove="rounded bg-o-color-2" separator=" "/>
     </xpath>
 </template>
 

--- a/theme_vehicle/views/new_page_template.xml
+++ b/theme_vehicle/views/new_page_template.xml
@@ -57,14 +57,29 @@
     </xpath>
 </template>
 
+<template id="new_page_template_about_full_s_image_text" inherit_id="website.new_page_template_about_full_s_image_text">
+    <xpath expr="//section" position="attributes">
+        <!-- pb56 is defined by both theme and new page template -->
+        <attribute name="class" add="pb56" remove="pt24 pb56" separator=" "/>
+    </xpath>
+</template>
+
 <template id="new_page_template_about_full_s_numbers" inherit_id="website.new_page_template_about_full_s_numbers">
     <!-- Shape option -->
     <xpath expr="//section" position="attributes">
+        <attribute name="class" remove="o_cc3" separator=" "/>
         <attribute name="data-oe-shape-data">{"shape":"web_editor/Rainy/09_001","flip":[]}</attribute>
     </xpath>
     <!-- Shape -->
     <xpath expr="//div[hasclass('container')]" position="before">
         <div class="o_we_shape o_web_editor_Rainy_09_001"/>
+    </xpath>
+</template>
+
+<template id="new_page_template_about_full_s_text_image" inherit_id="website.new_page_template_about_full_s_text_image">
+    <xpath expr="//section" position="attributes">
+        <!-- pb56 is defined by both theme and new page template -->
+        <attribute name="class" add="pt56" remove="pt56 pb24" separator=" "/>
     </xpath>
 </template>
 
@@ -79,13 +94,33 @@
     </xpath>
 </template>
 
+<template id="new_page_template_about_mini_s_cover" inherit_id="website.new_page_template_about_mini_s_cover">
+    <xpath expr="//section" position="attributes">
+        <attribute name="class" remove="pt0 pb40" separator=" "/>
+    </xpath>
+</template>
+
 <template id="new_page_template_about_personal_s_numbers" inherit_id="website.new_page_template_about_personal_s_numbers">
     <xpath expr="//section" position="attributes">
-        <attribute name="class" add="o_cc3" remove="o_cc4" separator=" "/>
+        <attribute name="class" remove="o_cc4 pt0" separator=" "/>
     </xpath>
 </template>
 
 <!-- Snippet customization Landing Pages -->
+
+<template id="new_page_template_landing_s_text_image" inherit_id="website.new_page_template_landing_s_text_image">
+    <xpath expr="//section" position="attributes">
+        <!-- pt56 is defined in both theme and new page template -->
+        <attribute name="class" add="pt56" remove="pt56 pb24" separator=" "/>
+    </xpath>
+</template>
+
+<template id="new_page_template_landing_0_s_cover" inherit_id="website.new_page_template_landing_0_s_cover">
+    <xpath expr="//section" position="attributes">
+        <!-- pb256 is defined in both theme and new page template -->
+        <attribute name="class" add="pb256" remove="pt0 pb256" separator=" "/>
+    </xpath>
+</template>
 
 <template id="new_page_template_landing_1_s_banner" inherit_id="website.new_page_template_landing_1_s_banner">
     <xpath expr="//section" position="attributes">
@@ -131,7 +166,21 @@
     </xpath>
 </template>
 
+<template id="new_page_template_gallery_s_image_text_2nd" inherit_id="website.new_page_template_gallery_s_image_text_2nd">
+    <xpath expr="//section" position="attributes">
+        <!-- pb56 is defined in both theme and new page template -->
+        <attribute name="class" add="pb56" remove="pt24 pb56" separator=" "/>
+    </xpath>
+</template>
+
 <!-- Snippet customization Services Pages -->
+
+<template id="new_page_template_services_s_text_image" inherit_id="website.new_page_template_services_s_text_image">
+    <xpath expr="//section" position="attributes">
+        <!-- pt56 is defined in both theme and new page template -->
+        <attribute name="class" add="pt56" remove="pt56 pb24" separator=" "/>
+    </xpath>
+</template>
 
 <!-- Snippet customization Pricing Pages -->
 
@@ -141,11 +190,25 @@
     </xpath>
 </template>
 
+<template id="new_page_template_pricing_s_image_text_2nd" inherit_id="website.new_page_template_pricing_s_image_text_2nd">
+    <xpath expr="//section" position="attributes">
+        <!-- pb56 is defined in both theme and new page template -->
+        <attribute name="class" add="pb56" remove="pt24 pb56" separator=" "/>
+    </xpath>
+</template>
+
 <!-- Snippet customization Team Pages -->
 
 <template id="new_page_template_team_s_text_block_h1" inherit_id="website.new_page_template_team_s_text_block_h1">
     <xpath expr="//section" position="attributes">
         <attribute name="class" add="o_cc3" separator=" "/>
+    </xpath>
+</template>
+
+<template id="new_page_template_team_s_text_image" inherit_id="website.new_page_template_team_s_text_image">
+    <xpath expr="//section" position="attributes">
+        <!-- pt56 is defined in both theme and new page template -->
+        <attribute name="class" add="pt56" remove="pt56 pb24" separator=" "/>
     </xpath>
 </template>
 

--- a/theme_yes/views/new_page_template.xml
+++ b/theme_yes/views/new_page_template.xml
@@ -118,6 +118,13 @@
     </xpath>
 </template>
 
+<template id="new_page_template_about_mini_s_cover" inherit_id="website.new_page_template_about_mini_s_cover">
+    <xpath expr="//section" position="attributes">
+        <!-- Defined in both theme and new page template -->
+        <attribute name="class" add="o_half_screen_height" remove="pt40 pb40 o_half_screen_height" separator=" "/>
+    </xpath>
+</template>
+
 <template id="new_page_template_about_mini_s_text_block_2nd" inherit_id="website.new_page_template_about_mini_s_text_block_2nd">
     <xpath expr="//section" position="attributes">
         <attribute name="class" add="o_cc2" separator=" "/>
@@ -144,6 +151,13 @@
     </xpath>
 </template>
 
+<template id="new_page_template_landing_0_s_cover" inherit_id="website.new_page_template_landing_0_s_cover">
+    <xpath expr="//section" position="attributes">
+        <!-- pb256 is defined by both theme and new page template -->
+        <attribute name="class" add="pb256" remove="pt208 pb256" separator=" "/>
+    </xpath>
+</template>
+
 <template id="new_page_template_landing_1_s_banner" inherit_id="website.new_page_template_landing_1_s_banner">
     <!-- Shape option -->
     <xpath expr="//section" position="attributes">
@@ -158,7 +172,7 @@
 <template id="new_page_template_landing_2_s_cover" inherit_id="website.new_page_template_landing_2_s_cover">
     <!-- Shape option -->
     <xpath expr="//section" position="attributes">
-        <attribute name="class" add="o_half_screen_height" remove="o_full_screen_height" separator=" "/>
+        <attribute name="class" add="o_half_screen_height" remove="o_half_screen_height" separator=" "/>
         <attribute name="data-oe-shape-data">{"shape":"web_editor/Origins/14_001"}</attribute>
     </xpath>
     <!-- Shape -->
@@ -182,7 +196,7 @@
 <template id="new_page_template_landing_4_s_cover" inherit_id="website.new_page_template_landing_4_s_cover">
     <!-- Shape option -->
     <xpath expr="//section" position="attributes">
-        <attribute name="class" add="o_half_screen_height" remove="o_full_screen_height" separator=" "/>
+        <attribute name="class" add="o_half_screen_height" remove="o_half_screen_height" separator=" "/>
         <attribute name="data-oe-shape-data">{"shape":"web_editor/Origins/14_001"}</attribute>
     </xpath>
     <!-- Shape -->
@@ -207,7 +221,7 @@
 <template id="new_page_template_gallery_s_cover" inherit_id="website.new_page_template_gallery_s_cover">
     <!-- Shape option -->
     <xpath expr="//section" position="attributes">
-        <attribute name="class" add="o_half_screen_height" remove="o_full_screen_height" separator=" "/>
+        <attribute name="class" add="o_half_screen_height" remove="o_half_screen_height" separator=" "/>
         <attribute name="data-oe-shape-data">{"shape":"web_editor/Origins/14_001"}</attribute>
     </xpath>
     <!-- Shape -->
@@ -229,12 +243,18 @@
 <template id="new_page_template_pricing_s_cover" inherit_id="website.new_page_template_pricing_s_cover">
     <!-- Shape option -->
     <xpath expr="//section" position="attributes">
-        <attribute name="class" add="o_half_screen_height" remove="o_full_screen_height" separator=" "/>
+        <attribute name="class" add="o_half_screen_height" remove="o_half_screen_height" separator=" "/>
         <attribute name="data-oe-shape-data">{"shape":"web_editor/Origins/14_001"}</attribute>
     </xpath>
     <!-- Shape -->
     <xpath expr="//*[hasclass('container')]" position="before">
         <div class="o_we_shape o_web_editor_Origins_14_001" style="background-image: url('/web_editor/shape/web_editor/Origins/14.svg?c1=o-color-1&amp;c5=o-color-1&amp;flip=x'); background-position: 50% 100%;"/>
+    </xpath>
+</template>
+
+<template id="new_page_template_pricing_3_s_carousel" inherit_id="website.new_page_template_pricing_3_s_carousel">
+    <xpath expr="//*[hasclass('carousel-item')][3]" position="attributes">
+        <attribute name="class" add="pt128 pb128" remove="pt152 pb152" separator=" "/>
     </xpath>
 </template>
 

--- a/theme_yes/views/snippets/s_carousel.xml
+++ b/theme_yes/views/snippets/s_carousel.xml
@@ -31,7 +31,7 @@
     <xpath expr="(//*[hasclass('container')])[3]" position="before">
         <div class="o_we_bg_filter" style="background-color: rgba(25, 41, 37, 0.55) !important;"/>
     </xpath>
-    <xpath expr="//*[hasclass('carousel-item')][2]" position="attributes">
+    <xpath expr="//*[hasclass('carousel-item')][3]" position="attributes">
         <attribute name="class" add="pt152 pb152" remove="pt128 pb128" separator=" "/>
     </xpath>
     <xpath expr="(//*[hasclass('carousel-content')])[3]" position="replace">

--- a/theme_yes/views/snippets/s_quotes_carousel.xml
+++ b/theme_yes/views/snippets/s_quotes_carousel.xml
@@ -4,7 +4,6 @@
 <template id="s_quotes_carousel" inherit_id="website.s_quotes_carousel">
     <!-- Quote 1 -->
     <xpath expr="//div[hasclass('carousel-item')]" position="attributes">
-        <attribute name="class" add="oe_img_bg o_bg_img_center" separator=" "/>
         <attribute name="style" add="background-image: url('/web/image/website.s_quotes_carousel_demo_image_0'); background-position: 50% 25%;" separator="; "/>
     </xpath>
     <xpath expr="//div[hasclass('container')]" position="before">

--- a/theme_zap/views/new_page_template.xml
+++ b/theme_zap/views/new_page_template.xml
@@ -37,6 +37,13 @@
     </xpath>
 </template>
 
+<template id="new_page_template_about_full_s_image_text" inherit_id="website.new_page_template_about_full_s_image_text">
+    <xpath expr="//section" position="attributes">
+        <!-- o_colored_level is defined by both theme and new page template -->
+        <attribute name="class" add="o_colored_level" remove="o_colored_level pt48 pb56" separator=" "/>
+    </xpath>
+</template>
+
 <template id="new_page_template_about_full_s_numbers" inherit_id="website.new_page_template_about_full_s_numbers">
     <xpath expr="//section" position="attributes">
         <attribute name="class" add="o_cc2" remove="o_cc3" separator=" "/>
@@ -51,7 +58,8 @@
 
 <template id="new_page_template_about_personal_s_numbers" inherit_id="website.new_page_template_about_personal_s_numbers">
     <xpath expr="//section" position="attributes">
-        <attribute name="class" remove="o_cc3" separator=" "/>
+        <!-- o_colored_level is defined by both theme and new page template -->
+        <attribute name="class" add="o_cc2 o_colored_level" remove="o_cc3 o_colored_level pt0" separator=" "/>
     </xpath>
 </template>
 
@@ -79,18 +87,6 @@
     </xpath>
 </template>
 
-<template id="new_page_template_landing_2_s_text_block_h2" inherit_id="website.new_page_template_landing_2_s_text_block_h2">
-    <xpath expr="//section" position="attributes">
-        <attribute name="class" add="o_cc2" separator=" "/>
-    </xpath>
-</template>
-
-<template id="new_page_template_landing_3_s_text_block_h2" inherit_id="website.new_page_template_landing_3_s_text_block_h2">
-    <xpath expr="//section" position="attributes">
-        <attribute name="class" add="o_cc2" separator=" "/>
-    </xpath>
-</template>
-
 <!-- Snippet customization Gallery Pages -->
 
 <template id="new_page_template_gallery_s_banner" inherit_id="website.new_page_template_gallery_s_banner">
@@ -109,6 +105,13 @@
     </xpath>
 </template>
 
+<template id="new_page_template_gallery_s_image_text_2nd" inherit_id="website.new_page_template_gallery_s_image_text_2nd">
+    <xpath expr="//section" position="attributes">
+        <!-- o_colored_level is defined by both theme and new page template -->
+        <attribute name="class" add="o_colored_level" remove="o_colored_level pt48 pb56" separator=" "/>
+    </xpath>
+</template>
+
 <!-- Snippet customization Services Pages -->
 
 <!-- Snippet customization Pricing Pages -->
@@ -116,6 +119,13 @@
 <template id="new_page_template_pricing_s_cover" inherit_id="website.new_page_template_pricing_s_cover">
     <xpath expr="//section" position="attributes">
         <attribute name="class" add="o_half_screen_height" remove="o_full_screen_height" separator=" "/>
+    </xpath>
+</template>
+
+<template id="new_page_template_pricing_s_image_text_2nd" inherit_id="website.new_page_template_pricing_s_image_text_2nd">
+    <xpath expr="//section" position="attributes">
+        <!-- o_colored_level is defined by both theme and new page template -->
+        <attribute name="class" add="o_colored_level" remove="o_colored_level pt48 pb56" separator=" "/>
     </xpath>
 </template>
 

--- a/theme_zap/views/snippets/s_numbers.xml
+++ b/theme_zap/views/snippets/s_numbers.xml
@@ -4,7 +4,7 @@
 <template id="s_numbers" inherit_id="website.s_numbers">
     <!-- Section -->
     <xpath expr="//section" position="attributes">
-        <attribute name="class" add="pt80 pb80" remove="pt48 pb24" separator=" "/>
+        <attribute name="class" add="pt80 pb80" remove="pt24 pb24" separator=" "/>
     </xpath>
     <!-- Column #01 -->
     <xpath expr="//*[hasclass('row')]/*[1]" position="attributes">

--- a/theme_zap/views/snippets/s_references.xml
+++ b/theme_zap/views/snippets/s_references.xml
@@ -16,32 +16,32 @@
     </xpath>
     <!-- Column #01 -->
     <xpath expr="//*[hasclass('row')]/*[1]" position="attributes">
-        <attribute name="class" add="o_cc o_cc1 rounded pt48 pb48" remove="" separator=" "/>
+        <attribute name="class" add="o_cc o_cc1 rounded pt48 pb48" remove="pt16 pb16" separator=" "/>
         <attribute name="style" add="box-shadow: rgba(0, 0, 0, 0.15) 0px 2px 4px 0px !important;" separator=" "/>
     </xpath>
     <!-- Column #02 -->
     <xpath expr="//*[hasclass('row')]/*[2]" position="attributes">
-        <attribute name="class" add="o_cc o_cc1 rounded pt48 pb48" remove="" separator=" "/>
+        <attribute name="class" add="o_cc o_cc1 rounded pt48 pb48" remove="pt16 pb16" separator=" "/>
         <attribute name="style" add="box-shadow: rgba(0, 0, 0, 0.15) 0px 2px 4px 0px !important;" separator=" "/>
     </xpath>
     <!-- Column #03 -->
     <xpath expr="//*[hasclass('row')]/*[3]" position="attributes">
-        <attribute name="class" add="o_cc o_cc1 rounded pt48 pb48" remove="" separator=" "/>
+        <attribute name="class" add="o_cc o_cc1 rounded pt48 pb48" remove="pt16 pb16" separator=" "/>
         <attribute name="style" add="box-shadow: rgba(0, 0, 0, 0.15) 0px 2px 4px 0px !important;" separator=" "/>
     </xpath>
     <!-- Column #04 -->
     <xpath expr="//*[hasclass('row')]/*[4]" position="attributes">
-        <attribute name="class" add="o_cc o_cc1 rounded pt48 pb48" remove="" separator=" "/>
+        <attribute name="class" add="o_cc o_cc1 rounded pt48 pb48" remove="pt16 pb16" separator=" "/>
         <attribute name="style" add="box-shadow: rgba(0, 0, 0, 0.15) 0px 2px 4px 0px !important;" separator=" "/>
     </xpath>
     <!-- Column #05 -->
     <xpath expr="//*[hasclass('row')]/*[5]" position="attributes">
-        <attribute name="class" add="o_cc o_cc1 rounded pt48 pb48" remove="" separator=" "/>
+        <attribute name="class" add="o_cc o_cc1 rounded pt48 pb48" remove="pt16 pb16" separator=" "/>
         <attribute name="style" add="box-shadow: rgba(0, 0, 0, 0.15) 0px 2px 4px 0px !important;" separator=" "/>
     </xpath>
     <!-- Column #06 -->
     <xpath expr="//*[hasclass('row')]/*[6]" position="attributes">
-        <attribute name="class" add="o_cc o_cc1 rounded pt48 pb48" remove="" separator=" "/>
+        <attribute name="class" add="o_cc o_cc1 rounded pt48 pb48" remove="pt16 pb16" separator=" "/>
         <attribute name="style" add="box-shadow: rgba(0, 0, 0, 0.15) 0px 2px 4px 0px !important;" separator=" "/>
     </xpath>
 </template>


### PR DESCRIPTION
When default snippets have been updated to rely on color presets ([1]),
some themes were not adapted accordingly.
This also happened whenever paddings of base blocks were modified.
Because of this there are elements in themes for which some classes are
applied several times, and some where classes are not removed before
adding a contradicting one.

This commit adjusts the classes so that themes neither:
- produce snippets with duplicated classes
- produce snippets with contradicting classes (e.g. two different
bottom paddings on the same element)

This commit also fixes a typo from [2] which was the source of
duplicate classes.

This PR also introduces a test to make sure the situation does not occur accidentally.

[1]: https://github.com/odoo/odoo/commit/5953c4df6b9c08519f64a65c1cf5d5558d59f7d4
[2]: https://github.com/odoo/design-themes/commit/299d504df31bf179775eec1d37e71605c3637460#diff-86c142838104de06e89f629c51cf791464538dc8899e6a3f00c24f69638db409R34

task-3562147