### PR TITLE
[FIX] theme_test_custo: consider the `top_menu` navbar class in tests

### DIFF
--- a/theme_test_custo/static/tests/tours/theme_menu_hierarchies.js
+++ b/theme_test_custo/static/tests/tours/theme_menu_hierarchies.js
@@ -8,21 +8,21 @@ wTourUtils.registerWebsitePreviewTour('theme_menu_hierarchies', {
 }, () => [
     {
         content: 'Check Mega Menu is correctly created',
-        trigger: 'iframe #top_menu a.o_mega_menu_toggle',
+        trigger: "iframe .top_menu a.o_mega_menu_toggle",
     }, {
         content: 'Check Mega Menu content',
-        trigger: 'iframe #top_menu div.o_mega_menu.show .fa-cube',
+        trigger: "iframe .top_menu div.o_mega_menu.show .fa-cube",
         run: () => null, // It's a check.
     }, {
         content: 'Check new top level menu is correctly created',
-        trigger: 'iframe #top_menu .nav-item.dropdown .dropdown-toggle:contains("Example 1")',
+        trigger: 'iframe .top_menu .nav-item.dropdown .dropdown-toggle:contains("Example 1")',
     }, {
         content: 'Check sub menu are correctly created',
-        trigger: 'iframe #top_menu .dropdown-menu.show a.dropdown-item:contains("Item 1")',
+        trigger: 'iframe .top_menu .dropdown-menu.show a.dropdown-item:contains("Item 1")',
         run: () => null, // It's a check.
     }, {
         content: 'The new menu hierarchy should not be included in the navbar',
-        trigger: 'iframe body:not(:has(#top_menu a[href="/dogs"]))',
+        trigger: 'iframe body:not(:has(.top_menu a[href="/dogs"]))',
         run: () => null, // It's a check.
     }, {
         content: 'The new menu hierarchy should be inside the footer',


### PR DESCRIPTION
In PR [1], the duplicated navbars ids `o_main_nav` and `top_menu` are
replaced by classes, to avoid having the same ids multiple times in the
DOM. Note that for stability, the ids are kept for the desktop view
navbar.

This commit adapts the tests so they also consider the classes and not
only the ids.

[1]: https://github.com/odoo/odoo/pull/146492

task-3609531

See PR [1] for the associated community PR.