### PR TITLE
[FIX] theme_*: make s_picture image responsive by default

### DIFF
--- a/theme_avantgarde/views/customizations.xml
+++ b/theme_avantgarde/views/customizations.xml
@@ -48,7 +48,7 @@
         We combine a wide spectrum of technologies with a good portion of creativity.
     </xpath>
     <xpath expr="//img" position="attributes">
-        <attribute name="class" add="img-fluid" remove="img-thumbnail" separator=" "/>
+        <attribute name="class" remove="img-thumbnail" separator=" "/>
         <attribute name="src">/web_editor/image_shape/website.s_picture_default_image/web_editor/composition/composition_organic_line.svg?c2=o-color-2</attribute>
         <attribute name="data-shape">web_editor/composition/composition_organic_line</attribute>
         <attribute name="data-original-mimetype">image/jpeg</attribute>

--- a/theme_cobalt/views/customizations.xml
+++ b/theme_cobalt/views/customizations.xml
@@ -175,7 +175,7 @@
         <attribute name="class" add="container-fluid px-5 px-lg-0" remove="container" separator=" "/>
     </xpath>
     <xpath expr="//img" position="attributes">
-        <attribute name="class" add="img-fluid" remove="img-thumbnail padding-large" separator=" "/>
+        <attribute name="class" remove="img-thumbnail padding-large" separator=" "/>
     </xpath>
     <xpath expr="//figcaption" position="replace">
         <figcaption class="text-400"><em>Our office in Dhaka</em></figcaption>

--- a/theme_paptic/views/customizations.xml
+++ b/theme_paptic/views/customizations.xml
@@ -290,7 +290,7 @@
     </xpath>
     <xpath expr="//img" position="attributes">
         <attribute name="src">/web_editor/shape/theme_paptic/s_picture.svg?c1=o-color-1</attribute>
-        <attribute name="class" add="img-fluid" remove="img-thumbnail" separator=" "/>
+        <attribute name="class" remove="img-thumbnail" separator=" "/>
     </xpath>
 </template>
 

--- a/theme_treehouse/views/snippets/s_picture.xml
+++ b/theme_treehouse/views/snippets/s_picture.xml
@@ -12,7 +12,7 @@
     </xpath>
     <!-- Image + Shape -->
     <xpath expr="//img" position="attributes">
-        <attribute name="class" add="img-fluid" remove="img-thumbnail padding-large" separator=" "/>
+        <attribute name="class" remove="img-thumbnail padding-large" separator=" "/>
         <attribute name="src">/web_editor/image_shape/website.s_picture_default_image/web_editor/special/special_filter.svg</attribute>
         <attribute name="data-file-name">01.svg</attribute>
         <attribute name="data-shape">web_editor/special/special_filter</attribute>

--- a/theme_vehicle/views/customizations.xml
+++ b/theme_vehicle/views/customizations.xml
@@ -159,7 +159,7 @@
     </xpath>
     <!-- Image + Shape -->
     <xpath expr="//img" position="attributes">
-        <attribute name="class" add="img-fluid" remove="img-thumbnail padding-large" separator=" "/>
+        <attribute name="class" remove="img-thumbnail padding-large" separator=" "/>
         <attribute name="src">/web/image/website.s_picture_default_image</attribute>
         <attribute name="data-file-name">01.svg</attribute>
     </xpath>


### PR DESCRIPTION
Some themes were making the s_picture image responsive on their own. It is now done generically, so the theme extensions must be removed to be able to merge.

task-3266862

X-original-commit: 08cb536b02e91d425dca826b42ad3219b46e69d6