### PR TITLE
[FIX] theme_*: Update homepage tours

### DIFF
--- a/theme_anelusia/static/src/js/tour.js
+++ b/theme_anelusia/static/src/js/tour.js
@@ -5,7 +5,7 @@ import wTourUtils from '@website/js/tours/tour_utils';
 const snippets = [
     {
         id: 's_text_cover',
-        name: 'Banner',
+        name: 'Text Cover',
     },
     {
         id: 's_images_wall',

--- a/theme_artists/static/src/js/tour.js
+++ b/theme_artists/static/src/js/tour.js
@@ -37,7 +37,7 @@ wTourUtils.registerThemeHomepageTour("artists_tour", () => [
     wTourUtils.goBackToBlocks(),
     wTourUtils.dragNDrop(snippets[2]),
     wTourUtils.dragNDrop(snippets[3]),
-    wTourUtils.clickOnText(snippets[3], 'h1'),
+    wTourUtils.clickOnText(snippets[3], 'h2'),
     wTourUtils.goBackToBlocks(),
     wTourUtils.dragNDrop(snippets[4]),
     wTourUtils.dragNDrop(snippets[5]),

--- a/theme_aviato/static/src/js/tour.js
+++ b/theme_aviato/static/src/js/tour.js
@@ -41,6 +41,6 @@ wTourUtils.registerThemeHomepageTour("aviato_tour", () => [
     wTourUtils.dragNDrop(snippets[4]),
     wTourUtils.dragNDrop(snippets[5]),
     wTourUtils.clickOnSnippet(snippets[5], 'top'),
-    wTourUtils.changeOption('BackgroundShape', 'we-toggler', _t('Background Shape')),
+    wTourUtils.changeOption('ColoredLevelBackground', 'we-button[data-toggle-bg-shape]', _t('Background Shape')),
     wTourUtils.selectNested('we-select-page', 'BackgroundShape', ':not(.o_we_pager_controls)', _t('Background Shape')),
 ]);

--- a/theme_notes/static/src/js/tour.js
+++ b/theme_notes/static/src/js/tour.js
@@ -33,7 +33,7 @@ const snippets = [
 wTourUtils.registerThemeHomepageTour("notes_tour", () => [
     wTourUtils.assertCssVariable('--color-palettes-name', '"notes-1"'),
     wTourUtils.dragNDrop(snippets[0]),
-    wTourUtils.clickOnText(snippets[0], 'h1'),
+    wTourUtils.clickOnText(snippets[0], 'h2'),
     wTourUtils.goBackToBlocks(),
     wTourUtils.dragNDrop(snippets[1]),
     wTourUtils.dragNDrop(snippets[2]),

--- a/theme_odoo_experts/static/src/js/tour.js
+++ b/theme_odoo_experts/static/src/js/tour.js
@@ -45,7 +45,7 @@ wTourUtils.registerThemeHomepageTour("odoo_experts_tour", () => [
     wTourUtils.dragNDrop(snippets[4]),
     wTourUtils.dragNDrop(snippets[5]),
     wTourUtils.clickOnSnippet(snippets[5], 'top'),
-    wTourUtils.changeOption('BackgroundShape', 'we-toggler', _t('Background Shape')),
+    wTourUtils.changeOption('ColoredLevelBackground', 'we-button[data-toggle-bg-shape]', _t('Background Shape')),
     wTourUtils.selectNested('we-select-page', 'BackgroundShape', ':not(.o_we_pager_controls)', _t('Background Shape')),
     wTourUtils.goBackToBlocks(),
     wTourUtils.dragNDrop(snippets[6]),

--- a/theme_yes/static/src/js/tour.js
+++ b/theme_yes/static/src/js/tour.js
@@ -33,7 +33,7 @@ wTourUtils.registerThemeHomepageTour("yes_tour", () => [
     wTourUtils.assertCssVariable('--color-palettes-name', '"yes-3"'),
     wTourUtils.dragNDrop(snippets[0]),
     wTourUtils.dragNDrop(snippets[1]),
-    wTourUtils.clickOnText(snippets[1], 'h1'),
+    wTourUtils.clickOnText(snippets[1], 'h2'),
     wTourUtils.goBackToBlocks(),
     wTourUtils.dragNDrop(snippets[2]),
     wTourUtils.dragNDrop(snippets[3]),


### PR DESCRIPTION
Steps to reproduce
==================

Run the `test_02_homepage_tour_every_theme` tour.

Cause of the issue
==================

There is an homepage tour for every theme. Since the owl conversion of web_tour, none of the custom theme tour were run and for every website, the default homepage tour was used instead.

Some updates to those themes caused the tours to fail, but since they weren't run, no one noticed.

The issue has been fixed in community:
https://github.com/odoo/odoo/pull/142350

Solution
========

Since 1aa6700c986a96463165824400a9157c1db4e723,
some h1 tags were replaced by h2.

Since 68c68740bff7e96b9530de7d6fd4cd58145434a0,
The banner has been replaced by a text cover.

opw-3595512