### PR TITLE
[IMP] test_themes, theme_* : Adapts tours for new dragNDrop system

### DIFF
--- a/test_themes/tests/test_new_page_templates.py
+++ b/test_themes/tests/test_new_page_templates.py
@@ -90,6 +90,7 @@ CONFLICTUAL_CLASSES_RE = {
         's_table_of_content_vertical_navbar', 's_table_of_content_navbar_sticky', 's_table_of_content_navbar_wrap',
         's_timeline_card',
         's_website_form_custom', 's_website_form_dnone', 's_website_form_field', 's_website_form_input', 's_website_form_mark',
+        's_donation_btn', 's_donation_custom_btn',
     ],
     # Text
     re.compile(r'^text-(?!(center|end|start|bg-|lg-)).*$'): [

--- a/theme_anelusia/static/src/js/tour.js
+++ b/theme_anelusia/static/src/js/tour.js
@@ -6,30 +6,37 @@ const snippets = [
     {
         id: 's_text_cover',
         name: 'Text Cover',
+        groupName: "Intro",
     },
     {
         id: 's_images_wall',
         name: 'Images Wall',
+        groupName: "Images",
     },
     {
         id: 's_color_blocks_2',
         name: 'Big Boxes',
+        groupName: "Content",
     },
     {
         id: 's_references',
         name: 'References',
+        groupName: "People",
     },
     {
         id: 's_media_list',
         name: 'Media List',
+        groupName: "Content",
     },
     {
         id: 's_company_team',
         name: 'Team',
+        groupName: "People",
     },
     {
         id: 's_call_to_action',
         name: 'Call to Action',
+        groupName: "Content",
     },
 ];
 

--- a/theme_artists/static/src/js/tour.js
+++ b/theme_artists/static/src/js/tour.js
@@ -4,28 +4,34 @@ import wTourUtils from '@website/js/tours/tour_utils';
 
 const snippets = [
     {
-        id: 's_carousel_wrapper',
+        id: 's_carousel',
         name: 'Carousel',
+        groupName: "Intro",
     },
     {
         id: 's_text_image',
         name: 'Text - Image',
+        groupName: "Content",
     },
     {
         id: 's_three_columns',
         name: 'Columns',
+        groupName: "Content",
     },
     {
         id: 's_title',
         name: 'Title',
+        groupName: "Text",
     },
     {
         id: 's_images_wall',
         name: 'Images Wall',
+        groupName: "Images",
     },
     {
         id: 's_call_to_action',
         name: 'Call to Action',
+        groupName: "Content",
     },
 ];
 

--- a/theme_avantgarde/static/src/js/tour.js
+++ b/theme_avantgarde/static/src/js/tour.js
@@ -5,22 +5,27 @@ const snippets = [
     {
         id: 's_cover',
         name: 'Cover',
+        groupName: "Intro",
     },
     {
         id: 's_picture',
         name: 'Title - Image',
+        groupName: "Images",
     },
     {
         id: 's_three_columns',
         name: 'Columns',
+        groupName: "Content",
     },
     {
         id: 's_text_image',
         name: 'Text - Image',
+        groupName: "Content",
     },
     {
         id: 's_call_to_action',
         name: 'Call to Action',
+        groupName: "Content",
     },
 ];
 

--- a/theme_aviato/static/src/js/tour.js
+++ b/theme_aviato/static/src/js/tour.js
@@ -7,26 +7,32 @@ const snippets = [
     {
         id: 's_cover',
         name: 'Cover',
+        groupName: "Intro",
     },
     {
         id: 's_text_image',
         name: 'Text - Image',
+        groupName: "Content",
     },
     {
         id: 's_image_text',
         name: 'Image - Text',
+        groupName: "Content",
     },
     {
         id: 's_title',
         name: 'Title',
+        groupName: "Text",
     },
     {
         id: 's_three_columns',
         name: 'Columns',
+        groupName: "Content",
     },
     {
         id: 's_picture',
         name: 'Title - Image',
+        groupName: "Images",
     },
 ];
 

--- a/theme_beauty/static/src/js/tour.js
+++ b/theme_beauty/static/src/js/tour.js
@@ -6,26 +6,32 @@ const snippets = [
     {
         id: 's_cover',
         name: 'Cover',
+        groupName: "Intro",
     },
     {
         id: 's_text_image',
         name: 'Text - Image',
+        groupName: "Content",
     },
     {
         id: 's_title',
         name: 'Title',
+        groupName: "Text",
     },
     {
         id: 's_product_list',
         name: 'Items',
+        groupName: "Content",
     },
     {
         id: 's_company_team',
         name: 'Team',
+        groupName: "People",
     },
     {
         id: 's_call_to_action',
         name: 'Call to Action',
+        groupName: "Content",
     },
 ];
 

--- a/theme_bewise/static/src/js/tour.js
+++ b/theme_bewise/static/src/js/tour.js
@@ -6,30 +6,37 @@ const snippets = [
     {
         id: 's_cover',
         name: 'Cover',
+        groupName: "Intro",
     },
     {
         id: 's_call_to_action',
         name: 'Call to Action',
+        groupName: "Content",
     },
     {
         id: 's_text_image',
         name: 'Text - Image',
+        groupName: "Content",
     },
     {
         id: 's_numbers',
         name: 'Numbers',
+        groupName: "Content",
     },
     {
         id: 's_image_text',
         name: 'Image - Text',
+        groupName: "Content",
     },
     {
-        id: 's_quotes_carousel_wrapper',
+        id: 's_quotes_carousel',
         name: 'Quotes',
+        groupName: "People",
     },
     {
         id: 's_color_blocks_2',
         name: 'Big Boxes',
+        groupName: "Content",
     },
 ];
 

--- a/theme_bistro/static/src/js/tour.js
+++ b/theme_bistro/static/src/js/tour.js
@@ -6,26 +6,32 @@ const snippets = [
     {
         id: 's_cover',
         name: 'Cover',
+        groupName: "Intro",
     },
     {
         id: 's_features',
         name: 'Features',
+        groupName: "Content",
     },
     {
         id: 's_picture',
         name: 'Title - Image',
+        groupName: "Images",
     },
     {
         id: 's_product_catalog',
         name: 'Pricelist',
+        groupName: "Content",
     },
     {
         id: 's_text_block',
         name: 'Text',
+        groupName: "Text",
     },
     {
         id: 's_quotes_carousel',
         name: 'Quotes',
+        groupName: "People",
     },
 ];
 

--- a/theme_bookstore/static/src/js/tour.js
+++ b/theme_bookstore/static/src/js/tour.js
@@ -7,26 +7,32 @@ const snippets = [
     {
         id: 's_cover',
         name: 'Cover',
+        groupName: "Intro",
     },
     {
         id: 's_masonry_block',
         name: 'Masonry',
+        groupName: "Images",
     },
     {
         id: 's_image_text',
         name: 'Image - Text',
+        groupName: "Content",
     },
     {
         id: 's_picture',
         name: 'Title - Image',
+        groupName: "Images",
     },
     {
         id: 's_product_list',
         name: 'Items',
+        groupName: "Content",
     },
     {
         id: 's_call_to_action',
         name: 'Call to Action',
+        groupName: "Content",
     },
 ];
 

--- a/theme_buzzy/static/src/js/tour.js
+++ b/theme_buzzy/static/src/js/tour.js
@@ -6,26 +6,32 @@ const snippets = [
     {
         id: 's_banner',
         name: 'Banner',
+        groupName: "Intro",
     },
     {
         id: 's_text_image',
         name: 'Text - Image',
+        groupName: "Content",
     },
     {
         id: 's_three_columns',
         name: 'Columns',
+        groupName: "Content",
     },
     {
         id: 's_image_text',
         name: 'Image - Text',
+        groupName: "Content",
     },
     {
         id: 's_numbers',
         name: 'Numbers',
+        groupName: "Content",
     },
     {
         id: 's_call_to_action',
         name: 'Call to Action',
+        groupName: "Content",
     },
 ];
 

--- a/theme_clean/static/src/js/tour.js
+++ b/theme_clean/static/src/js/tour.js
@@ -7,34 +7,42 @@ const snippets = [
     {
         id: 's_cover',
         name: 'Cover',
+        groupName: "Intro",
     },
     {
         id: 's_text_image',
         name: 'Text - Image',
+        groupName: "Content",
     },
     {
         id: 's_title',
         name: 'Title',
+        groupName: "Text",
     },
     {
         id: 's_features',
         name: 'Features',
+        groupName: "Content",
     },
     {
         id: 's_carousel',
         name: 'Carousel',
+        groupName: "Intro",
     },
     {
         id: 's_numbers',
         name: 'Numbers',
+        groupName: "Content",
     },
     {
         id: 's_three_columns',
         name: 'Columns',
+        groupName: "Content",
     },
     {
         id: 's_call_to_action',
         name: 'Call to Action',
+        groupName: "Content",
     },
 ];
 

--- a/theme_cobalt/static/src/js/tour.js
+++ b/theme_cobalt/static/src/js/tour.js
@@ -6,26 +6,32 @@ const snippets = [
     {
         id: 's_banner',
         name: 'Banner',
+        groupName: "Intro",
     },
     {
         id: 's_references',
         name: 'References',
+        groupName: "People",
     },
     {
         id: 's_text_image',
         name: 'Text - Image',
+        groupName: "Content",
     },
     {
         id: 's_color_blocks_2',
         name: 'Big Boxes',
+        groupName: "Content",
     },
     {
         id: 's_title',
         name: 'Title',
+        groupName: "Text",
     },
     {
         id: 's_image_gallery',
         name: 'Images Wall',
+        groupName: "Images",
     },
 ];
 

--- a/theme_enark/static/src/js/tour.js
+++ b/theme_enark/static/src/js/tour.js
@@ -6,26 +6,32 @@ const snippets = [
     {
         id: 's_banner',
         name: 'Banner',
+        groupName: "Intro",
     },
     {
         id: 's_picture',
         name: 'Title - Image',
+        groupName: "Images",
     },
     {
         id: 's_numbers',
         name: 'Numbers',
+        groupName: "Content",
     },
     {
         id: 's_text_image',
         name: 'Text - Image',
+        groupName: "Content",
     },
     {
-        id: 's_image_wall',
+        id: 's_images_wall',
         name: 'Images Wall',
+        groupName: "Images",
     },
     {
         id: 's_call_to_action',
         name: 'Call to Action',
+        groupName: "Content",
     },
 ];
 

--- a/theme_graphene/static/src/js/tour.js
+++ b/theme_graphene/static/src/js/tour.js
@@ -6,22 +6,27 @@ const snippets = [
     {
         id: 's_cover',
         name: 'Cover',
+        groupName: "Intro",
     },
     {
         id: 's_text_image',
         name: 'Text - Image',
+        groupName: "Content",
     },
     {
         id: 's_numbers',
         name: 'Numbers',
+        groupName: "Content",
     },
     {
         id: 's_picture',
         name: 'Title - Image',
+        groupName: "Images",
     },
     {
         id: 's_comparisons',
         name: 'Comparisons',
+        groupName: "Content",
     },
 ];
 

--- a/theme_kea/static/src/js/tour.js
+++ b/theme_kea/static/src/js/tour.js
@@ -6,26 +6,32 @@ const snippets = [
     {
         id: 's_cover',
         name: 'Cover',
+        groupName: "Intro",
     },
     {
         id: 's_text_image',
         name: 'Text - Image',
+        groupName: "Content",
     },
     {
         id: 's_picture',
         name: 'Title - Image',
+        groupName: "Images",
     },
     {
         id: 's_image_text',
         name: 'Image - Text',
+        groupName: "Content",
     },
     {
         id: 's_color_blocks_2',
         name: 'Big Boxes',
+        groupName: "Content",
     },
     {
         id: 's_media_list',
         name: 'Media List',
+        groupName: "Content",
     },
 ];
 

--- a/theme_kiddo/static/src/js/tour.js
+++ b/theme_kiddo/static/src/js/tour.js
@@ -6,22 +6,27 @@ const snippets = [
     {
         id: 's_banner',
         name: 'Banner',
+        groupName: "Intro",
     },
     {
         id: 's_image_text',
         name: 'Image - Text',
+        groupName: "Content",
     },
     {
         id: 's_three_columns',
         name: 'Columns',
+        groupName: "Content",
     },
     {
         id: 's_product_list',
         name: 'Items',
+        groupName: "Content",
     },
     {
         id: 's_call_to_action',
         name: 'Call to Action',
+        groupName: "Content",
     },
 ];
 

--- a/theme_loftspace/static/src/js/tour.js
+++ b/theme_loftspace/static/src/js/tour.js
@@ -6,22 +6,27 @@ const snippets = [
     {
         id: 's_cover',
         name: 'Cover',
+        groupName: "Intro",
     },
     {
         id: 's_three_columns',
         name: 'Columns',
+        groupName: "Content",
     },
     {
         id: 's_title',
         name: 'Title',
+        groupName: "Text",
     },
     {
         id: 's_images_wall',
         name: 'Images Wall',
+        groupName: "Images",
     },
     {
         id: 's_call_to_action',
         name: 'Call to Action',
+        groupName: "Content",
     },
 ];
 

--- a/theme_monglia/static/src/js/tour.js
+++ b/theme_monglia/static/src/js/tour.js
@@ -6,34 +6,42 @@ const snippets = [
     {
         id: 's_cover',
         name: 'Cover',
+        groupName: "Intro",
     },
     {
         id: 's_title',
         name: 'Title',
+        groupName: "Text",
     },
     {
         id: 's_text_block',
         name: 'Text',
+        groupName: "Text",
     },
     {
         id: 's_three_columns',
         name: 'Columns',
+        groupName: "Content",
     },
     {
-        id: 's_image_wall',
+        id: 's_images_wall',
         name: 'Images Wall',
+        groupName: "Images",
     },
     {
         id: 's_title',
         name: 'Title',
+        groupName: "Text",
     },
     {
         id: 's_media_list',
         name: 'Media List',
+        groupName: "Content",
     },
     {
         id: 's_text_image',
         name: 'Text - Image',
+        groupName: "Content",
     },
 ];
 

--- a/theme_nano/static/src/js/tour.js
+++ b/theme_nano/static/src/js/tour.js
@@ -6,26 +6,32 @@ const snippets = [
     {
         id: 's_cover',
         name: 'Cover',
+        groupName: "Intro",
     },
     {
         id: 's_features',
         name: 'Features',
+        groupName: "Content",
     },
     {
         id: 's_text_block',
         name: 'Text',
+        groupName: "Text",
     },
     {
         id: 's_images_wall',
         name: 'Images Wall',
+        groupName: "Images",
     },
     {
         id: 's_parallax',
         name: 'Parallax',
+        groupName: "Images",
     },
     {
         id: 's_references',
         name: 'References',
+        groupName: "People",
     },
 ];
 

--- a/theme_notes/static/src/js/tour.js
+++ b/theme_notes/static/src/js/tour.js
@@ -7,26 +7,32 @@ const snippets = [
     {
         id: 's_carousel',
         name: 'Carousel',
+        groupName: "Intro",
     },
     {
         id: 's_masonry_block',
         name: 'Masonry',
+        groupName: "Images",
     },
     {
         id: 's_text_image',
         name: 'Text - Image',
+        groupName: "Content",
     },
     {
         id: 's_product_catalog',
         name: 'Pricelist',
+        groupName: "Content",
     },
     {
         id: 's_media_list',
         name: 'Media List',
+        groupName: "Content",
     },
     {
         id: 's_company_team',
         name: 'Team',
+        groupName: "People",
     },
 ];
 

--- a/theme_odoo_experts/static/src/js/tour.js
+++ b/theme_odoo_experts/static/src/js/tour.js
@@ -7,30 +7,37 @@ const snippets = [
     {
         id: 's_picture',
         name: 'Title - Image',
+        groupName: "Images",
     },
     {
         id: 's_references',
         name: 'References',
+        groupName: "People",
     },
     {
         id: 's_text_image',
         name: 'Image - Text',
+        groupName: "Content",
     },
     {
         id: 's_text_image',
         name: 'Text - Image',
+        groupName: "Content",
     },
     {
         id: 's_title',
         name: 'Title',
+        groupName: "Text",
     },
     {
         id: 's_comparisons',
         name: 'Comparisons',
+        groupName: "Content",
     },
     {
         id: 's_call_to_action',
         name: 'Call to Action',
+        groupName: "Content",
     },
 ];
 

--- a/theme_orchid/static/src/js/tour.js
+++ b/theme_orchid/static/src/js/tour.js
@@ -7,26 +7,32 @@ const snippets = [
     {
         id: 's_cover',
         name: 'Cover',
+        groupName: "Intro",
     },
     {
         id: 's_image_text',
         name: 'Image - Text',
+        groupName: "Content",
     },
     {
         id: 's_text_image',
         name: 'Text - Image',
+        groupName: "Content",
     },
     {
         id: 's_three_columns',
         name: 'Columns',
+        groupName: "Content",
     },
     {
         id: 's_quotes_carousel',
         name: 'Quotes',
+        groupName: "People",
     },
     {
         id: 's_call_to_action',
         name: 'Call to Action',
+        groupName: "Content",
     },
 ];
 

--- a/theme_paptic/static/src/js/tour.js
+++ b/theme_paptic/static/src/js/tour.js
@@ -6,26 +6,32 @@ const snippets = [
     {
         id: 's_cover',
         name: 'Cover',
+        groupName: "Intro",
     },
     {
         id: 's_image_text',
         name: 'Image - Text',
+        groupName: "Content",
     },
     {
         id: 's_references',
         name: 'References',
+        groupName: "People",
     },
     {
         id: 's_three_columns',
         name: 'Columns',
+        groupName: "Content",
     },
     {
         id: 's_comparisons',
         name: 'Comparisons',
+        groupName: "Content",
     },
     {
         id: 's_call_to_action',
         name: 'Call to Action',
+        groupName: "Content",
     },
 ];
 

--- a/theme_real_estate/static/src/js/tour.js
+++ b/theme_real_estate/static/src/js/tour.js
@@ -6,42 +6,52 @@ const snippets = [
     {
         id: 's_banner',
         name: 'Banner',
+        groupName: "Intro",
     },
     {
         id: 's_text_block',
         name: 'Text',
+        groupName: "Text",
     },
     {
         id: 's_text_image',
         name: 'Text - Image',
+        groupName: "Content",
     },
     {
         id: 's_image_text',
         name: 'Image - Text',
+        groupName: "Content",
     },
     {
         id: 's_title',
         name: 'Title',
+        groupName: "Text",
     },
     {
         id: 's_three_columns',
         name: 'Columns',
+        groupName: "Content",
     },
     {
-        id: 's_title:last-child',
+        id: 's_title',
         name: 'Title',
+        groupName: "Text",
     },
     {
         id: 's_masonry_block',
         name: 'Masonry',
+        groupName: "Images",
     },
     {
         id: 's_numbers',
         name: 'Numbers',
+        groupName: "Content",
     },
     {
         id: 's_quotes_carousel',
         name: 'Quotes',
+        groupName: "People",
     },
 ];
 

--- a/theme_treehouse/static/src/js/tour.js
+++ b/theme_treehouse/static/src/js/tour.js
@@ -6,22 +6,27 @@ const snippets = [
     {
         id: 's_cover',
         name: 'Cover',
+        groupName: "Intro",
     },
     {
         id: 's_text_image',
         name: 'Text - Image',
+        groupName: "Content",
     },
     {
         id: 's_title',
         name: 'Title',
+        groupName: "Text",
     },
     {
         id: 's_three_columns',
         name: 'Columns',
+        groupName: "Content",
     },
     {
         id: 's_call_to_action',
         name: 'Call to Action',
+        groupName: "Content",
     },
 ];
 

--- a/theme_vehicle/static/src/js/tour.js
+++ b/theme_vehicle/static/src/js/tour.js
@@ -6,26 +6,32 @@ const snippets = [
     {
         id: 's_cover',
         name: 'Cover',
+        groupName: "Intro",
     },
     {
         id: 's_text_image',
         name: 'Text - Image',
+        groupName: "Content",
     },
     {
         id: 's_image_text',
         name: 'Image - Text',
+        groupName: "Content",
     },
     {
         id: 's_picture',
         name: 'Title - Image',
+        groupName: "Images",
     },
     {
         id: 's_masonry_block',
         name: 'Masonry',
+        groupName: "Images",
     },
     {
         id: 's_call_to_action',
         name: 'Call to Action',
+        groupName: "Content",
     },
 ];
 

--- a/theme_yes/static/src/js/tour.js
+++ b/theme_yes/static/src/js/tour.js
@@ -6,26 +6,32 @@ const snippets = [
     {
         id: 's_cover',
         name: 'Cover',
+        groupName: "Intro",
     },
     {
         id: 's_title',
         name: 'Title',
+        groupName: "Text",
     },
     {
         id: 's_company_team',
         name: 'Team',
+        groupName: "People",
     },
     {
         id: 's_media_list',
         name: 'Media List',
+        groupName: "Content",
     },
     {
         id: 's_images_wall',
         name: 'Images Wall',
+        groupName: "Images",
     },
     {
         id: 's_quotes_carousel',
         name: 'Quotes',
+        groupName: "People",
     },
 ];
 

--- a/theme_zap/static/src/js/tour.js
+++ b/theme_zap/static/src/js/tour.js
@@ -6,26 +6,32 @@ const snippets = [
     {
         id: 's_banner',
         name: 'Banner',
+        groupName: "Intro",
     },
     {
         id: 's_three_columns',
         name: 'Columns',
+        groupName: "Content",
     },
     {
         id: 's_color_blocks_2',
         name: 'Big Boxes',
+        groupName: "Content",
     },
     {
         id: 's_features',
         name: 'Features',
+        groupName: "Content",
     },
     {
         id: 's_masonry_block',
         name: 'Masonry',
+        groupName: "Images",
     },
     {
         id: 's_references',
         name: 'References',
+        groupName: "People",
     },
 ];
 


### PR DESCRIPTION
[IMP] test_themes, theme_* : Adaps tours for new dragNDrop system

Following the change in the way of dragging and dropping a snippet onto
the page (by selecting it from a dialog displaying the actual previews
of snippets). The themes tours have been adapted to this change in this
commit.

task-3919405