### PR TITLE
[FIX] theme_enark: set a real boolean value to `btn-outline-primary`

### DIFF
--- a/theme_enark/static/src/scss/primary_variables.scss
+++ b/theme_enark/static/src/scss/primary_variables.scss
@@ -146,7 +146,7 @@ $o-website-values-palettes: (
         'buttons-font':         'Bitter',
         'footer-template':      'descriptive',
         'header-links-style':   'outline',
-        'btn-primary-outline':  'true',
+        'btn-primary-outline':  true,
     ),
 );
 


### PR DESCRIPTION
For each theme, there are files redefining the different website SCSS variables, in order for the color palettes, fonts, buttons,... to have the styles defined by them. These redefinitions are also used by the "Theme Options", to show the current values in the different widgets.

In order for the primary buttons to be "outlined", the "Enark" theme set the `btn-primary-outline` variable to `'true'`. However, this value should be a boolean instead of a string. Indeed, since the option does not recognize the string value, the "Buttons Primary Style" widget therefore shows a "/" instead of "Outline", which is not correct.

This commit fixes this by setting a boolean value.

opw-3957157