### PR TITLE
[FIX] theme_kiddo: remove vimeo video that no longer exists

### DIFF
--- a/theme_kiddo/views/snippets/s_banner.xml
+++ b/theme_kiddo/views/snippets/s_banner.xml
@@ -4,17 +4,9 @@
 <template id="s_banner" inherit_id="website.s_banner">
     <!-- Section -->
     <xpath expr="//section" position="attributes">
-        <attribute name="class" add="o_background_video s_parallax_no_overflow_hidden oe_img_bg o_bg_img_center" remove="parallax s_parallax_is_fixed" separator=" "/>
-        <attribute name="data-bg-video-src">//player.vimeo.com/video/60112275?autoplay=1&amp;muted=1&amp;loop=1</attribute>
+        <attribute name="class" add="s_parallax_no_overflow_hidden oe_img_bg o_bg_img_center" remove="parallax s_parallax_is_fixed" separator=" "/>
         <attribute name="data-oe-shape-data">{"shape":"web_editor/Origins/17"}</attribute>
         <attribute name="style">position: relative; background-image: url("/web/image/website.s_banner_default_image");</attribute>
-    </xpath>
-
-    <!-- Video -->
-    <xpath expr="//div[hasclass('container')]" position="before">
-        <div class="o_bg_video_container">
-            <iframe id="o_bg_video_iframe_5" class="o_bg_video_iframe fade show" src="//player.vimeo.com/video/60112275?autoplay=1&amp;muted=1&amp;loop=1" style="width: 100%; height: 146.716%; left: 0px; top: -23.3581%;" frameborder="0"></iframe>
-        </div>
     </xpath>
 
     <!-- Shape -->


### PR DESCRIPTION
The video used in theme_kiddo for the banner snippet no longer works. Either because it was requested too many times too quickly, or because the video was removed from Vimeo.

This commit removes the video. It does not replace it because pulling informations from external ressources which aren't guaranteed or handled by Odoo tend to randomly crash the Runbot.

This is actually the reason for this fix in the first place. Staging is crashing for 15.0.

runbot-71672