### PR TITLE
[IMP] theme_*: adapt themes with new `s_motto` snippet

### DIFF
--- a/theme_aviato/__manifest__.py
+++ b/theme_aviato/__manifest__.py
@@ -19,6 +19,7 @@
         'views/snippets/s_text_image.xml',
         'views/snippets/s_image_punchy.xml',
         'views/snippets/s_three_columns.xml',
+        'views/snippets/s_motto.xml',
         'views/snippets/s_picture.xml',
         'views/snippets/s_popup.xml',
         'views/snippets/s_title.xml',

--- a/theme_aviato/views/snippets/s_motto.xml
+++ b/theme_aviato/views/snippets/s_motto.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+
+<template id="s_motto" inherit_id="website.s_motto">
+    <!-- Shape -->
+    <xpath expr="//section" position="attributes">
+        <attribute name="data-oe-shape-data">{'shape':'web_editor/Floats/09','showOnMobile':false, 'animated': true}</attribute>
+    </xpath>
+    <xpath expr="//div[hasclass('o_we_shape')]" position="attributes">
+        <attribute name="class" remove="o_web_editor_Floats_07" add="o_web_editor_Floats_09" separator=" "/>
+    </xpath>
+</template>
+
+</odoo>

--- a/theme_bistro/__manifest__.py
+++ b/theme_bistro/__manifest__.py
@@ -34,6 +34,7 @@
         'views/snippets/s_carousel.xml',
         'views/snippets/s_image_hexagonal.xml',
         'views/snippets/s_striped_center_top.xml',
+        'views/snippets/s_motto.xml',
         'views/new_page_template.xml',
 
     ],

--- a/theme_bistro/views/snippets/s_motto.xml
+++ b/theme_bistro/views/snippets/s_motto.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+
+<template id="s_motto" inherit_id="website.s_motto">
+    <!-- Shape -->
+    <xpath expr="//section" position="attributes">
+        <attribute name="data-oe-shape-data">{'shape':'web_editor/Floats/09','showOnMobile':false, 'animated': true}</attribute>
+    </xpath>
+    <xpath expr="//div[hasclass('o_we_shape')]" position="attributes">
+        <attribute name="class" remove="o_web_editor_Floats_07" add="o_web_editor_Floats_09" separator=" "/>
+    </xpath>
+</template>
+
+</odoo>

--- a/theme_kea/__manifest__.py
+++ b/theme_kea/__manifest__.py
@@ -19,6 +19,7 @@
         'views/snippets/s_media_list.xml',
         'views/snippets/s_freegrid.xml',
         'views/snippets/s_references.xml',
+        'views/snippets/s_motto.xml',
         'views/snippets/s_color_blocks_2.xml',
         'views/snippets/s_features_wall.xml',
         'views/snippets/s_picture.xml',

--- a/theme_kea/views/snippets/s_motto.xml
+++ b/theme_kea/views/snippets/s_motto.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+
+<template id="s_motto" inherit_id="website.s_motto">
+    <!-- Shape -->
+    <xpath expr="//section" position="attributes">
+        <attribute name="data-oe-shape-data">{'shape':'web_editor/Floats/09','showOnMobile':false, 'animated': true}</attribute>
+    </xpath>
+    <xpath expr="//div[hasclass('o_we_shape')]" position="attributes">
+        <attribute name="class" remove="o_web_editor_Floats_07" add="o_web_editor_Floats_09" separator=" "/>
+    </xpath>
+</template>
+
+</odoo>

--- a/theme_kiddo/__manifest__.py
+++ b/theme_kiddo/__manifest__.py
@@ -16,6 +16,7 @@
         'views/snippets/s_image_text.xml',
         'views/snippets/s_picture.xml',
         'views/snippets/s_product_list.xml',
+        'views/snippets/s_motto.xml',
         'views/snippets/s_call_to_action.xml',
         'views/snippets/s_freegrid.xml',
         'views/snippets/s_company_team_shapes.xml',

--- a/theme_kiddo/views/snippets/s_motto.xml
+++ b/theme_kiddo/views/snippets/s_motto.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+
+<template id="s_motto" inherit_id="website.s_motto">
+    <!-- Shape -->
+    <xpath expr="//section" position="attributes">
+        <attribute name="data-oe-shape-data">{'shape':'web_editor/Floats/09','showOnMobile':false, 'animated': true}</attribute>
+    </xpath>
+    <xpath expr="//div[hasclass('o_we_shape')]" position="attributes">
+        <attribute name="class" remove="o_web_editor_Floats_07" add="o_web_editor_Floats_09" separator=" "/>
+    </xpath>
+</template>
+
+</odoo>

--- a/theme_nano/__manifest__.py
+++ b/theme_nano/__manifest__.py
@@ -15,6 +15,7 @@
         'views/snippets/s_banner.xml',
         'views/snippets/s_carousel.xml',
         'views/snippets/s_cover.xml',
+        'views/snippets/s_motto.xml',
         'views/snippets/s_features.xml',
         'views/snippets/s_image_text.xml',
         'views/snippets/s_freegrid.xml',

--- a/theme_nano/views/snippets/s_motto.xml
+++ b/theme_nano/views/snippets/s_motto.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+
+<template id="s_motto" inherit_id="website.s_motto">
+    <!-- Section -->
+    <xpath expr="//section" position="attributes">
+        <attribute name="class" remove="o_cc o_cc1" add="o_cc o_cc5" separator=" "/>
+    </xpath>
+</template>
+
+</odoo>

--- a/theme_orchid/__manifest__.py
+++ b/theme_orchid/__manifest__.py
@@ -14,6 +14,7 @@
         'views/snippets/s_cta_box.xml',
         'views/snippets/s_cover.xml',
         'views/snippets/s_text_image.xml',
+        'views/snippets/s_motto.xml',
         'views/snippets/s_image_text.xml',
         'views/snippets/s_image_punchy.xml',
         'views/snippets/s_three_columns.xml',

--- a/theme_orchid/views/snippets/s_motto.xml
+++ b/theme_orchid/views/snippets/s_motto.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+
+<template id="s_motto" inherit_id="website.s_motto">
+    <!-- Shape -->
+    <xpath expr="//section" position="attributes">
+        <attribute name="data-oe-shape-data">{'shape':'web_editor/Floats/09','showOnMobile':false, 'animated': true}</attribute>
+    </xpath>
+    <xpath expr="//div[hasclass('o_we_shape')]" position="attributes">
+        <attribute name="class" remove="o_web_editor_Floats_07" add="o_web_editor_Floats_09" separator=" "/>
+    </xpath>
+</template>
+
+</odoo>

--- a/theme_paptic/views/customizations.xml
+++ b/theme_paptic/views/customizations.xml
@@ -178,6 +178,17 @@
     </xpath>
 </template>
 
+<!-- ==== Motto ===== -->
+<template id="s_motto" inherit_id="website.s_motto" name="Paptic s_motto">
+    <!-- Shape -->
+    <xpath expr="//section" position="attributes">
+        <attribute name="data-oe-shape-data">{'shape':'web_editor/Floats/09','showOnMobile':false, 'animated': true}</attribute>
+    </xpath>
+    <xpath expr="//div[hasclass('o_we_shape')]" position="attributes">
+        <attribute name="class" remove="o_web_editor_Floats_07" add="o_web_editor_Floats_09" separator=" "/>
+    </xpath>
+</template>
+
 <!-- ======== CAROUSEL ======== -->
  <template id="s_carousel" inherit_id="website.s_carousel" name="Paptic s_carousel">
     <xpath expr="(//div[hasclass('carousel-item')])[2]" position="attributes">

--- a/theme_vehicle/views/customizations.xml
+++ b/theme_vehicle/views/customizations.xml
@@ -431,6 +431,14 @@
     </xpath>
 </template>
 
+<!-- ==== MOTTO ===== -->
+<template id="s_motto" inherit_id="website.s_motto">
+    <!-- Section -->
+    <xpath expr="//section" position="attributes">
+        <attribute name="class" remove="o_cc o_cc1" add="o_cc o_cc5" separator=" "/>
+    </xpath>
+</template>
+
 <!-- ======== UNVEIL ======== -->
 <template id="s_unveil" inherit_id="website.s_unveil">
     <!-- Section -->


### PR DESCRIPTION
*: (aviato, bistro, kea, kiddo, nano, orchid, paptic, vehicle)

This commit adapts the design of new `s_motto` snippet for multiple themes.

task-4077607

requires: https://github.com/odoo/odoo/pull/175550