### PR TITLE
[IMP] theme_treehouse: adapt theme with new `s_tabs` design

### DIFF
--- a/theme_treehouse/views/snippets/s_tabs.xml
+++ b/theme_treehouse/views/snippets/s_tabs.xml
@@ -6,18 +6,18 @@
     <xpath expr="//section" position="attributes">
         <attribute name="class" add="o_cc o_cc2 pt64 pb64" remove="pt48 pb48" separator=" "/>
     </xpath>
-    <xpath expr="//*[hasclass('nav')]" position="attributes">
-        <attribute name="class" add="card-header-tabs nav-tabs" remove="justify-content-center nav-pills" separator=" "/>
-    </xpath>
     <!-- Card -->
     <xpath expr="//*[hasclass('s_tabs_main')]" position="attributes">
         <attribute name="class" add="card" separator=" "/>
     </xpath>
-    <xpath expr="//*[hasclass('s_tabs_content')]" position="attributes">
-        <attribute name="class" add="card-body" separator=" "/>
-    </xpath>
     <xpath expr="//*[hasclass('s_tabs_nav')]" position="attributes">
-        <attribute name="class" add="card-header" separator=" "/>
+        <attribute name="class" add="card-header o_cc o_cc4 border-0 px-0 overflow-x-auto overflow-y-hidden" remove="mb-3" separator=" "/>
+    </xpath>
+    <xpath expr="//*[hasclass('nav')]" position="attributes">
+        <attribute name="class" add="nav-tabs card-header-tabs mx-0 px-2 border-bottom" remove="nav-underline overflow-y-hidden overflow-x-auto" separator=" "/>
+    </xpath>
+    <xpath expr="//*[hasclass('s_tabs_content')]" position="attributes">
+        <attribute name="class" add="p-3" separator=" "/>
     </xpath>
 </template>
 


### PR DESCRIPTION
This commit adapts the design of `s_tabs` for `theme_treehouse`, based on the new Odoo 18 snippet redesign.

task-3657591

Requires: https://github.com/odoo/odoo/pull/172717