### PR TITLE
[FIX] theme_*: fix some configurator templates

### DIFF
--- a/theme_beauty/views/snippets/s_product_list.xml
+++ b/theme_beauty/views/snippets/s_product_list.xml
@@ -60,7 +60,7 @@
         <attribute name="data-oe-shape-data">{"shape":"web_editor/Wavy/15","flip":[]}</attribute>
     </xpath>
     <!-- Shape -->
-    <xpath expr="//div[hasclass('container-fluid')]" position="before">
+    <xpath expr="//div[hasclass('container')]" position="before">
         <div class="o_we_shape o_web_editor_Wavy_15"/>
     </xpath>
 </template>

--- a/theme_odoo_experts/views/snippets/s_cover.xml
+++ b/theme_odoo_experts/views/snippets/s_cover.xml
@@ -35,7 +35,7 @@
         <attribute name="data-oe-shape-data">{"shape":"web_editor/Origins/02_001","flip":[]}</attribute>
     </xpath>
     <!-- Shape -->
-    <xpath expr="//div[hasclass('container')]" position="before">
+    <xpath expr="//div[hasclass('o_container_small')]" position="before">
         <div class="o_we_shape o_web_editor_Origins_02_001"/>
     </xpath>
 </template>

--- a/theme_paptic/views/customizations.xml
+++ b/theme_paptic/views/customizations.xml
@@ -436,7 +436,7 @@
         <attribute name="data-oe-shape-data">{"shape":"web_editor/Origins/07_002","flip":["x"]}</attribute>
     </xpath>
     <!-- Shape -->
-    <xpath expr="//div[hasclass('container')]" position="before">
+    <xpath expr="//div[hasclass('o_container_small')]" position="before">
         <div class="o_we_shape o_web_editor_Origins_07_002" style="background-image: url('/web_editor/shape/web_editor/Origins/07_002.svg?c3=o-color-4&amp;c4=o-color-2&amp;c5=o-color-4&amp;flip=x'); background-position: 50% 50%;"/>
     </xpath>
 </template>


### PR DESCRIPTION
Since [1] when background shapes were extracted to configurator-specific templates, some xpath were broken.
By separating the definition of the shape from the definition of the base snippet theme customization, changes between `container` and `o_container_small` are already applied before taking the shape definition into account.

This commit fixes the templates which have this issue.

[1]: https://github.com/odoo/design-themes/commit/d206c119720d557c11320ebb3d7339890b8f9efa

task-3555325