### PR TITLE
[FIX] theme_*: call _generate_primary_templates before importing data

### DIFF
--- a/test_themes/tests/__init__.py
+++ b/test_themes/tests/__init__.py
@@ -3,4 +3,5 @@
 
 from . import test_crawl
 from . import test_new_page_templates
+from . import test_theme_standalone
 from . import test_theme_upgrade

--- a/test_themes/tests/test_theme_standalone.py
+++ b/test_themes/tests/test_theme_standalone.py
@@ -1,0 +1,24 @@
+# -*- coding: utf-8 -*-
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+from odoo.addons.website.tools import MockRequest
+from odoo.tests import standalone
+
+
+@standalone('website_standalone')
+def test_01_theme_install_generate_primary_templates(env):
+    """ This test ensures the theme `_generate_primary_snippet_templates()`
+    method is correctly called before xml views are generated.
+    """
+    # 1. Setup
+    theme_buzzy = env.ref('base.module_theme_clean')
+
+    if theme_buzzy.state == 'installed':
+        theme_buzzy.button_immediate_uninstall()
+    # Ensure those views are deleted to mimic the initial state of theme not installed.
+    # Because "theme_buzzy" was installed before through "test_themes" dependencies, removing
+    # those views is needed to replicate the bug: if the configurator views are not generated,
+    # the theme install will fail because some of the imported views inherit them.
+    env['ir.ui.view'].with_context(_force_unlink=True).search([('key', '=', 'website.configurator_s_banner')]).unlink()
+    env['ir.ui.view'].with_context(_force_unlink=True).search([('key', '=', 'website.configurator_s_cover')]).unlink()
+    theme_buzzy.button_immediate_install()

--- a/theme_anelusia/__manifest__.py
+++ b/theme_anelusia/__manifest__.py
@@ -7,6 +7,7 @@
     'version': '2.1.0',
     'depends': ['theme_common'],
     'data': [
+        'data/generate_primary_template.xml',
         'data/ir_asset.xml',
         'views/images_content.xml',
         'views/images_library.xml',

--- a/theme_anelusia/data/generate_primary_template.xml
+++ b/theme_anelusia/data/generate_primary_template.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+
+<!-- Generate primary snippet templates that are not predefined -->
+<function model="ir.module.module" name="_generate_primary_snippet_templates">
+    <value eval="[ref('base.module_theme_anelusia')]"/>
+</function>
+
+</odoo>

--- a/theme_artists/__manifest__.py
+++ b/theme_artists/__manifest__.py
@@ -7,6 +7,7 @@
     'version': '2.1.0',
     'depends': ['theme_common'],
     'data': [
+        'data/generate_primary_template.xml',
         'data/ir_asset.xml',
         'views/images.xml',
 

--- a/theme_artists/data/generate_primary_template.xml
+++ b/theme_artists/data/generate_primary_template.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+
+<!-- Generate primary snippet templates that are not predefined -->
+<function model="ir.module.module" name="_generate_primary_snippet_templates">
+    <value eval="[ref('base.module_theme_artists')]"/>
+</function>
+
+</odoo>

--- a/theme_avantgarde/__manifest__.py
+++ b/theme_avantgarde/__manifest__.py
@@ -6,6 +6,7 @@
     'sequence': 150,
     'version': '2.0.0',
     'data': [
+        'data/generate_primary_template.xml',
         'data/ir_asset.xml',
         'views/images_library.xml',
         'views/customizations.xml',

--- a/theme_avantgarde/data/generate_primary_template.xml
+++ b/theme_avantgarde/data/generate_primary_template.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+
+<!-- Generate primary snippet templates that are not predefined -->
+<function model="ir.module.module" name="_generate_primary_snippet_templates">
+    <value eval="[ref('base.module_theme_avantgarde')]"/>
+</function>
+
+</odoo>

--- a/theme_aviato/__manifest__.py
+++ b/theme_aviato/__manifest__.py
@@ -7,6 +7,7 @@
     'version': '1.0.0',
     'depends': ['theme_common'],
     'data': [
+        'data/generate_primary_template.xml',
         'data/ir_asset.xml',
         'views/images_library.xml',
 

--- a/theme_aviato/data/generate_primary_template.xml
+++ b/theme_aviato/data/generate_primary_template.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+
+<!-- Generate primary snippet templates that are not predefined -->
+<function model="ir.module.module" name="_generate_primary_snippet_templates">
+    <value eval="[ref('base.module_theme_aviato')]"/>
+</function>
+
+</odoo>

--- a/theme_beauty/__manifest__.py
+++ b/theme_beauty/__manifest__.py
@@ -7,6 +7,7 @@
     'version': '2.1.0',
     'depends': ['theme_common'],
     'data': [
+        'data/generate_primary_template.xml',
         'data/ir_asset.xml',
         'views/images.xml',
 

--- a/theme_beauty/data/generate_primary_template.xml
+++ b/theme_beauty/data/generate_primary_template.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+
+<!-- Generate primary snippet templates that are not predefined -->
+<function model="ir.module.module" name="_generate_primary_snippet_templates">
+    <value eval="[ref('base.module_theme_beauty')]"/>
+</function>
+
+</odoo>

--- a/theme_bewise/__manifest__.py
+++ b/theme_bewise/__manifest__.py
@@ -7,6 +7,7 @@
     'version': '2.1.0',
     'depends': ['theme_common'],
     'data': [
+        'data/generate_primary_template.xml',
         'data/ir_asset.xml',
         'views/image_content.xml',
         'views/customizations.xml',

--- a/theme_bewise/data/generate_primary_template.xml
+++ b/theme_bewise/data/generate_primary_template.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+
+<!-- Generate primary snippet templates that are not predefined -->
+<function model="ir.module.module" name="_generate_primary_snippet_templates">
+    <value eval="[ref('base.module_theme_bewise')]"/>
+</function>
+
+</odoo>

--- a/theme_bistro/__manifest__.py
+++ b/theme_bistro/__manifest__.py
@@ -7,6 +7,7 @@
     'version': '2.0.0',
     'depends': ['theme_common'],
     'data': [
+        'data/generate_primary_template.xml',
         'data/ir_asset.xml',
         'views/images_library.xml',
 

--- a/theme_bistro/data/generate_primary_template.xml
+++ b/theme_bistro/data/generate_primary_template.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+
+<!-- Generate primary snippet templates that are not predefined -->
+<function model="ir.module.module" name="_generate_primary_snippet_templates">
+    <value eval="[ref('base.module_theme_bistro')]"/>
+</function>
+
+</odoo>

--- a/theme_bookstore/__manifest__.py
+++ b/theme_bookstore/__manifest__.py
@@ -7,6 +7,7 @@
     'version': '2.1.0',
     'depends': ['theme_common'],
     'data': [
+        'data/generate_primary_template.xml',
         'data/ir_asset.xml',
         'views/images.xml',
 

--- a/theme_bookstore/data/generate_primary_template.xml
+++ b/theme_bookstore/data/generate_primary_template.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+
+<!-- Generate primary snippet templates that are not predefined -->
+<function model="ir.module.module" name="_generate_primary_snippet_templates">
+    <value eval="[ref('base.module_theme_bookstore')]"/>
+</function>
+
+</odoo>

--- a/theme_buzzy/__manifest__.py
+++ b/theme_buzzy/__manifest__.py
@@ -7,6 +7,7 @@
     'version': '1.0.0',
     'depends': ['website'],
     'data': [
+        'data/generate_primary_template.xml',
         'data/ir_asset.xml',
         'views/images_library.xml',
 

--- a/theme_buzzy/data/generate_primary_template.xml
+++ b/theme_buzzy/data/generate_primary_template.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+
+<!-- Generate primary snippet templates that are not predefined -->
+<function model="ir.module.module" name="_generate_primary_snippet_templates">
+    <value eval="[ref('base.module_theme_buzzy')]"/>
+</function>
+
+</odoo>

--- a/theme_clean/__manifest__.py
+++ b/theme_clean/__manifest__.py
@@ -7,6 +7,7 @@
     'version': '2.1.0',
     'depends': ['theme_common'],
     'data': [
+        'data/generate_primary_template.xml',
         'data/ir_asset.xml',
         'views/image_content.xml',
 

--- a/theme_clean/data/generate_primary_template.xml
+++ b/theme_clean/data/generate_primary_template.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+
+<!-- Generate primary snippet templates that are not predefined -->
+<function model="ir.module.module" name="_generate_primary_snippet_templates">
+    <value eval="[ref('base.module_theme_clean')]"/>
+</function>
+
+</odoo>

--- a/theme_cobalt/__manifest__.py
+++ b/theme_cobalt/__manifest__.py
@@ -7,6 +7,7 @@
     'version': '2.0.0',
     'depends': ['website'],
     'data': [
+        'data/generate_primary_template.xml',
         'data/ir_asset.xml',
         'views/images.xml',
         'views/customizations.xml',

--- a/theme_cobalt/data/generate_primary_template.xml
+++ b/theme_cobalt/data/generate_primary_template.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+
+<!-- Generate primary snippet templates that are not predefined -->
+<function model="ir.module.module" name="_generate_primary_snippet_templates">
+    <value eval="[ref('base.module_theme_cobalt')]"/>
+</function>
+
+</odoo>

--- a/theme_enark/__manifest__.py
+++ b/theme_enark/__manifest__.py
@@ -7,6 +7,7 @@
     'version': '2.0.0',
     'depends': ['theme_common'],
     'data': [
+        'data/generate_primary_template.xml',
         'data/ir_asset.xml',
         'views/snippets_options.xml',
         'views/image_library.xml',

--- a/theme_enark/data/generate_primary_template.xml
+++ b/theme_enark/data/generate_primary_template.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+
+<!-- Generate primary snippet templates that are not predefined -->
+<function model="ir.module.module" name="_generate_primary_snippet_templates">
+    <value eval="[ref('base.module_theme_enark')]"/>
+</function>
+
+</odoo>

--- a/theme_graphene/__manifest__.py
+++ b/theme_graphene/__manifest__.py
@@ -6,6 +6,7 @@
     'sequence': 110,
     'version': '2.0.0',
     'data': [
+        'data/generate_primary_template.xml',
         'data/ir_asset.xml',
         'views/images_library.xml',
         'views/customizations.xml',

--- a/theme_graphene/data/generate_primary_template.xml
+++ b/theme_graphene/data/generate_primary_template.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+
+<!-- Generate primary snippet templates that are not predefined -->
+<function model="ir.module.module" name="_generate_primary_snippet_templates">
+    <value eval="[ref('base.module_theme_graphene')]"/>
+</function>
+
+</odoo>

--- a/theme_kea/__manifest__.py
+++ b/theme_kea/__manifest__.py
@@ -7,6 +7,7 @@
     'version': '2.0.0',
     'depends': ['theme_common'],
     'data': [
+        'data/generate_primary_template.xml',
         'data/ir_asset.xml',
         'views/images_content.xml',
 

--- a/theme_kea/data/generate_primary_template.xml
+++ b/theme_kea/data/generate_primary_template.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+
+<!-- Generate primary snippet templates that are not predefined -->
+<function model="ir.module.module" name="_generate_primary_snippet_templates">
+    <value eval="[ref('base.module_theme_kea')]"/>
+</function>
+
+</odoo>

--- a/theme_kiddo/__manifest__.py
+++ b/theme_kiddo/__manifest__.py
@@ -7,6 +7,7 @@
     'version': '2.1.0',
     'depends': ['theme_common'],
     'data': [
+        'data/generate_primary_template.xml',
         'data/ir_asset.xml',
         'views/images_library.xml',
 

--- a/theme_kiddo/data/generate_primary_template.xml
+++ b/theme_kiddo/data/generate_primary_template.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+
+<!-- Generate primary snippet templates that are not predefined -->
+<function model="ir.module.module" name="_generate_primary_snippet_templates">
+    <value eval="[ref('base.module_theme_kiddo')]"/>
+</function>
+
+</odoo>

--- a/theme_loftspace/__manifest__.py
+++ b/theme_loftspace/__manifest__.py
@@ -7,6 +7,7 @@
     'version': '2.1.0',
     'depends': ['theme_common'],
     'data': [
+        'data/generate_primary_template.xml',
         'data/ir_asset.xml',
         'views/images_content.xml',
 

--- a/theme_loftspace/data/generate_primary_template.xml
+++ b/theme_loftspace/data/generate_primary_template.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+
+<!-- Generate primary snippet templates that are not predefined -->
+<function model="ir.module.module" name="_generate_primary_snippet_templates">
+    <value eval="[ref('base.module_theme_loftspace')]"/>
+</function>
+
+</odoo>

--- a/theme_monglia/__manifest__.py
+++ b/theme_monglia/__manifest__.py
@@ -7,6 +7,7 @@
     'version': '2.0.0',
     'depends': ['theme_common'],
     'data': [
+        'data/generate_primary_template.xml',
         'data/ir_asset.xml',
         'views/images_content.xml',
         'views/customizations.xml',

--- a/theme_monglia/data/generate_primary_template.xml
+++ b/theme_monglia/data/generate_primary_template.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+
+<!-- Generate primary snippet templates that are not predefined -->
+<function model="ir.module.module" name="_generate_primary_snippet_templates">
+    <value eval="[ref('base.module_theme_monglia')]"/>
+</function>
+
+</odoo>

--- a/theme_nano/__manifest__.py
+++ b/theme_nano/__manifest__.py
@@ -7,6 +7,7 @@
     'version': '2.0.0',
     'depends': ['theme_common'],
     'data': [
+        'data/generate_primary_template.xml',
         'data/ir_asset.xml',
         'views/images_library.xml',
 

--- a/theme_nano/data/generate_primary_template.xml
+++ b/theme_nano/data/generate_primary_template.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+
+<!-- Generate primary snippet templates that are not predefined -->
+<function model="ir.module.module" name="_generate_primary_snippet_templates">
+    <value eval="[ref('base.module_theme_nano')]"/>
+</function>
+
+</odoo>

--- a/theme_notes/__manifest__.py
+++ b/theme_notes/__manifest__.py
@@ -7,6 +7,7 @@
     'version': '2.1.0',
     'depends': ['theme_common'],
     'data': [
+        'data/generate_primary_template.xml',
         'data/ir_asset.xml',
         'views/images_library.xml',
 

--- a/theme_notes/data/generate_primary_template.xml
+++ b/theme_notes/data/generate_primary_template.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+
+<!-- Generate primary snippet templates that are not predefined -->
+<function model="ir.module.module" name="_generate_primary_snippet_templates">
+    <value eval="[ref('base.module_theme_notes')]"/>
+</function>
+
+</odoo>

--- a/theme_odoo_experts/__manifest__.py
+++ b/theme_odoo_experts/__manifest__.py
@@ -7,6 +7,7 @@
     'version': '2.1.0',
     'depends': ['theme_common'],
     'data': [
+        'data/generate_primary_template.xml',
         'data/ir_asset.xml',
         'views/images.xml',
 

--- a/theme_odoo_experts/data/generate_primary_template.xml
+++ b/theme_odoo_experts/data/generate_primary_template.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+
+<!-- Generate primary snippet templates that are not predefined -->
+<function model="ir.module.module" name="_generate_primary_snippet_templates">
+    <value eval="[ref('base.module_theme_odoo_experts')]"/>
+</function>
+
+</odoo>

--- a/theme_orchid/__manifest__.py
+++ b/theme_orchid/__manifest__.py
@@ -7,6 +7,7 @@
     'version': '2.0.0',
     'depends': ['theme_common'],
     'data': [
+        'data/generate_primary_template.xml',
         'data/ir_asset.xml',
         'views/images.xml',
 

--- a/theme_orchid/data/generate_primary_template.xml
+++ b/theme_orchid/data/generate_primary_template.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+
+<!-- Generate primary snippet templates that are not predefined -->
+<function model="ir.module.module" name="_generate_primary_snippet_templates">
+    <value eval="[ref('base.module_theme_orchid')]"/>
+</function>
+
+</odoo>

--- a/theme_paptic/__manifest__.py
+++ b/theme_paptic/__manifest__.py
@@ -7,6 +7,7 @@
     'version': '2.1.0',
     'depends': ['website'],
     'data': [
+        'data/generate_primary_template.xml',
         'data/ir_asset.xml',
         'views/images.xml',
         'views/customizations.xml',

--- a/theme_paptic/data/generate_primary_template.xml
+++ b/theme_paptic/data/generate_primary_template.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+
+<!-- Generate primary snippet templates that are not predefined -->
+<function model="ir.module.module" name="_generate_primary_snippet_templates">
+    <value eval="[ref('base.module_theme_paptic')]"/>
+</function>
+
+</odoo>

--- a/theme_real_estate/__manifest__.py
+++ b/theme_real_estate/__manifest__.py
@@ -7,6 +7,7 @@
     'version': '2.0.0',
     'depends': ['theme_common'],
     'data': [
+        'data/generate_primary_template.xml',
         'data/ir_asset.xml',
         'views/images.xml',
 

--- a/theme_real_estate/data/generate_primary_template.xml
+++ b/theme_real_estate/data/generate_primary_template.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+
+<!-- Generate primary snippet templates that are not predefined -->
+<function model="ir.module.module" name="_generate_primary_snippet_templates">
+    <value eval="[ref('base.module_theme_real_estate')]"/>
+</function>
+
+</odoo>

--- a/theme_treehouse/__manifest__.py
+++ b/theme_treehouse/__manifest__.py
@@ -7,6 +7,7 @@
     'version': '2.0.0',
     'depends': ['theme_common'],
     'data': [
+        'data/generate_primary_template.xml',
         'data/ir_asset.xml',
         'views/images_library.xml',
 

--- a/theme_treehouse/data/generate_primary_template.xml
+++ b/theme_treehouse/data/generate_primary_template.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+
+<!-- Generate primary snippet templates that are not predefined -->
+<function model="ir.module.module" name="_generate_primary_snippet_templates">
+    <value eval="[ref('base.module_theme_treehouse')]"/>
+</function>
+
+</odoo>

--- a/theme_vehicle/__manifest__.py
+++ b/theme_vehicle/__manifest__.py
@@ -7,6 +7,7 @@
     'version': '2.0.0',
     'depends': ['theme_common'],
     'data': [
+        'data/generate_primary_template.xml',
         'data/ir_asset.xml',
         'views/images.xml',
         'views/customizations.xml',

--- a/theme_vehicle/data/generate_primary_template.xml
+++ b/theme_vehicle/data/generate_primary_template.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+
+<!-- Generate primary snippet templates that are not predefined -->
+<function model="ir.module.module" name="_generate_primary_snippet_templates">
+    <value eval="[ref('base.module_theme_vehicle')]"/>
+</function>
+
+</odoo>

--- a/theme_yes/__manifest__.py
+++ b/theme_yes/__manifest__.py
@@ -7,6 +7,7 @@
     'version': '2.0.0',
     'depends': ['theme_common'],
     'data': [
+        'data/generate_primary_template.xml',
         'data/ir_asset.xml',
         'views/images.xml',
 

--- a/theme_yes/data/generate_primary_template.xml
+++ b/theme_yes/data/generate_primary_template.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+
+<!-- Generate primary snippet templates that are not predefined -->
+<function model="ir.module.module" name="_generate_primary_snippet_templates">
+    <value eval="[ref('base.module_theme_yes')]"/>
+</function>
+
+</odoo>

--- a/theme_zap/__manifest__.py
+++ b/theme_zap/__manifest__.py
@@ -7,6 +7,7 @@
     'version': '2.0.0',
     'depends': ['theme_common'],
     'data': [
+        'data/generate_primary_template.xml',
         'data/ir_asset.xml',
         'views/images_library.xml',
 

--- a/theme_zap/data/generate_primary_template.xml
+++ b/theme_zap/data/generate_primary_template.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+
+<!-- Generate primary snippet templates that are not predefined -->
+<function model="ir.module.module" name="_generate_primary_snippet_templates">
+    <value eval="[ref('base.module_theme_zap')]"/>
+</function>
+
+</odoo>


### PR DESCRIPTION
To make sure the required primary templates have been generated from the theme's manifest when inherited views are imported/updated, this commit triggers their generation from a first imported XML file.

This has been added to all themes for consistency, even the ones that do not require it currently.

Related to https://github.com/odoo/odoo/pull/148443

task-3670496