### PR TITLE
[REF] theme_cobalt, *: migrate from deprecated t-esc to t-out

### DIFF
--- a/theme_cobalt/views/customizations.xml
+++ b/theme_cobalt/views/customizations.xml
@@ -183,7 +183,7 @@
 
 <!-- ==== Call To Action ===== -->
 <template id="s_call_to_action" inherit_id="website.s_call_to_action" name="Cobalt s_call_to_action">
-    <xpath expr="//t[@t-esc='cta_btn_text']" position="replace" mode="inner">
+    <xpath expr="//t[@t-out='cta_btn_text']" position="replace" mode="inner">
         START NOW
     </xpath>
 </template>

--- a/theme_graphene/views/customizations.xml
+++ b/theme_graphene/views/customizations.xml
@@ -22,7 +22,7 @@
                     Our mission is to give customers the best experience.<br/>Extensive documentation &amp; guides, an active community,<br/>24/7 support make it a pleasure to work with us.
                 </p>
                 <p>
-                    <a t-att-href="cta_btn_href" class="btn btn-primary btn-lg o_translate_inline"><t t-esc="cta_btn_text">Contact us</t></a>
+                    <a t-att-href="cta_btn_href" class="btn btn-primary btn-lg o_translate_inline"><t t-out="cta_btn_text">Contact us</t></a>
                 </p>
             </div>
         </div>

--- a/theme_kiddo/views/snippets/s_call_to_action.xml
+++ b/theme_kiddo/views/snippets/s_call_to_action.xml
@@ -19,7 +19,7 @@
             <h3 style="text-align: center;">2,000 parents<br/> brought their kid to our nursery.</h3>
             <p style="text-align: center;">Entrust us with your children and go to work with peace of mind</p>
             <p><br/></p>
-            <p style="text-align: center;"><a t-att-href="cta_btn_href" class="btn btn-primary btn-lg o_translate_inline"><t t-esc="cta_btn_text">Contact us</t></a></p>
+            <p style="text-align: center;"><a t-att-href="cta_btn_href" class="btn btn-primary btn-lg o_translate_inline"><t t-out="cta_btn_text">Contact us</t></a></p>
         </div>
     </xpath>
 

--- a/theme_odoo_experts/views/snippets/s_picture.xml
+++ b/theme_odoo_experts/views/snippets/s_picture.xml
@@ -28,7 +28,7 @@
     <!-- Add a button -->
     <xpath expr="//p[1]" position="after">
         <p style="text-align: center;">
-            <a t-att-href="cta_btn_href" class="btn btn-primary rounded-circle btn-lg o_translate_inline"><t t-esc="cta_btn_text">Contact Us</t></a>
+            <a t-att-href="cta_btn_href" class="btn btn-primary rounded-circle btn-lg o_translate_inline"><t t-out="cta_btn_text">Contact Us</t></a>
         </p>
     </xpath>
     <!-- Image -->

--- a/theme_test_custo/views/footer.xml
+++ b/theme_test_custo/views/footer.xml
@@ -16,7 +16,7 @@
                             <ul class="list-unstyled">
                                 <t t-set="animal_menu" t-value="request.env.ref('theme_test_custo.main_menu_animals')"/>
                                 <li t-foreach="request.env['website.menu'].search([('theme_template_id', '=', animal_menu.id), ('website_id', '=', request.website.id)]).child_id" t-as="menu">
-                                    <a t-att-href="menu.url" t-esc="menu.name"/>
+                                    <a t-att-href="menu.url" t-out="menu.name"/>
                                 </li>
                             </ul>
                         </div>


### PR DESCRIPTION
*: theme_graphene, theme_kiddo, theme_odoo_experts, theme_paptic, theme_test_custo

This commit updates all instances of the deprecated t-esc attribute within the web_editor and website modules to use the recommended t-out attribute.

See also :
- https://github.com/odoo/odoo/pull/168191
- https://github.com/odoo/enterprise/pull/65501

task-3573251