### PR TITLE
[FIX] test_themes: fix test new page templates

### DIFF
--- a/test_themes/tests/test_new_page_templates.py
+++ b/test_themes/tests/test_new_page_templates.py
@@ -172,7 +172,7 @@ class TestNewPageTemplates(TransactionCase):
                             # Only look at blocks in website.snippets
                             html_tree = blocks_el[0]
                         for el in html_tree.xpath('//*[@class]'):
-                            classes = el.attrib['class'].split(' ')
+                            classes = el.attrib['class'].split()
                             classes_inventory.update(classes)
                             if len(classes) != len(set(classes)):
                                 errors.append("Using %r, view %r contains duplicate classes: %r" % (theme_name, view.key, classes))


### PR DESCRIPTION
The following commit [1] added a test to verify that there are no duplicate classes in the elements of predefined page templates.

This test worked fine until it failed when we attempted to merge a commit in which a template is rendered with empty spaces in the class attribute of an element. The test considered the empty spaces as classes and therefore assumed that two identical classes existed.

This commit excludes empty spaces when retrieving classes in this test.

[1]: https://github.com/odoo/design-themes/commit/758e2ab819df37c56103b1e82f1e6358b3dba00c

task-3662985