### PR TITLE
[REM] theme_*: remove useless scss variable overrides

### DIFF
--- a/theme_anelusia/static/src/scss/primary_variables.scss
+++ b/theme_anelusia/static/src/scss/primary_variables.scss
@@ -8,7 +8,6 @@ $o-website-values-palettes: (
 
         // Header
         'header-font-size':                 1rem,
-        'header-template':                  'default',
 
         // Font
         'font':                             'Source Sans Pro',
@@ -42,7 +41,6 @@ $o-theme-h2-font-size-multiplier: (32 / 16);
 $o-theme-h3-font-size-multiplier: (28 / 16);
 $o-theme-h4-font-size-multiplier: (24 / 16);
 $o-theme-h5-font-size-multiplier: (21 / 16);
-$o-theme-h6-font-size-multiplier: 1;
 
 $o-theme-headings-font-weight: 700;
 

--- a/theme_artists/static/src/scss/primary_variables.scss
+++ b/theme_artists/static/src/scss/primary_variables.scss
@@ -99,7 +99,6 @@ $o-website-values-palettes: (
         'headings-font': 'Oxygen',
         'btn-ripple': true,
         'header-template': 'hamburger',
-        'hamburger-position': 'left',
         'footer-template': 'centered',
         'link-underline': 'never',
     ),

--- a/theme_avantgarde/static/src/scss/primary_variables.scss
+++ b/theme_avantgarde/static/src/scss/primary_variables.scss
@@ -88,11 +88,8 @@ $o-theme-color-palettes: map-merge($o-theme-color-palettes,
 // Fonts
 //------------------------------------------------------------------------------
 
-$o-theme-h1-font-size-multiplier: 3;
-$o-theme-h2-font-size-multiplier: 2.5;
 $o-theme-h3-font-size-multiplier: (31.25 / 16);
 $o-theme-h4-font-size-multiplier: (25.00 / 16);
-$o-theme-h5-font-size-multiplier: (20.00 / 16);
 $o-theme-h6-font-size-multiplier: 1.1;
 
 $o-theme-font-configs: (
@@ -177,9 +174,7 @@ $o-theme-font-configs: (
 $o-website-values-palettes: (
     (
         'color-palettes-name': 'avantgarde-3',
-        'layout': 'full',
 
-        'font-size-base': 1rem,
         'font': 'Syne',
 
         'header-template': 'hamburger',

--- a/theme_beauty/static/src/scss/primary_variables.scss
+++ b/theme_beauty/static/src/scss/primary_variables.scss
@@ -66,7 +66,6 @@ $o-website-values-palettes: (
         'headings-font': 'DM Serif Display',
 
         'header-template': 'sales_one',
-        'footer-template': 'default',
         'header-links-style': 'outline',
 
         // Buttons

--- a/theme_bewise/static/src/scss/primary_variables.scss
+++ b/theme_bewise/static/src/scss/primary_variables.scss
@@ -109,14 +109,10 @@ $o-website-values-palettes: (
         'font': 'Darker Grotesque',
         'headings-font': 'Raleway',
 
-        'layout': 'full',
-        'header-template': 'default',
-        'menu-box-shadow': false,
         'footer-template': 'headline',
 
         'btn-font-size-lg': 1.65rem,
         'btn-padding-y-lg': .5rem,
-        'btn-padding-x-lg': 2.5rem,
         'btn-ripple': true,
     ),
 );

--- a/theme_bistro/static/src/scss/primary_variables.scss
+++ b/theme_bistro/static/src/scss/primary_variables.scss
@@ -12,7 +12,6 @@ $o-website-values-palettes: (
         'logo-height':                      3rem,
         'fixed-logo-height':                2rem,
         'header-links-style':               'pills',
-        'menu-box-shadow':                  none,
 
         // Font
         'font':                             'Poppins',
@@ -95,9 +94,6 @@ $o-theme-font-configs: (
 
 // Headings
 
-$o-theme-h1-font-size-multiplier:           3;
-$o-theme-h2-font-size-multiplier:           2.5;
-$o-theme-h3-font-size-multiplier:           2;
 $o-theme-h4-font-size-multiplier:           1.75;
 $o-theme-h5-font-size-multiplier:           1.5;
 $o-theme-h6-font-size-multiplier:           1.25;

--- a/theme_bookstore/static/src/scss/primary_variables.scss
+++ b/theme_bookstore/static/src/scss/primary_variables.scss
@@ -4,10 +4,7 @@
 
 $o-theme-h1-font-size-multiplier: (62 / 16);
 $o-theme-h2-font-size-multiplier: (48 / 16);
-$o-theme-h3-font-size-multiplier: (32 / 16);
-$o-theme-h4-font-size-multiplier: (24 / 16);
 $o-theme-h5-font-size-multiplier: 1;
-$o-theme-h6-font-size-multiplier: 1;
 
 $o-theme-font-configs: (
     'Heebo': (

--- a/theme_buzzy/static/src/scss/primary_variables.scss
+++ b/theme_buzzy/static/src/scss/primary_variables.scss
@@ -9,7 +9,6 @@ $o-website-values-palettes: (
         // Header
         'logo-height':                      2.75rem,
         'fixed-logo-height':                2rem,
-        'header-template':                  'default',
 
         // Font
         'font':                             'Montserrat',
@@ -104,9 +103,6 @@ $o-theme-font-configs: (
 
 // Headings
 
-$o-theme-h1-font-size-multiplier:           3;
-$o-theme-h2-font-size-multiplier:           2.5;
-$o-theme-h3-font-size-multiplier:           2;
 $o-theme-h4-font-size-multiplier:           1.75;
 $o-theme-h5-font-size-multiplier:           1.5;
 

--- a/theme_clean/static/src/scss/primary_variables.scss
+++ b/theme_clean/static/src/scss/primary_variables.scss
@@ -105,7 +105,6 @@ $o-theme-color-palettes: map-merge($o-theme-color-palettes,
 $o-theme-h1-font-size-multiplier: (62 / 16);
 $o-theme-h2-font-size-multiplier: (48 / 16);
 $o-theme-h3-font-size-multiplier: (36 / 16);
-$o-theme-h4-font-size-multiplier: (24 / 16);
 $o-theme-h5-font-size-multiplier: (21 / 16);
 $o-theme-h6-font-size-multiplier: (18 / 16);
 

--- a/theme_cobalt/static/src/scss/primary_variables.scss
+++ b/theme_cobalt/static/src/scss/primary_variables.scss
@@ -4,9 +4,6 @@
 
 $o-theme-h1-font-size-multiplier: (62 / 16);
 $o-theme-h2-font-size-multiplier: (48 / 16);
-$o-theme-h3-font-size-multiplier: (32 / 16);
-$o-theme-h4-font-size-multiplier: (24 / 16);
-$o-theme-h5-font-size-multiplier: (20 / 16);
 $o-theme-h6-font-size-multiplier: 1.1;
 
 $o-theme-font-configs: (
@@ -33,8 +30,6 @@ $o-website-values-palettes: (
         'font': 'Inter',
 
         'headings-line-height': 1.1,
-
-        'menu-box-shadow': false,
 
         'btn-ripple': true,
         'btn-secondary-outline': true,

--- a/theme_enark/static/src/scss/primary_variables.scss
+++ b/theme_enark/static/src/scss/primary_variables.scss
@@ -80,9 +80,6 @@ $o-theme-color-palettes: map-merge($o-theme-color-palettes,
 
 $o-theme-h1-font-size-multiplier: (62 / 16);
 $o-theme-h2-font-size-multiplier: (48 / 16);
-$o-theme-h3-font-size-multiplier: (32 / 16);
-$o-theme-h4-font-size-multiplier: (24 / 16);
-$o-theme-h5-font-size-multiplier: (20 / 16);
 $o-theme-h6-font-size-multiplier: (18 / 16);
 
 $o-theme-font-configs: (

--- a/theme_graphene/static/src/scss/primary_variables.scss
+++ b/theme_graphene/static/src/scss/primary_variables.scss
@@ -95,8 +95,6 @@ $o-website-values-palettes: (
     (
         'color-palettes-name': 'graphene-1',
 
-        'font-size-base': 1rem,
-
         'font': 'Source Sans Pro',
         'headings-font': 'Assistant',
 

--- a/theme_kea/static/src/scss/primary_variables.scss
+++ b/theme_kea/static/src/scss/primary_variables.scss
@@ -64,8 +64,6 @@ $o-theme-color-palettes: map-merge($o-theme-color-palettes,
 $o-theme-h1-font-size-multiplier: (62 / 16);
 $o-theme-h2-font-size-multiplier: (48 / 16);
 $o-theme-h3-font-size-multiplier: (36 / 16);
-$o-theme-h4-font-size-multiplier: (24 / 16);
-$o-theme-h5-font-size-multiplier: (20 / 16);
 $o-theme-h6-font-size-multiplier: (18 / 16);
 
 $headings-font-weight:700;

--- a/theme_kiddo/static/src/scss/primary_variables.scss
+++ b/theme_kiddo/static/src/scss/primary_variables.scss
@@ -56,7 +56,6 @@ $o-theme-color-palettes: map-merge($o-theme-color-palettes,
 
 $o-theme-h1-font-size-multiplier: (40 / 14);
 $o-theme-h2-font-size-multiplier: (38 / 14);
-$o-theme-h3-font-size-multiplier: (28 / 14);
 $o-theme-h4-font-size-multiplier: (24 / 14);
 $o-theme-h5-font-size-multiplier: (20 / 14);
 $o-theme-h6-font-size-multiplier: (16 / 14);
@@ -129,7 +128,6 @@ $o-website-values-palettes: (
         'logo-height': 3rem,
         'fixed-logo-height': 3rem,
         'btn-border-radius': 2rem,
-        'btn-border-radius-lg': 2rem,
         'btn-padding-y': .5rem,
         'btn-padding-x': 1.25rem,
         'btn-padding-y-lg': .75rem,
@@ -139,7 +137,6 @@ $o-website-values-palettes: (
         'navbar-font': 'Varela Round',
         'buttons-font': 'Varela Round',
         'link-underline': 'never',
-        'header-template': 'default',
         'footer-template': 'centered',
     ),
 );

--- a/theme_loftspace/static/src/scss/primary_variables.scss
+++ b/theme_loftspace/static/src/scss/primary_variables.scss
@@ -74,10 +74,7 @@ $o-theme-color-palettes: map-merge($o-theme-color-palettes,
 $o-theme-h1-font-size-multiplier: (62 / 16);
 $o-theme-h2-font-size-multiplier: (36 / 16);
 $o-theme-h3-font-size-multiplier: (28 / 16);
-$o-theme-h4-font-size-multiplier: (24 / 16);
-$o-theme-h5-font-size-multiplier: (21 / 16);
 $o-theme-h5-font-size-multiplier: (18 / 16);
-$o-theme-h6-font-size-multiplier: 1;
 
 $o-theme-font-configs: (
     'Heebo': (
@@ -138,7 +135,6 @@ $o-website-values-palettes: (
         'navbar-font': 'Poppins',
         'buttons-font': 'Poppins',
         'header-template': 'search',
-        'footer-template': 'default',
         'link-underline': 'never',
     ),
 );

--- a/theme_nano/static/src/scss/primary_variables.scss
+++ b/theme_nano/static/src/scss/primary_variables.scss
@@ -8,11 +8,9 @@ $o-website-values-palettes: (
 
         // Header
         'header-template':                  'search',
-        'hamburger-position':               'left',
         'header-font-size':                 1rem,
         'header-links-style':               'fill',
         'menu-border-radius':               0,
-        'menu-box-shadow':                  none,
 
         // Font
         'font':                             'Oxygen',
@@ -92,9 +90,6 @@ $o-theme-font-configs: (
 );
 
 // Headings
-
-$o-theme-h1-font-size-multiplier:           3;
-$o-theme-h2-font-size-multiplier:           2.5;
 
 $o-theme-headings-font-weight:              400;
 

--- a/theme_notes/static/src/scss/primary_variables.scss
+++ b/theme_notes/static/src/scss/primary_variables.scss
@@ -57,9 +57,6 @@ $o-theme-color-palettes: map-merge($o-theme-color-palettes,
 $o-theme-h1-font-size-multiplier: (62 / 16);
 $o-theme-h2-font-size-multiplier: (36 / 16);
 $o-theme-h3-font-size-multiplier: (28 / 16);
-$o-theme-h4-font-size-multiplier: (24 / 16);
-$o-theme-h5-font-size-multiplier: (20 / 16);
-$o-theme-h6-font-size-multiplier: 1;
 
 $o-theme-headings-font-weight: 700;
 
@@ -128,7 +125,6 @@ $o-website-values-palettes: (
         'navbar-font': 'Montserrat',
         'buttons-font': 'Montserrat',
         'link-underline': 'never',
-        'header-template': 'default',
         'footer-template': 'descriptive',
     ),
 );

--- a/theme_odoo_experts/static/src/scss/primary_variables.scss
+++ b/theme_odoo_experts/static/src/scss/primary_variables.scss
@@ -5,7 +5,6 @@
 $o-theme-h1-font-size-multiplier: (62 / 16);
 $o-theme-h2-font-size-multiplier: (44 / 16);
 $o-theme-h3-font-size-multiplier: (36 / 16);
-$o-theme-h4-font-size-multiplier: (24 / 16);
 $o-theme-h5-font-size-multiplier: (21 / 16);
 $o-theme-h6-font-size-multiplier: (18 / 16);
 

--- a/theme_orchid/static/src/scss/primary_variables.scss
+++ b/theme_orchid/static/src/scss/primary_variables.scss
@@ -5,7 +5,6 @@
 $o-theme-h1-font-size-multiplier: (62 / 16);
 $o-theme-h2-font-size-multiplier: (48 / 16);
 $o-theme-h3-font-size-multiplier: (36 / 16);
-$o-theme-h4-font-size-multiplier: (24 / 16);
 $o-theme-h5-font-size-multiplier: (21 / 16);
 $o-theme-h6-font-size-multiplier: (18 / 16);
 
@@ -63,7 +62,6 @@ $o-website-values-palettes: (
         'color-palettes-name': 'orchid-7',
         'font': 'Questrial',
         'headings-font': 'Cormorant Garamond',
-        'header-template': 'default',
         'footer-template': 'descriptive',
     ),
 );

--- a/theme_paptic/static/src/scss/primary_variables.scss
+++ b/theme_paptic/static/src/scss/primary_variables.scss
@@ -4,7 +4,6 @@
 
 $o-theme-h1-font-size-multiplier: (48 / 14);
 $o-theme-h2-font-size-multiplier: (38 / 14);
-$o-theme-h3-font-size-multiplier: (28 / 14);
 $o-theme-h4-font-size-multiplier: (24 / 14);
 $o-theme-h5-font-size-multiplier: (21 / 14);
 $o-theme-h6-font-size-multiplier: (18 / 14);
@@ -44,15 +43,12 @@ $o-website-values-palettes: (
         'header-font-size': (14 / 16) * 1rem,
         'headings-line-height': 1.1,
 
-        'menu-box-shadow': false,
-
         'btn-ripple': true,
 
         'btn-font-size': (14 / 16) * 1rem,
         'btn-border-radius': 2px,
 
         'btn-font-size-lg': (14 / 16) * 1rem,
-        'btn-padding-y-lg': 1rem,
         'btn-padding-x-lg': (28 / 16) * 1rem,
     ),
 );

--- a/theme_real_estate/static/src/scss/primary_variables.scss
+++ b/theme_real_estate/static/src/scss/primary_variables.scss
@@ -73,7 +73,6 @@ $o-theme-h2-font-size-multiplier: (36 / 16);
 $o-theme-h3-font-size-multiplier: (24 / 16);
 $o-theme-h4-font-size-multiplier: (20 / 16);
 $o-theme-h5-font-size-multiplier: (18 / 16);
-$o-theme-h6-font-size-multiplier: (16 / 16);
 
 //------------------------------------------------------------------------------
 // Website customizations
@@ -85,9 +84,6 @@ $btn-font-weight: 500;
 $o-website-values-palettes: (
     (
         'color-palettes-name': 'real-estate-4',
-        // Header
-        'header-template': 'default',
-
         // Font
         'font': 'Roboto',
 

--- a/theme_treehouse/static/src/scss/primary_variables.scss
+++ b/theme_treehouse/static/src/scss/primary_variables.scss
@@ -92,10 +92,6 @@ $o-theme-font-configs: (
 
 // Headings
 
-$o-theme-h1-font-size-multiplier:           3;
-$o-theme-h2-font-size-multiplier:           2.5;
-$o-theme-h3-font-size-multiplier:           2;
-
 $o-theme-headings-font-weight:              400;
 
 // Texts

--- a/theme_vehicle/static/src/scss/primary_variables.scss
+++ b/theme_vehicle/static/src/scss/primary_variables.scss
@@ -55,7 +55,6 @@ $o-theme-h2-font-size-multiplier: (38 / 16);
 $o-theme-h3-font-size-multiplier: (24 / 16);
 $o-theme-h4-font-size-multiplier: (20 / 16);
 $o-theme-h5-font-size-multiplier: (18 / 16);
-$o-theme-h6-font-size-multiplier: (16 / 16);
 
 $o-theme-headings-font-weight: 600;
 
@@ -110,7 +109,6 @@ $o-website-values-palettes: (
         'navbar-font': 'Fira Sans',
 
         'buttons-font': 'Fira Sans',
-        'btn-primary-outline': false,
         'btn-secondary-outline': true,
 
         'btn-border-width': 2px,
@@ -123,7 +121,6 @@ $o-website-values-palettes: (
         'btn-padding-y-lg': .6rem,
         'btn-font-size': 1.2rem,
 
-        'header-template': 'default',
         'header-links-style': 'border-bottom',
         'footer-template': 'minimalist',
     ),

--- a/theme_yes/static/src/scss/primary_variables.scss
+++ b/theme_yes/static/src/scss/primary_variables.scss
@@ -1,13 +1,7 @@
 //------------------------------------------------------------------------------
 // Fonts
 //------------------------------------------------------------------------------
-
-$o-theme-h1-font-size-multiplier: (36 / 12);
-$o-theme-h2-font-size-multiplier: (30 / 12);
-$o-theme-h3-font-size-multiplier: (24 / 12);
-$o-theme-h4-font-size-multiplier: (18 / 12);
 $o-theme-h5-font-size-multiplier: (14 / 12);
-$o-theme-h6-font-size-multiplier: 1;
 
 $o-theme-font-configs: (
     'Playfair Display': (

--- a/theme_zap/static/src/scss/primary_variables.scss
+++ b/theme_zap/static/src/scss/primary_variables.scss
@@ -102,9 +102,6 @@ $o-theme-font-configs: (
 
 // Headings
 
-$o-theme-h1-font-size-multiplier:           3;
-$o-theme-h2-font-size-multiplier:           2.5;
-
 $o-theme-headings-font-weight:              400;
 
 // Texts


### PR DESCRIPTION
This commit removes the overrides of scss variables that are set to the default value.

task-2463604

We do this in a separate PR to facilitate [this other PR](https://github.com/odoo/design-themes/pull/766).