### PR TITLE
[FIX] theme_bewise: replace "diplomatic" by "academic"

### DIFF
--- a/theme_bewise/i18n/theme_bewise.pot
+++ b/theme_bewise/i18n/theme_bewise.pot
@@ -219,7 +219,7 @@ msgstr ""
 #. module: theme_bewise
 #: model_terms:theme.ir.ui.view,arch:theme_bewise.s_quotes_carousel
 msgid ""
-"Thanks to its innovative system, the school offers a diplomatic training "
+"Thanks to its innovative system, the school offers an academic training "
 "during which we are followed by a \"mentor\", a sort of \"tutor\"!"
 msgstr ""
 

--- a/theme_bewise/views/customizations.xml
+++ b/theme_bewise/views/customizations.xml
@@ -197,7 +197,7 @@
         <attribute name="class" add="bg-o-color-1" remove="bg-o-color-2" separator=" "/>
     </xpath>
     <xpath expr="(//blockquote)[2]//p" position="replace" mode="inner">
-        Thanks to its innovative system, the school offers a diplomatic training during which we are followed by a "mentor", a sort of "tutor"!
+        Thanks to its innovative system, the school offers an academic training during which we are followed by a "mentor", a sort of "tutor"!
     </xpath>
     <xpath expr="(//span[hasclass('s_blockquote_author')])[2]" position="replace" mode="inner">
         <b>Jane DOE</b> • Graduated in 2017


### PR DESCRIPTION
This commit rephrases one of the quotes block's sentences to use the word "academic" instead of "diplomatic".