### PR TITLE
[IMP] theme_*: adapt themes with new `s_image_wall` design

### DIFF
--- a/theme_artists/views/snippets/s_image_gallery.xml
+++ b/theme_artists/views/snippets/s_image_gallery.xml
@@ -14,19 +14,19 @@
     </xpath>
     <!-- Images -->
     <xpath expr="//img" position="attributes">
-        <attribute name="class" add="rounded shadow" separator=" "/>
+        <attribute name="class" add="shadow" separator=" "/>
     </xpath>
     <xpath expr="(//img)[2]" position="attributes">
-        <attribute name="class" add="rounded shadow" separator=" "/>
+        <attribute name="class" add="shadow" separator=" "/>
     </xpath>
     <xpath expr="(//img)[4]" position="attributes">
-        <attribute name="class" add="rounded shadow" separator=" "/>
+        <attribute name="class" add="shadow" separator=" "/>
     </xpath>
     <xpath expr="(//img)[5]" position="attributes">
-        <attribute name="class" add="rounded shadow" separator=" "/>
+        <attribute name="class" add="shadow" separator=" "/>
     </xpath>
     <xpath expr="(//img)[6]" position="attributes">
-        <attribute name="class" add="rounded shadow" separator=" "/>
+        <attribute name="class" add="shadow" separator=" "/>
     </xpath>
 </template>
 

--- a/theme_bookstore/__manifest__.py
+++ b/theme_bookstore/__manifest__.py
@@ -25,6 +25,7 @@
         'views/snippets/s_media_list.xml',
         'views/snippets/s_comparisons.xml',
         'views/snippets/s_features_grid.xml',
+        'views/snippets/s_image_gallery.xml',
         'views/snippets/s_product_catalog.xml',
         'views/snippets/s_quotes_carousel.xml',
         'views/new_page_template.xml',

--- a/theme_bookstore/views/snippets/s_image_gallery.xml
+++ b/theme_bookstore/views/snippets/s_image_gallery.xml
@@ -2,14 +2,6 @@
 <odoo>
 
 <template id="s_images_wall" inherit_id="website.s_images_wall">
-    <!-- Section -->
-    <xpath expr="//section" position="attributes">
-        <attribute name="class" add="pt96 pb96" remove="pt24 pb24" separator=" "/>
-    </xpath>
-    <xpath expr="//div[hasclass('o_masonry_col')][2]//img" position="replace">
-        <img class="img img-fluid d-block" src="/web/image/website.library_image_21" data-index="4" data-name="Image"/>
-    </xpath>
-    <!-- Remove images roundness -->
     <xpath expr="//img" position="attributes">
         <attribute name="class" remove="rounded" separator=" "/>
     </xpath>

--- a/theme_cobalt/views/customizations.xml
+++ b/theme_cobalt/views/customizations.xml
@@ -209,6 +209,25 @@
     <xpath expr="//div[hasclass('col-lg-6')][2]/img" position="after">
         <img class="img img-fluid d-block" src="/web/image/website.library_image_16" data-index="1" data-name="Image"/>
     </xpath>
+    <!-- Remove image roundness -->
+    <xpath expr="//img" position="attributes">
+        <attribute name="class" remove="rounded" separator=" "/>
+    </xpath>
+    <xpath expr="(//img)[2]" position="attributes">
+        <attribute name="class" remove="rounded" separator=" "/>
+    </xpath>
+    <xpath expr="(//img)[3]" position="attributes">
+        <attribute name="class" remove="rounded" separator=" "/>
+    </xpath>
+    <xpath expr="(//img)[4]" position="attributes">
+        <attribute name="class" remove="rounded" separator=" "/>
+    </xpath>
+    <xpath expr="(//img)[5]" position="attributes">
+        <attribute name="class" remove="rounded" separator=" "/>
+    </xpath>
+    <xpath expr="(//img)[6]" position="attributes">
+        <attribute name="class" remove="rounded" separator=" "/>
+    </xpath>
 </template>
 
 <!-- ======== BIG BOXES ======== -->

--- a/theme_enark/views/snippets/s_image_gallery.xml
+++ b/theme_enark/views/snippets/s_image_gallery.xml
@@ -20,6 +20,24 @@
     <xpath expr="//div[hasclass('container')]" position="attributes">
         <attribute name="class" add="container-fluid" remove="container" separator=" "/>
     </xpath>
+    <xpath expr="//img" position="attributes">
+        <attribute name="class" remove="rounded" separator=" "/>
+    </xpath>
+    <xpath expr="(//img)[2]" position="attributes">
+        <attribute name="class" remove="rounded" separator=" "/>
+    </xpath>
+    <xpath expr="(//img)[3]" position="attributes">
+        <attribute name="class" remove="rounded" separator=" "/>
+    </xpath>
+    <xpath expr="(//img)[4]" position="attributes">
+        <attribute name="class" remove="rounded" separator=" "/>
+    </xpath>
+    <xpath expr="(//img)[5]" position="attributes">
+        <attribute name="class" remove="rounded" separator=" "/>
+    </xpath>
+    <xpath expr="(//img)[6]" position="attributes">
+        <attribute name="class" remove="rounded" separator=" "/>
+    </xpath>
 </template>
 
 </odoo>

--- a/theme_graphene/views/customizations.xml
+++ b/theme_graphene/views/customizations.xml
@@ -283,4 +283,26 @@
     </xpath>
 </template>
 
+<!-- ======== IMAGE WALL ======== -->
+<template id="s_images_wall" inherit_id="website.s_images_wall">
+    <xpath expr="//img" position="attributes">
+        <attribute name="class" remove="rounded" separator=" "/>
+    </xpath>
+    <xpath expr="(//img)[2]" position="attributes">
+        <attribute name="class" remove="rounded" separator=" "/>
+    </xpath>
+    <xpath expr="(//img)[3]" position="attributes">
+        <attribute name="class" remove="rounded" separator=" "/>
+    </xpath>
+    <xpath expr="(//img)[4]" position="attributes">
+        <attribute name="class" remove="rounded" separator=" "/>
+    </xpath>
+    <xpath expr="(//img)[5]" position="attributes">
+        <attribute name="class" remove="rounded" separator=" "/>
+    </xpath>
+    <xpath expr="(//img)[6]" position="attributes">
+        <attribute name="class" remove="rounded" separator=" "/>
+    </xpath>
+</template>
+
 </odoo>

--- a/theme_monglia/views/customizations.xml
+++ b/theme_monglia/views/customizations.xml
@@ -223,25 +223,6 @@
     <xpath expr="//section" position="attributes">
         <attribute name="class" add="o_cc2 o_spc-medium" remove="o_cc5 o_spc-small" separator=" "/>
     </xpath>
-    <!-- Image -->
-    <xpath expr="//img" position="attributes">
-        <attribute name="class" add="rounded" separator=" "/>
-    </xpath>
-    <xpath expr="(//img)[2]" position="attributes">
-        <attribute name="class" add="rounded" separator=" "/>
-    </xpath>
-    <xpath expr="(//img)[3]" position="attributes">
-        <attribute name="class" add="rounded" separator=" "/>
-    </xpath>
-    <xpath expr="(//img)[4]" position="attributes">
-        <attribute name="class" add="rounded" separator=" "/>
-    </xpath>
-    <xpath expr="(//img)[5]" position="attributes">
-        <attribute name="class" add="rounded" separator=" "/>
-    </xpath>
-    <xpath expr="(//img)[6]" position="attributes">
-        <attribute name="class" add="rounded" separator=" "/>
-    </xpath>
 </template>
 
 </odoo>

--- a/theme_vehicle/views/customizations.xml
+++ b/theme_vehicle/views/customizations.xml
@@ -324,4 +324,26 @@
     </xpath>
 </template>
 
+<!-- ======== IMAGE WALL ======== -->
+<template id="s_images_wall" inherit_id="website.s_images_wall">
+    <xpath expr="//img" position="attributes">
+        <attribute name="class" remove="rounded" separator=" "/>
+    </xpath>
+    <xpath expr="(//img)[2]" position="attributes">
+        <attribute name="class" remove="rounded" separator=" "/>
+    </xpath>
+    <xpath expr="(//img)[3]" position="attributes">
+        <attribute name="class" remove="rounded" separator=" "/>
+    </xpath>
+    <xpath expr="(//img)[4]" position="attributes">
+        <attribute name="class" remove="rounded" separator=" "/>
+    </xpath>
+    <xpath expr="(//img)[5]" position="attributes">
+        <attribute name="class" remove="rounded" separator=" "/>
+    </xpath>
+    <xpath expr="(//img)[6]" position="attributes">
+        <attribute name="class" remove="rounded" separator=" "/>
+    </xpath>
+</template>
+
 </odoo>

--- a/theme_yes/views/snippets/s_image_gallery.xml
+++ b/theme_yes/views/snippets/s_image_gallery.xml
@@ -15,16 +15,6 @@
     <xpath expr="//*[hasclass('container')]" position="attributes">
         <attribute name="class" add="o_container_small" remove="container" separator=" "/>
     </xpath>
-    <!-- Images -->
-    <xpath expr="//*[hasclass('carousel-item')]//img" position="attributes">
-        <attribute name="class" add="rounded" separator=" "/>
-    </xpath>
-    <xpath expr="//*[hasclass('carousel-item')][2]//img" position="attributes">
-        <attribute name="class" add="rounded" separator=" "/>
-    </xpath>
-    <xpath expr="//*[hasclass('carousel-item')][3]//img" position="attributes">
-        <attribute name="class" add="rounded" separator=" "/>
-    </xpath>
 </template>
 
 </odoo>

--- a/theme_yes/views/snippets/s_images_wall.xml
+++ b/theme_yes/views/snippets/s_images_wall.xml
@@ -10,25 +10,6 @@
     <xpath expr="//*[hasclass('container')]" position="before">
         <div class="o_we_shape o_web_editor_Floats_12"/>
     </xpath>
-    <!-- Images -->
-    <xpath expr="//img" position="attributes">
-        <attribute name="class" add="rounded" separator=" "/>
-    </xpath>
-    <xpath expr="(//img)[2]" position="attributes">
-        <attribute name="class" add="rounded" separator=" "/>
-    </xpath>
-    <xpath expr="(//img)[3]" position="attributes">
-        <attribute name="class" add="rounded" separator=" "/>
-    </xpath>
-    <xpath expr="(//img)[4]" position="attributes">
-        <attribute name="class" add="rounded" separator=" "/>
-    </xpath>
-    <xpath expr="(//img)[5]" position="attributes">
-        <attribute name="class" add="rounded" separator=" "/>
-    </xpath>
-    <xpath expr="(//img)[6]" position="attributes">
-        <attribute name="class" add="rounded" separator=" "/>
-    </xpath>
 </template>
 
 </odoo>

--- a/theme_zap/__manifest__.py
+++ b/theme_zap/__manifest__.py
@@ -22,6 +22,7 @@
         'views/snippets/s_references.xml',
         'views/snippets/s_image_text.xml',
         'views/snippets/s_three_columns.xml',
+        'views/snippets/s_image_gallery.xml',
         'views/new_page_template.xml',
     ],
     'images': [

--- a/theme_zap/views/snippets/s_image_gallery.xml
+++ b/theme_zap/views/snippets/s_image_gallery.xml
@@ -2,14 +2,6 @@
 <odoo>
 
 <template id="s_images_wall" inherit_id="website.s_images_wall">
-    <!-- Section -->
-    <xpath expr="//section" position="attributes">
-        <attribute name="class" add="pt96 pb96" remove="pt24 pb24" separator=" "/>
-    </xpath>
-    <xpath expr="//div[hasclass('o_masonry_col')][2]//img" position="replace">
-        <img class="img img-fluid d-block" src="/web/image/website.library_image_21" data-index="4" data-name="Image"/>
-    </xpath>
-    <!-- Remove images roundness -->
     <xpath expr="//img" position="attributes">
         <attribute name="class" remove="rounded" separator=" "/>
     </xpath>


### PR DESCRIPTION
*: (artists, bookstore, cobalt, enark, graphene, monglia, real_estate, vehicle, yes, zap)

This commit adapts the design of `s_image_wall` for multiple themes, based on the new Odoo 18 snippet redesign.

Requires:
- https://github.com/odoo/odoo/pull/163839

task-3654301