### PR TITLE
[REF] web_tour: prepare to change the default action in tour_compiler

### DIFF
--- a/theme_test_custo/static/tests/tours/theme_menu_hierarchies.js
+++ b/theme_test_custo/static/tests/tours/theme_menu_hierarchies.js
@@ -11,6 +11,7 @@ wTourUtils.registerWebsitePreviewTour('theme_menu_hierarchies', {
     {
         content: 'Check Mega Menu is correctly created',
         trigger: ":iframe .top_menu a.o_mega_menu_toggle",
+        run: "click",
     }, {
         content: 'Check Mega Menu content',
         trigger: ":iframe .top_menu div.o_mega_menu.show .fa-cube",
@@ -18,6 +19,7 @@ wTourUtils.registerWebsitePreviewTour('theme_menu_hierarchies', {
     }, {
         content: 'Check new top level menu is correctly created',
         trigger: ':iframe .top_menu .nav-item.dropdown .dropdown-toggle:contains("Example 1")',
+        run: "click",
     }, {
         content: 'Check sub menu are correctly created',
         trigger: ':iframe .top_menu .dropdown-menu.show a.dropdown-item:contains("Item 1")',
@@ -35,6 +37,7 @@ wTourUtils.registerWebsitePreviewTour('theme_menu_hierarchies', {
     {
         content: 'Click on footer',
         trigger: ':iframe footer',
+        run: "click",
     }, {
         content: 'The theme custom footer template should be listed and selected',
         trigger: 'we-select[data-variable="footer-template"] we-toggler img[src*="/theme_test_custo"]',
@@ -42,6 +45,7 @@ wTourUtils.registerWebsitePreviewTour('theme_menu_hierarchies', {
     }, {
         content: 'Click on header',
         trigger: ':iframe header',
+        run: "click",
     }, {
         content: 'The theme custom header template should be listed and selected',
         trigger: 'we-select[data-variable="header-template"] we-toggler img[src*="/theme_test_custo"]',
@@ -49,6 +53,7 @@ wTourUtils.registerWebsitePreviewTour('theme_menu_hierarchies', {
     }, {
         content: 'Click on image which has a shape',
         trigger: ':iframe #wrap .s_text_image img[data-shape]',
+        run: "click",
     }, {
         content: 'The theme custom "Blob 01" shape should be listed and selected',
         trigger: 'we-select[data-name="shape_img_opt"] we-toggler:contains("Blob 01")',
@@ -56,6 +61,7 @@ wTourUtils.registerWebsitePreviewTour('theme_menu_hierarchies', {
     }, {
         content: 'Click on section which has a bg shape',
         trigger: ':iframe #wrap .s_text_block[data-oe-shape-data]',
+        run: "click",
     }, {
         content: 'The theme custom "Curve 01" shape should be listed and selected',
         trigger: 'we-select[data-name="bg_shape_opt"] we-toggler:contains("Curve 01")',

--- a/theme_test_custo/static/tests/tours/website_theme_preview.js
+++ b/theme_test_custo/static/tests/tours/website_theme_preview.js
@@ -9,6 +9,7 @@ registry.category("web_tour.tours").add("website_theme_preview", {
 [{
     content: "Click on create new website",
     trigger: 'button[name="action_website_create_new"]',
+    run: "click",
 }, {
     content: "insert website name",
     trigger: '[name="name"] input',
@@ -16,17 +17,21 @@ registry.category("web_tour.tours").add("website_theme_preview", {
 }, {
     content: "Validate the website creation modal",
     trigger: "button.btn-primary",
+    run: "click",
 },
 // Configurator first screen
 {
     content: "Click Skip and start from scratch",
     trigger: "button:contains('Skip and start from scratch')",
+    run: "click",
 }, {
     content: "Click on the Live preview of a theme",
     trigger: ".o_theme_preview .o_button_area .btn-secondary:contains('Live Preview')",
+    run: "click",
 }, {
     content: "Switch from desktop to mobile preview",
     trigger: ".btn[for=themeViewerMobile]",
+    run: "click",
 }, {
     content: "Check that the mobile view is active",
     trigger: ".o_view_form_theme_preview_controller .o_field_iframe > div.is_mobile:visible",
@@ -34,6 +39,7 @@ registry.category("web_tour.tours").add("website_theme_preview", {
 }, {
     content: "Switch back to desktop",
     trigger: ".btn[for=themeViewerDesktop]",
+    run: "click",
 }, {
     content: "Check that the desktop view is active",
     trigger: ".o_view_form_theme_preview_controller .o_field_iframe > div:not(.is_mobile):visible",


### PR DESCRIPTION
Currently, in tour_compiler, to check that an element is actually present in the DOM in a step, there are 2 possibilities.
- `isCheck: true` => Checks that the element is in the DOM. The latter can be disabled.
- `run() {}` => Checks that the element is in the DOM (because this is what is done by default). However, if the element is disabled, the step will be aborted.

In the codebase, we can see a lot of `run() {} //it's a check` and `isCheck:true`. However, the behavior is not exactly the same. What's more, there are 2 ways to do "the same thing". In order to clarify the turns API, it was decided to no longer put an action (step.run) by default. (Previously, the default action was the "click" action).
From then on, it is no longer necessary to stipulate `step.isCheck: true` nor `run() {}`.
The corollary is that now, you must explicitly write `run: click`, if you want the click action to be triggered on the target.

This commit sets the stage for making this change.