### PR TITLE
[FIX] test_themes: fix test_01_theme_upgrade_post_copy

### DIFF
--- a/test_themes/tests/__init__.py
+++ b/test_themes/tests/__init__.py
@@ -1,7 +1,11 @@
 # -*- coding: utf-8 -*-
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
+# The order of these tests is important, as the last one will uninstall this
+# module. Ideally, the tests would be independent from one another but for now,
+# ensure this order.
 
 from . import test_crawl
 from . import test_new_page_templates
-from . import test_theme_standalone
 from . import test_theme_upgrade
+# This test should be last.
+from . import test_theme_standalone


### PR DESCRIPTION
Commit [1] introduced a new test that uninstalls theme_buzzy. This leads to the whole module being uninstalled because this module has all themes as dependencies.

To fix this, we just run the test as the last test, ensuring the module is still installed for other tests.

Ideally, test would be independent from one another, but for now, the order matters.

[1]: https://github.com/odoo/design-themes/commit/4cdd1db20c021ebd369b46c739591def9732eec5