### PR TITLE
[FIX] theme_*: fix linter error for runbot build

### DIFF
--- a/theme_artists/static/src/js/tour.js
+++ b/theme_artists/static/src/js/tour.js
@@ -2,9 +2,6 @@
 
 import wTourUtils from 'website.tour_utils';
 
-const core = require("web.core");
-const _t = core._t;
-
 const snippets = [
     {
         id: 's_carousel_wrapper',

--- a/theme_aviato/static/src/js/tour.js
+++ b/theme_aviato/static/src/js/tour.js
@@ -1,9 +1,7 @@
 /** @odoo-module */
 
+import { _t } from 'web.core';
 import wTourUtils from 'website.tour_utils';
-
-const core = require("web.core");
-const _t = core._t;
 
 const snippets = [
     {

--- a/theme_bewise/static/src/js/tour.js
+++ b/theme_bewise/static/src/js/tour.js
@@ -1,8 +1,7 @@
 /** @odoo-module */
-import wTourUtils from 'website.tour_utils';
 
-const core = require("web.core");
-const _t = core._t;
+import { _t } from 'web.core';
+import wTourUtils from 'website.tour_utils';
 
 const snippets = [
     {

--- a/theme_bookstore/static/src/js/tour.js
+++ b/theme_bookstore/static/src/js/tour.js
@@ -1,9 +1,7 @@
 /** @odoo-module */
 
+import { _t } from 'web.core';
 import wTourUtils from 'website.tour_utils';
-
-const core = require("web.core");
-const _t = core._t;
 
 const snippets = [
     {

--- a/theme_clean/static/src/js/tour.js
+++ b/theme_clean/static/src/js/tour.js
@@ -1,9 +1,7 @@
 /** @odoo-module */
 
+import { _t } from 'web.core';
 import wTourUtils from 'website.tour_utils';
-
-const core = require("web.core");
-const _t = core._t;
 
 const snippets = [
     {

--- a/theme_enark/static/src/js/tour.js
+++ b/theme_enark/static/src/js/tour.js
@@ -1,10 +1,7 @@
 odoo.define("theme_enark.tour.enark", function (require) {
 "use strict";
 
-const core = require("web.core");
-const _t = core._t;
 const wTourUtils = require("website.tour_utils");
-var tour = require("web_tour.tour");
 
 const snippets = [
     {

--- a/theme_graphene/static/src/js/tour.js
+++ b/theme_graphene/static/src/js/tour.js
@@ -1,11 +1,7 @@
 odoo.define("theme_graphene.tour.graphene", function (require) {
 "use strict";
 
-const core = require("web.core");
-const _t = core._t;
-
 const wTourUtils = require("website.tour_utils");
-var tour = require("web_tour.tour");
 
 const snippets = [
     {

--- a/theme_kiddo/static/src/js/tour.js
+++ b/theme_kiddo/static/src/js/tour.js
@@ -1,8 +1,7 @@
 /** @odoo-module */
-import wTourUtils from 'website.tour_utils';
 
-const core = require("web.core");
-const _t = core._t;
+import { _t } from 'web.core';
+import wTourUtils from 'website.tour_utils';
 
 const snippets = [
     {

--- a/theme_notes/static/src/js/tour.js
+++ b/theme_notes/static/src/js/tour.js
@@ -1,9 +1,7 @@
 /** @odoo-module */
 
+import { _t } from 'web.core';
 import wTourUtils from 'website.tour_utils';
-
-const core = require("web.core");
-const _t = core._t;
 
 const snippets = [
     {

--- a/theme_odoo_experts/static/src/js/tour.js
+++ b/theme_odoo_experts/static/src/js/tour.js
@@ -1,9 +1,7 @@
 /** @odoo-module */
 
+import { _t } from 'web.core';
 import wTourUtils from 'website.tour_utils';
-
-const core = require("web.core");
-const _t = core._t;
 
 const snippets = [
     {

--- a/theme_orchid/static/src/js/tour.js
+++ b/theme_orchid/static/src/js/tour.js
@@ -1,9 +1,7 @@
 /** @odoo-module */
 
+import { _t } from 'web.core';
 import wTourUtils from 'website.tour_utils';
-
-const core = require("web.core");
-const _t = core._t;
 
 const snippets = [
     {

--- a/theme_vehicle/static/src/js/tour.js
+++ b/theme_vehicle/static/src/js/tour.js
@@ -1,11 +1,7 @@
 odoo.define("theme_vehicle.tour.vehicle", function (require) {
 "use strict";
 
-const core = require("web.core");
-const _t = core._t;
-
 const wTourUtils = require("website.tour_utils");
-var tour = require("web_tour.tour");
 
 const snippets = [
     {


### PR DESCRIPTION
There is a linter error in the modified files of this PR about `require` not defined.
It's actually not really a problem as those files are transcompiled from ES6 module to odoo module, injecting `require` before the file is actually used/read by the browser, at which point no issue actually arise.

Those linter error were introduced with PR [1] in Odoo 15 but were fix in Odoo 16 with commit [2] (which should have arguably be done in Odoo 15).

[1]: https://github.com/odoo/design-themes/pull/500
[2]: https://github.com/odoo/design-themes/commit/dc2f5112022b5f987ed418e04b5e15c93dc7a731