### PR TITLE
[IMP] theme_*: adapt themes with new `s_striped_top` snippet

### DIFF
--- a/theme_anelusia/__manifest__.py
+++ b/theme_anelusia/__manifest__.py
@@ -15,6 +15,7 @@
         'views/snippets/s_cta_box.xml',
         'views/snippets/s_company_team.xml',
         'views/snippets/s_cover.xml',
+        'views/snippets/s_striped_top.xml',
         'views/snippets/s_image_gallery.xml',
         'views/snippets/s_carousel.xml',
         'views/snippets/s_media_list.xml',

--- a/theme_anelusia/views/snippets/s_striped_top.xml
+++ b/theme_anelusia/views/snippets/s_striped_top.xml
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+
+<template id="s_striped_top" inherit_id="website.s_striped_top">
+    <!-- Title -->
+    <xpath expr="//h1" position="attributes">
+        <attribute name="class" add="h2-fs" separator=" "/>
+    </xpath>
+    <xpath expr="//h1" position="replace" mode="inner">
+        Embrace Style: Discover the Ultimate Experience in Fashion Excellence
+    </xpath>
+    <!-- Lead -->
+    <xpath expr="//p" position="replace" mode="inner">
+        Color trends are already waiting to spring into action for the next summer.
+    </xpath>
+    <!-- Image -->
+    <xpath expr="//img" position="attributes">
+        <attribute name="src">/web/image/website.s_media_list_default_image_1</attribute>
+    </xpath>
+</template>
+
+</odoo>

--- a/theme_artists/__manifest__.py
+++ b/theme_artists/__manifest__.py
@@ -11,6 +11,7 @@
         'data/ir_asset.xml',
         'views/images.xml',
 
+        'views/snippets/s_striped_top.xml',
         'views/snippets/s_cta_box.xml',
         'views/snippets/s_parallax.xml',
         'views/snippets/s_text_image.xml',

--- a/theme_artists/views/snippets/s_striped_top.xml
+++ b/theme_artists/views/snippets/s_striped_top.xml
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+
+<template id="s_striped_top" inherit_id="website.s_striped_top">
+    <!-- Title -->
+    <xpath expr="//h1" position="attributes">
+        <attribute name="class" add="h2-fs" separator=" "/>
+    </xpath>
+    <xpath expr="//h1" position="replace" mode="inner">
+        Exploring Art's Masterpieces: A Journey to the Best Creations
+    </xpath>
+    <!-- Lead -->
+    <xpath expr="//p" position="replace" mode="inner">
+        Color trends are already waiting to spring into action for the next summer.
+    </xpath>
+    <!-- Image -->
+    <xpath expr="//img" position="attributes">
+        <attribute name="src">/web/image/website.s_media_list_default_image_1</attribute>
+    </xpath>
+</template>
+
+</odoo>

--- a/theme_avantgarde/views/customizations.xml
+++ b/theme_avantgarde/views/customizations.xml
@@ -33,6 +33,18 @@
     </xpath>
 </template>
 
+<!-- ======== STRIPED TOP ======== -->
+<template id="s_striped_top" inherit_id="website.s_striped_top">
+    <!-- Button -->
+    <xpath expr="//a" position="attributes">
+        <attribute name="class" add="btn-secondary" remove="btn-primary" separator=" "/>
+    </xpath>
+    <!-- Image -->
+    <xpath expr="//img" position="attributes">
+        <attribute name="src">/web/image/website.s_media_list_default_image_1</attribute>
+    </xpath>
+</template>
+
 <!-- ======== PICTURE ======== -->
 <template id="s_picture" inherit_id="website.s_picture" name="Avantgarde s_cover">
     <xpath expr="//section" position="attributes">

--- a/theme_aviato/__manifest__.py
+++ b/theme_aviato/__manifest__.py
@@ -13,6 +13,7 @@
 
         'views/snippets/s_cta_box.xml',
         'views/snippets/s_cover.xml',
+        'views/snippets/s_striped_top.xml',
         'views/snippets/s_features.xml',
         'views/snippets/s_image_text.xml',
         'views/snippets/s_freegrid.xml',

--- a/theme_aviato/views/snippets/s_striped_top.xml
+++ b/theme_aviato/views/snippets/s_striped_top.xml
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+
+<template id="s_striped_top" inherit_id="website.s_striped_top">
+    <!-- Section -->
+    <xpath expr="//section" position="attributes">
+        <attribute name="class" remove="o_cc5" add="o_cc2" separator=" "/>
+    </xpath>
+    <!-- Title -->
+    <xpath expr="//h1" position="attributes">
+        <attribute name="class" add="h2-fs" separator=" "/>
+    </xpath>
+    <xpath expr="//h1" position="replace" mode="inner">
+        Discovering the Ultimate Travel Experience
+    </xpath>
+    <!-- Lead -->
+    <xpath expr="//p" position="replace" mode="inner">
+        A travel agent helps you to plan your trip from start to finish.
+    </xpath>
+    <!-- Image -->
+    <xpath expr="//img" position="attributes">
+        <attribute name="src">/web/image/website.s_media_list_default_image_1</attribute>
+    </xpath>
+</template>
+
+</odoo>

--- a/theme_beauty/__manifest__.py
+++ b/theme_beauty/__manifest__.py
@@ -13,6 +13,7 @@
 
         'views/snippets/s_cta_box.xml',
         'views/snippets/s_cover.xml',
+        'views/snippets/s_striped_top.xml',
         'views/snippets/s_text_image.xml',
         'views/snippets/s_title.xml',
         'views/snippets/s_company_team.xml',

--- a/theme_beauty/views/snippets/s_striped_top.xml
+++ b/theme_beauty/views/snippets/s_striped_top.xml
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+
+<template id="s_striped_top" inherit_id="website.s_striped_top">
+    <!-- Title -->
+    <xpath expr="//h1" position="attributes">
+        <attribute name="class" add="h2-fs" separator=" "/>
+    </xpath>
+    <xpath expr="//h1" position="replace" mode="inner">
+        Discover the Ultimate Beauty with Top Cosmetics
+    </xpath>
+    <!-- Lead -->
+    <xpath expr="//p" position="replace" mode="inner">
+        Working beauty from the inside out
+    </xpath>
+    <!-- Image -->
+    <xpath expr="//img" position="attributes">
+        <attribute name="src">/web/image/website.s_media_list_default_image_1</attribute>
+    </xpath>
+</template>
+
+</odoo>

--- a/theme_bewise/views/customizations.xml
+++ b/theme_bewise/views/customizations.xml
@@ -28,6 +28,29 @@
     </xpath>
 </template>
 
+<!-- ======== STRIPED TOP ======== -->
+<template id="s_striped_top" inherit_id="website.s_striped_top">
+    <!-- Section -->
+    <xpath expr="//section" position="attributes">
+        <attribute name="class" remove="o_cc5" add="o_cc3" separator=" "/>
+    </xpath>
+    <!-- Title -->
+    <xpath expr="//h1" position="attributes">
+        <attribute name="class" add="h2-fs" separator=" "/>
+    </xpath>
+    <xpath expr="//h1" position="replace" mode="inner">
+        Empowering Minds: Innovate, Educate, Inspire, Succeed
+    </xpath>
+    <!-- Lead -->
+    <xpath expr="//p" position="replace" mode="inner">
+        Discover our program in details
+    </xpath>
+    <!-- Image -->
+    <xpath expr="//img" position="attributes">
+        <attribute name="src">/web/image/website.s_picture_default_image</attribute>
+    </xpath>
+</template>
+
 <!-- ======== TEXT-IMAGE ======== -->
 <template id="s_text_image" inherit_id="website.s_text_image" name="Be Wise s_text_image">
     <xpath expr="//h2" position="replace" mode="inner">

--- a/theme_bistro/__manifest__.py
+++ b/theme_bistro/__manifest__.py
@@ -37,6 +37,7 @@
         'views/snippets/s_striped_center_top.xml',
         'views/snippets/s_motto.xml',
         'views/snippets/s_key_images.xml',
+        'views/snippets/s_striped_top.xml',
         'views/new_page_template.xml',
 
     ],

--- a/theme_bistro/views/snippets/s_striped_top.xml
+++ b/theme_bistro/views/snippets/s_striped_top.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+
+<template id="s_striped_top" inherit_id="website.s_striped_top">
+    <!-- Title -->
+    <xpath expr="//h1" position="replace" mode="inner">
+        Charming Culinary Escape: Your Neighborhood Bistro Delight
+    </xpath>
+    <!-- Lead -->
+    <xpath expr="//p" position="replace" mode="inner">
+        Enjoy the tastiest meal of your life at our place
+    </xpath>
+    <!-- Image -->
+    <xpath expr="//img" position="attributes">
+        <attribute name="src">/web/image/website.s_picture_default_image</attribute>
+    </xpath>
+</template>
+
+</odoo>

--- a/theme_bookstore/__manifest__.py
+++ b/theme_bookstore/__manifest__.py
@@ -12,6 +12,7 @@
         'views/images.xml',
 
         'views/snippets/s_cta_box.xml',
+        'views/snippets/s_striped_top.xml',
         'views/snippets/s_title.xml',
         'views/snippets/s_three_columns.xml',
         'views/snippets/s_picture.xml',

--- a/theme_bookstore/views/snippets/s_striped_top.xml
+++ b/theme_bookstore/views/snippets/s_striped_top.xml
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+
+<template id="s_striped_top" inherit_id="website.s_striped_top">
+    <!-- Title -->
+    <xpath expr="//h1" position="attributes">
+        <attribute name="class" add="h2-fs" separator=" "/>
+    </xpath>
+    <xpath expr="//h1" position="replace" mode="inner">
+        Where Every Book Lover Finds Delight
+    </xpath>
+    <!-- Lead -->
+    <xpath expr="//p" position="replace" mode="inner">
+        Take a look at our recommendations
+    </xpath>
+    <!-- Image -->
+    <xpath expr="//img" position="attributes">
+        <attribute name="src">/web/image/website.s_media_list_default_image_1</attribute>
+    </xpath>
+</template>
+
+</odoo>

--- a/theme_buzzy/__manifest__.py
+++ b/theme_buzzy/__manifest__.py
@@ -12,6 +12,7 @@
         'views/images_library.xml',
 
         'views/snippets/s_cta_box.xml',
+        'views/snippets/s_striped_top.xml',
         'views/snippets/s_title.xml',
         'views/snippets/s_banner.xml',
         'views/snippets/s_image_text.xml',

--- a/theme_buzzy/views/snippets/s_striped_top.xml
+++ b/theme_buzzy/views/snippets/s_striped_top.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+
+<template id="s_striped_top" inherit_id="website.s_striped_top">
+    <!-- Title -->
+    <xpath expr="//h1" position="attributes">
+        <attribute name="class" add="h2-fs" separator=" "/>
+    </xpath>
+    <!-- Image -->
+    <xpath expr="//img" position="attributes">
+        <attribute name="src">/web/image/website.s_text_image_default_image</attribute>
+    </xpath>
+</template>
+
+</odoo>

--- a/theme_clean/__manifest__.py
+++ b/theme_clean/__manifest__.py
@@ -13,6 +13,7 @@
 
         'views/snippets/s_cta_box.xml',
         'views/snippets/s_cover.xml',
+        'views/snippets/s_striped_top.xml',
         'views/snippets/s_carousel.xml',
         'views/snippets/s_text_image.xml',
         'views/snippets/s_three_columns.xml',

--- a/theme_clean/views/snippets/s_striped_top.xml
+++ b/theme_clean/views/snippets/s_striped_top.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+
+<template id="s_striped_top" inherit_id="website.s_striped_top">
+    <!-- Title -->
+    <xpath expr="//h1" position="attributes">
+        <attribute name="class" add="h2-fs" separator=" "/>
+    </xpath>
+    <!-- Image -->
+    <xpath expr="//img" position="attributes">
+        <attribute name="src">/web/image/website.s_text_image_default_image</attribute>
+    </xpath>
+</template>
+
+</odoo>

--- a/theme_enark/__manifest__.py
+++ b/theme_enark/__manifest__.py
@@ -15,6 +15,7 @@
         'views/snippets/s_closer_look.xml',
         'views/snippets/s_cta_box.xml',
         'views/snippets/s_banner.xml',
+        'views/snippets/s_striped_top.xml',
         'views/snippets/s_cover.xml',
         'views/snippets/s_text_image.xml',
         'views/snippets/s_picture.xml',

--- a/theme_enark/views/snippets/s_striped_top.xml
+++ b/theme_enark/views/snippets/s_striped_top.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+
+<template id="s_striped_top" inherit_id="website.s_striped_top">
+    <!-- Title -->
+    <xpath expr="//h1" position="attributes">
+        <attribute name="class" add="h3-fs" separator=" "/>
+    </xpath>
+    <xpath expr="//h1" position="replace" mode="inner">
+        Experience the Future of<br/>Innovation in Every<br/>Interaction
+    </xpath>
+    <!-- Button -->
+    <xpath expr="//a" position="attributes">
+        <attribute name="class" add="btn-secondary" remove="btn-primary" separator=" "/>
+    </xpath>
+</template>
+
+</odoo>

--- a/theme_graphene/views/customizations.xml
+++ b/theme_graphene/views/customizations.xml
@@ -35,6 +35,14 @@
     </xpath>
 </template>
 
+<!-- ======== STRIPED TOP ======== -->
+<template id="s_striped_top" inherit_id="website.s_striped_top">
+    <!-- Title -->
+    <xpath expr="//h1" position="attributes">
+        <attribute name="class" add="h2-fs" separator=" "/>
+    </xpath>
+</template>
+
 <!-- ======== TEXT-IMAGE ======== -->
 <template id="s_text_image" inherit_id="website.s_text_image" name="Graphene s_text_image">
     <xpath expr="//section" position="attributes">

--- a/theme_kea/__manifest__.py
+++ b/theme_kea/__manifest__.py
@@ -13,6 +13,7 @@
 
         'views/snippets/s_cta_box.xml',
         'views/snippets/s_cover.xml',
+        'views/snippets/s_striped_top.xml',
         'views/snippets/s_image_text.xml',
         'views/snippets/s_text_image.xml',
         'views/snippets/s_three_columns.xml',

--- a/theme_kea/views/snippets/s_striped_top.xml
+++ b/theme_kea/views/snippets/s_striped_top.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+
+<template id="s_striped_top" inherit_id="website.s_striped_top">
+    <!-- Title -->
+    <xpath expr="//h1" position="attributes">
+        <attribute name="class" add="h2-fs" separator=" "/>
+    </xpath>
+</template>
+
+</odoo>

--- a/theme_kiddo/__manifest__.py
+++ b/theme_kiddo/__manifest__.py
@@ -13,6 +13,7 @@
 
         'views/snippets/s_cta_box.xml',
         'views/snippets/s_banner.xml',
+        'views/snippets/s_striped_top.xml',
         'views/snippets/s_image_text.xml',
         'views/snippets/s_picture.xml',
         'views/snippets/s_product_list.xml',

--- a/theme_kiddo/views/snippets/s_striped_top.xml
+++ b/theme_kiddo/views/snippets/s_striped_top.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+
+<template id="s_striped_top" inherit_id="website.s_striped_top">
+    <xpath expr="//h1" position="replace" mode="inner">
+        Happy Kids, Happy Parents: Great Childcare
+    </xpath>
+    <!-- Lead -->
+    <xpath expr="//p" position="replace" mode="inner">
+        A little place of paradise.
+    </xpath>
+    <!-- Image -->
+    <xpath expr="//img" position="attributes">
+        <attribute name="src">/web/image/website.s_media_list_default_image_1</attribute>
+    </xpath>
+</template>
+
+</odoo>

--- a/theme_loftspace/__manifest__.py
+++ b/theme_loftspace/__manifest__.py
@@ -13,6 +13,7 @@
 
         'views/snippets/s_cta_box.xml',
         'views/snippets/s_cover.xml',
+        'views/snippets/s_striped_top.xml',
         'views/snippets/s_text_image.xml',
         'views/snippets/s_title.xml',
         'views/snippets/s_three_columns.xml',

--- a/theme_loftspace/views/snippets/s_striped_top.xml
+++ b/theme_loftspace/views/snippets/s_striped_top.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+
+<template id="s_striped_top" inherit_id="website.s_striped_top">
+    <!-- Title -->
+    <xpath expr="//h1" position="attributes">
+        <attribute name="class" add="h2-fs" separator=" "/>
+    </xpath>
+</template>
+
+</odoo>

--- a/theme_monglia/views/customizations.xml
+++ b/theme_monglia/views/customizations.xml
@@ -69,6 +69,14 @@
     <xpath expr="//a[@t-att-href='cta_btn_href'][2]" position="replace"/>
 </template>
 
+<!-- ======== STRIPED TOP ======== -->
+<template id="s_striped_top" inherit_id="website.s_striped_top">
+    <!-- Image -->
+    <xpath expr="//img" position="attributes">
+        <attribute name="src">/web/image/website.s_picture_default_image</attribute>
+    </xpath>
+</template>
+
 <!-- ======== MEDIA LIST ======== -->
  <template id="s_media_list" inherit_id="website.s_media_list" name="Monglia s_media_list">
     <xpath expr="//div[hasclass('container')]/div/div[1]//h3" position="replace" mode="inner">

--- a/theme_notes/__manifest__.py
+++ b/theme_notes/__manifest__.py
@@ -13,6 +13,7 @@
 
         'views/snippets/s_cta_box.xml',
         'views/snippets/s_carousel.xml',
+        'views/snippets/s_striped_top.xml',
         'views/snippets/s_image_text.xml',
         'views/snippets/s_media_list.xml',
         'views/snippets/s_company_team.xml',

--- a/theme_notes/views/snippets/s_striped_top.xml
+++ b/theme_notes/views/snippets/s_striped_top.xml
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+
+<template id="s_striped_top" inherit_id="website.s_striped_top">
+    <!-- Title -->
+    <xpath expr="//h1" position="attributes">
+        <attribute name="class" add="h2-fs" separator=" "/>
+    </xpath>
+    <xpath expr="//h1" position="replace" mode="inner">
+        Discover the Ultimate Festival Experience
+    </xpath>
+    <!-- Lead -->
+    <xpath expr="//p" position="replace" mode="inner">
+        Enjoy the atmosphere
+    </xpath>
+    <!-- Image -->
+    <xpath expr="//img" position="attributes">
+        <attribute name="src">/web/image/website.s_picture_default_image</attribute>
+    </xpath>
+</template>
+
+</odoo>

--- a/theme_odoo_experts/__manifest__.py
+++ b/theme_odoo_experts/__manifest__.py
@@ -13,6 +13,7 @@
 
         'views/snippets/s_cta_box.xml',
         'views/snippets/s_banner.xml',
+        'views/snippets/s_striped_top.xml',
         'views/snippets/s_media_list.xml',
         'views/snippets/s_image_text.xml',
         'views/snippets/s_call_to_action.xml',

--- a/theme_odoo_experts/views/snippets/s_striped_top.xml
+++ b/theme_odoo_experts/views/snippets/s_striped_top.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+
+<template id="s_striped_top" inherit_id="website.s_striped_top">
+    <!-- Title -->
+    <xpath expr="//h1" position="attributes">
+        <attribute name="class" add="h2-fs" separator=" "/>
+    </xpath>
+    <!-- Image -->
+    <xpath expr="//img" position="attributes">
+        <attribute name="src">/web/image/website.s_picture_default_image</attribute>
+    </xpath>
+</template>
+
+</odoo>

--- a/theme_orchid/__manifest__.py
+++ b/theme_orchid/__manifest__.py
@@ -13,6 +13,7 @@
 
         'views/snippets/s_cta_box.xml',
         'views/snippets/s_cover.xml',
+        'views/snippets/s_striped_top.xml',
         'views/snippets/s_text_image.xml',
         'views/snippets/s_motto.xml',
         'views/snippets/s_image_text.xml',

--- a/theme_orchid/views/snippets/s_striped_top.xml
+++ b/theme_orchid/views/snippets/s_striped_top.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+
+<template id="s_striped_top" inherit_id="website.s_striped_top">
+    <!-- Title -->
+    <xpath expr="//h1" position="replace" mode="inner">
+        Live life in full bloom with Orchid
+    </xpath>
+    <!-- Lead -->
+    <xpath expr="//p" position="replace" mode="inner">
+        Discover the Orchid concept
+    </xpath>
+    <!-- Image -->
+    <xpath expr="//img" position="attributes">
+        <attribute name="src">/web/image/website.s_picture_default_image</attribute>
+    </xpath>
+</template>
+
+</odoo>

--- a/theme_real_estate/__manifest__.py
+++ b/theme_real_estate/__manifest__.py
@@ -14,6 +14,7 @@
         'views/snippets/s_cta_box.xml',
         'views/snippets/s_banner.xml',
         'views/snippets/s_picture.xml',
+        'views/snippets/s_striped_top.xml',
         'views/snippets/s_image_text.xml',
         'views/snippets/s_image_title.xml',
         'views/snippets/s_text_image.xml',

--- a/theme_real_estate/views/snippets/s_striped_top.xml
+++ b/theme_real_estate/views/snippets/s_striped_top.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+
+<template id="s_striped_top" inherit_id="website.s_striped_top">
+    <!-- Title -->
+    <xpath expr="//h1" position="attributes">
+        <attribute name="class" add="h2-fs" separator=" "/>
+    </xpath>
+</template>
+
+</odoo>

--- a/theme_vehicle/views/customizations.xml
+++ b/theme_vehicle/views/customizations.xml
@@ -17,6 +17,13 @@
     </xpath>
 </template>
 
+<template id="s_striped_top" inherit_id="website.s_striped_top">
+    <!-- Image -->
+    <xpath expr="//img" position="attributes">
+        <attribute name="src">/web/image/website.s_picture_default_image</attribute>
+    </xpath>
+</template>
+
 <!-- ======== TEXT - IMAGE ======== -->
 <template id="s_text_image" inherit_id="website.s_text_image" name="Vehicle s_text_image">
     <xpath expr="//section" position="attributes">

--- a/theme_yes/__manifest__.py
+++ b/theme_yes/__manifest__.py
@@ -13,6 +13,7 @@
 
         'views/snippets/s_cta_box.xml',
         'views/snippets/s_banner.xml',
+        'views/snippets/s_striped_top.xml',
         'views/snippets/s_call_to_action.xml',
         'views/snippets/s_carousel.xml',
         'views/snippets/s_company_team.xml',

--- a/theme_yes/views/snippets/s_striped_top.xml
+++ b/theme_yes/views/snippets/s_striped_top.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+
+<template id="s_striped_top" inherit_id="website.s_striped_top">
+    <!-- Title -->
+    <xpath expr="//h1" position="replace" mode="inner">
+       Elegant Wedding Planning for Your Perfect Day
+    </xpath>
+    <!-- Lead -->
+    <xpath expr="//p" position="replace" mode="inner">
+        Let us plan your perfect day
+    </xpath>
+    <!-- Image -->
+    <xpath expr="//img" position="attributes">
+        <attribute name="src">/web/image/website.s_picture_default_image</attribute>
+    </xpath>
+</template>
+
+</odoo>

--- a/theme_zap/__manifest__.py
+++ b/theme_zap/__manifest__.py
@@ -13,6 +13,7 @@
 
         'views/snippets/s_cta_box.xml',
         'views/snippets/s_banner.xml',
+        'views/snippets/s_striped_top.xml',
         'views/snippets/s_call_to_action.xml',
         'views/snippets/s_color_blocks_2.xml',
         'views/snippets/s_cover.xml',

--- a/theme_zap/views/snippets/s_striped_top.xml
+++ b/theme_zap/views/snippets/s_striped_top.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+
+<template id="s_striped_top" inherit_id="website.s_striped_top">
+    <!-- Section -->
+    <xpath expr="//section" position="attributes">
+        <attribute name="class" remove="o_cc5" add="o_cc2" separator=" "/>
+    </xpath>
+    <!-- Image -->
+    <xpath expr="//img" position="attributes">
+        <attribute name="src">/web/image/website.s_text_image_default_image</attribute>
+    </xpath>
+</template>
+
+</odoo>


### PR DESCRIPTION
*: (anelusia, artists, aviato, beauty, bewise, bookstore, buzzy, clean, enark, graphene, kea, loftspace, notes, odoo_experts, orchid, real_estate)

This commit adapts the design of new `s_striped_top` snippet for multiple themes.

task-4077621

requires: https://github.com/odoo/odoo/pull/175525