### PR TITLE
[FIX] test_themes: adapt switcher tooltip format

### DIFF
--- a/test_themes/static/src/systray_items/website_switcher.js
+++ b/test_themes/static/src/systray_items/website_switcher.js
@@ -18,10 +18,10 @@ patch(WebsiteSwitcherSystray.prototype, {
             const themesWebsites = await this.orm.call('website', 'get_test_themes_websites_theme_preview');
             for (const themeId in themesWebsites) {
                 this.tooltips[themeId] = {
-                    tooltipTemplate: 'test_themes.ThemeTooltip',
-                    tooltipPosition: 'left',
-                    tooltipDelay: 100,
-                    tooltipInfo: JSON.stringify({url: themesWebsites[themeId]}),
+                    "data-tooltip-template": 'test_themes.ThemeTooltip',
+                    "data-tooltip-position": 'left',
+                    "data-tooltip-delay": 100,
+                    "data-tooltip-info": JSON.stringify({url: themesWebsites[themeId]}),
                 };
             }
         });

--- a/test_themes/static/src/systray_items/website_switcher.xml
+++ b/test_themes/static/src/systray_items/website_switcher.xml
@@ -6,7 +6,7 @@
 
 <t t-name="test_themes.WebsiteSwitcherSystray" t-inherit="website.WebsiteSwitcherSystray" t-inherit-mode="extension">
     <xpath expr="//DropdownItem" position="attributes">
-        <attribute name="dataset">this.tooltips[element.id]</attribute>
+        <attribute name="attrs">this.tooltips[element.id]</attribute>
     </xpath>
     <!-- With this module installed, disable the warning -->
     <xpath expr="//DropdownItem/t[@t-if='!element.domain']" position="replace">


### PR DESCRIPTION
This adapts the WebsiteSwitcherSystray's DropdownItem
tooltips dataset to the changed API brought in
the community repository.

Task: [3266145](https://www.odoo.com/mail/view?model=project.task&res_id=3266145&access_token=7a09516e-1a2d-4970-a909-0f5099588055)