### PR TITLE
[FIX] theme_*: register unused configurator snippets

### DIFF
--- a/theme_anelusia/__manifest__.py
+++ b/theme_anelusia/__manifest__.py
@@ -48,6 +48,8 @@
     'configurator_snippets': {
         'homepage': ['s_text_cover', 's_images_wall', 's_color_blocks_2', 's_references',
                      's_media_list', 's_company_team', 's_call_to_action'],
+        # TODO In master, remove unused templates instead.
+        '_': ['s_comparisons'],
     },
     'license': 'LGPL-3',
     'live_test_url': 'https://theme-anelusia.odoo.com',

--- a/theme_artists/__manifest__.py
+++ b/theme_artists/__manifest__.py
@@ -54,6 +54,8 @@
     },
     'configurator_snippets': {
         'homepage': ['s_carousel', 's_text_image', 's_three_columns', 's_title', 's_images_wall', 's_call_to_action'],
+        # TODO In master, remove unused templates instead.
+        '_': ['s_parallax', 's_numbers', 's_image_text', 's_product_catalog', 's_quotes_carousel'],
     },
     'license': 'LGPL-3',
     'live_test_url': 'https://theme-artists.odoo.com',

--- a/theme_bewise/__manifest__.py
+++ b/theme_bewise/__manifest__.py
@@ -26,6 +26,8 @@
     },
     'configurator_snippets': {
         'homepage': ['s_cover', 's_call_to_action', 's_text_image', 's_numbers', 's_image_text', 's_quotes_carousel', 's_color_blocks_2'],
+        # TODO In master, remove unused templates instead.
+        '_': ['s_company_team'],
     },
     'license': 'LGPL-3',
     'live_test_url': 'https://theme-bewise.odoo.com',

--- a/theme_bistro/__manifest__.py
+++ b/theme_bistro/__manifest__.py
@@ -40,6 +40,8 @@
     'configurator_snippets': {
         'homepage': ['s_cover', 's_features', 's_picture', 's_product_catalog', 's_text_block', 's_quotes_carousel'],
         'pricing': ["s_text_image", "s_product_catalog"],
+        # TODO In master, remove unused templates instead.
+        '_': ['s_banner'],
     },
     'license': 'LGPL-3',
     'live_test_url': 'https://theme-bistro.odoo.com',

--- a/theme_bookstore/__manifest__.py
+++ b/theme_bookstore/__manifest__.py
@@ -45,6 +45,8 @@
     },
     'configurator_snippets': {
         'homepage': ['s_cover', 's_masonry_block', 's_image_text', 's_picture', 's_product_list', 's_call_to_action'],
+        # TODO In master, remove unused templates instead.
+        '_': ['s_product_catalog'],
     },
     'new_page_templates': {
         'about': {

--- a/theme_buzzy/__manifest__.py
+++ b/theme_buzzy/__manifest__.py
@@ -47,6 +47,8 @@
     ],
     'configurator_snippets': {
         'homepage': ['s_banner', 's_text_image', 's_three_columns', 's_image_text', 's_numbers', 's_call_to_action'],
+        # TODO In master, remove unused templates instead.
+        '_': ['s_title'],
     },
     'new_page_templates': {
         'about': {

--- a/theme_clean/__manifest__.py
+++ b/theme_clean/__manifest__.py
@@ -41,6 +41,8 @@
     'configurator_snippets': {
         'homepage': ['s_cover', 's_text_image', 's_title', 's_features', 's_carousel', 's_numbers',
                      's_three_columns', 's_call_to_action'],
+        # TODO In master, remove unused templates instead.
+        '_': ['s_comparisons'],
     },
     'license': 'LGPL-3',
     'live_test_url': 'https://theme-clean.odoo.com',

--- a/theme_cobalt/__manifest__.py
+++ b/theme_cobalt/__manifest__.py
@@ -26,6 +26,8 @@
     },
     'configurator_snippets': {
         'homepage': ['s_banner', 's_references', 's_text_image', 's_color_blocks_2', 's_images_wall'],
+        # TODO In master, remove unused templates instead.
+        '_': ['s_image_text', 's_three_columns', 's_picture'],
     },
     'license': 'LGPL-3',
     'live_test_url': 'https://theme-cobalt.odoo.com',

--- a/theme_graphene/__manifest__.py
+++ b/theme_graphene/__manifest__.py
@@ -23,6 +23,8 @@
     },
     'configurator_snippets': {
         'homepage': ['s_cover', 's_text_image', 's_numbers', 's_picture', 's_comparisons'],
+        # TODO In master, remove unused templates instead.
+        '_': ['s_company_team'],
     },
     'new_page_templates': {
         'about': {

--- a/theme_kea/__manifest__.py
+++ b/theme_kea/__manifest__.py
@@ -39,6 +39,8 @@
     },
     'configurator_snippets': {
         'homepage': ['s_cover', 's_text_image', 's_picture', 's_image_text', 's_color_blocks_2', 's_media_list'],
+        # TODO In master, remove unused templates instead.
+        '_': ['s_references'],
     },
     'new_page_templates': {
         'about': {

--- a/theme_kiddo/__manifest__.py
+++ b/theme_kiddo/__manifest__.py
@@ -35,6 +35,8 @@
     },
     'configurator_snippets': {
         'homepage': ['s_banner', 's_image_text', 's_three_columns', 's_product_list', 's_call_to_action'],
+        # TODO In master, remove unused templates instead.
+        '_': ['s_picture'],
     },
     'new_page_templates': {
         'about': {

--- a/theme_notes/__manifest__.py
+++ b/theme_notes/__manifest__.py
@@ -46,6 +46,8 @@
     },
     'configurator_snippets': {
         'homepage': ['s_carousel', 's_masonry_block', 's_text_image', 's_product_catalog', 's_media_list', 's_company_team'],
+        # TODO In master, remove unused templates instead.
+        '_': ['s_cover'],
     },
     'new_page_templates': {
         'about': {

--- a/theme_odoo_experts/__manifest__.py
+++ b/theme_odoo_experts/__manifest__.py
@@ -41,6 +41,8 @@
     },
     'configurator_snippets': {
         'homepage': ['s_picture', 's_references', 's_image_text', 's_text_image', 's_title', 's_comparisons', 's_call_to_action'],
+        # TODO In master, remove unused templates instead.
+        '_': ['s_media_list', 's_company_team', 's_cover', 's_numbers'],
     },
     'new_page_templates': {
         'about': {

--- a/theme_paptic/__manifest__.py
+++ b/theme_paptic/__manifest__.py
@@ -23,6 +23,8 @@
     },
     'configurator_snippets': {
         'homepage': ['s_cover', 's_image_text', 's_references', 's_three_columns', 's_comparisons', 's_call_to_action'],
+        # TODO In master, remove unused templates instead.
+        '_': ['s_media_list'],
     },
     'new_page_templates': {
         'about': {

--- a/theme_vehicle/__manifest__.py
+++ b/theme_vehicle/__manifest__.py
@@ -26,6 +26,8 @@
     },
     'configurator_snippets': {
         'homepage': ['s_cover', 's_text_image', 's_image_text', 's_picture', 's_masonry_block', 's_call_to_action'],
+        # TODO In master, remove unused templates instead.
+        '_': ['s_numbers', 's_references'],
     },
     'new_page_templates': {
         'about': {


### PR DESCRIPTION
When shapes were extracted to configurator snippets in [1], some configurator-specific snippets were created that do not appear on pages of the specific theme.
Because in [2] the call to `_generate_primary_snippet_templates` is done on a full list of themes instead of only the installed ones, the problem was not noticed: if any theme defines a block, it's website-side configurator-specific template is generated.
This is not the case during an upgrade: the templates are generated only for the installed themes. Because of this some "useless" configurator templates trigger an error when importing their XML definition because their parent template does not exist.

This commit fixes this by adding those templates in a pseudo page `_` in the `configurator_snippets` entry of each theme's manifest. In master, the templates will be removed instead.

[1]: https://github.com/odoo/design-themes/commit/d206c119720d557c11320ebb3d7339890b8f9efa
[2]: https://github.com/odoo/odoo/commit/928eeca714a161f6bc03343e4dc8af9b050b9841#diff-f49a1e9eda23df9f1d48121ba376a5fabafe70ea18b29d4eab23d737e5d4eeb6R446