### PR TITLE
[IMP] theme_*: adapt themes with new global roundness option

### DIFF
--- a/theme_anelusia/static/src/scss/bootstrap_overridden.scss
+++ b/theme_anelusia/static/src/scss/bootstrap_overridden.scss
@@ -14,10 +14,6 @@ $spacer:                                    1.25rem !default;
 //
 // Define common padding and border radius sizes and more.
 
-$border-radius:                             0 !default;
-$border-radius-lg:                          0 !default;
-$border-radius-sm:                          0 !default;
-
 $box-shadow-sm:                             0 0 .3125rem rgba(0,0,0,.25) !default;
 $box-shadow:                                0 0 .3125rem rgba(0,0,0,.25) !default;
 $box-shadow-lg:                             0 0 .3125rem rgba(0,0,0,.25) !default;

--- a/theme_anelusia/static/src/scss/primary_variables.scss
+++ b/theme_anelusia/static/src/scss/primary_variables.scss
@@ -13,6 +13,12 @@ $o-website-values-palettes: (
         'font':                             'Source Sans Pro',
         'headings-font':                    'Spartan',
 
+        // Roundness
+        'roundness':                        'rounded-0',
+        'border-radius-sm':                 null,
+        'border-radius':                    null,
+        'border-radius-lg':                 null,
+
         // Links
         'link-underline':                   'never',
 

--- a/theme_aviato/static/src/scss/bootstrap_overridden.scss
+++ b/theme_aviato/static/src/scss/bootstrap_overridden.scss
@@ -20,9 +20,7 @@ $spacer:                                    1.25rem !default;
 //
 // Define common padding and border radius sizes and more.
 
-$border-radius:                             .375rem !default;
-$border-radius-lg:                          .5rem !default;
-$border-radius-sm:                          .25rem !default;
+$border-radius-lg:                          o-website-value('border-radius-lg') or map-get(map-get($o-theme-border-radius, o-website-value('roundness')), border-radius-lg) !default;
 
 // Buttons + Forms
 //

--- a/theme_bistro/static/src/scss/bootstrap_overridden.scss
+++ b/theme_bistro/static/src/scss/bootstrap_overridden.scss
@@ -39,9 +39,7 @@ $spacer:                                    1.25rem !default;
 //
 // Define common padding and border radius sizes and more.
 
-$border-radius:                             .375rem !default;
-$border-radius-lg:                          .5rem !default;
-$border-radius-sm:                          .25rem !default;
+$border-radius-lg:                          o-website-value('border-radius-lg') or map-get(map-get($o-theme-border-radius, o-website-value('roundness')), border-radius-lg) !default;
 
 // Typography
 //

--- a/theme_treehouse/static/src/scss/bootstrap_overridden.scss
+++ b/theme_treehouse/static/src/scss/bootstrap_overridden.scss
@@ -40,9 +40,7 @@ $spacer:                                    1.25rem !default;
 //
 // Define common padding and border radius sizes and more.
 
-$border-radius:                             .375rem !default;
-$border-radius-lg:                          .5rem !default;
-$border-radius-sm:                          .25rem !default;
+$border-radius-lg:                          o-website-value('border-radius-lg') or map-get(map-get($o-theme-border-radius, o-website-value('roundness')), border-radius-lg) !default;
 
 // Typography
 //

--- a/theme_zap/static/src/scss/bootstrap_overridden.scss
+++ b/theme_zap/static/src/scss/bootstrap_overridden.scss
@@ -69,9 +69,7 @@ $spacer:                                    1.25rem !default;
 //
 // Define common padding and border radius sizes and more.
 
-$border-radius:                             .125rem !default;
-$border-radius-lg:                          .25rem !default;
-$border-radius-sm:                          0 !default;
+$border-radius-lg:                          o-website-value('border-radius-lg') or map-get(map-get($o-theme-border-radius, o-website-value('roundness')), border-radius-lg) !default;
 
 // Typography
 //

--- a/theme_zap/static/src/scss/primary_variables.scss
+++ b/theme_zap/static/src/scss/primary_variables.scss
@@ -5,6 +5,7 @@
 $o-website-values-palettes: (
     (
         'color-palettes-name':              'base-2',
+        'roundness':                        'rounded-1',
 
         // Header
         'header-template':                  'sales_four',


### PR DESCRIPTION
*: (anelusia, aviato, bistro, treehouse, zap)

This commit adapts the themes to the use of a global roundness option, based on the new Odoo 18 website.

task-3641683

Requires: https://github.com/odoo/odoo/pull/149629