### PR TITLE
[IMP] theme_paptic: s_showcase adaptations

### DIFF
--- a/theme_paptic/views/customizations.xml
+++ b/theme_paptic/views/customizations.xml
@@ -134,17 +134,14 @@
 
 <!-- ==== Showcase ===== -->
 <template id="s_showcase" inherit_id="website.s_showcase" name="Paptic s_showcase">
-    <xpath expr="//i[hasclass('text-secondary')]" position="attributes">
-        <attribute name="class" remove="text-secondary" separator=" "/>
+    <xpath expr="//i[hasclass('s_showcase_icon')]" position="attributes">
+        <attribute name="class" add="bg-o-color-1" remove="bg-o-color-3" separator=" "/>
     </xpath>
-    <xpath expr="//i[hasclass('text-secondary')]" position="attributes">
-        <attribute name="class" remove="text-secondary" separator=" "/>
+    <xpath expr="(//i[hasclass('s_showcase_icon')])[2]" position="attributes">
+        <attribute name="class" add="bg-o-color-1" remove="bg-o-color-3" separator=" "/>
     </xpath>
-    <xpath expr="//i[hasclass('text-secondary')]" position="attributes">
-        <attribute name="class" remove="text-secondary" separator=" "/>
-    </xpath>
-    <xpath expr="//i[hasclass('text-secondary')]" position="attributes">
-        <attribute name="class" remove="text-secondary" separator=" "/>
+    <xpath expr="(//i[hasclass('s_showcase_icon')])[3]" position="attributes">
+        <attribute name="class" add="bg-o-color-1" remove="bg-o-color-3" separator=" "/>
     </xpath>
 </template>
 


### PR DESCRIPTION
This commit removes the `s_showcase` customization since this snippets has been redesigned in PR[1].

task-3657637
Part of task-3619705

[1]: https://github.com/odoo/odoo/pull/172771

Requires: 
- https://github.com/odoo/odoo/pull/172771