### PR TITLE
[IMP] theme_*: adapt themes with new `s_sidegrid` snippet

### DIFF
--- a/theme_anelusia/__manifest__.py
+++ b/theme_anelusia/__manifest__.py
@@ -23,6 +23,7 @@
         'views/snippets/s_text_cover.xml',
         'views/snippets/s_color_blocks_2.xml',
         'views/snippets/s_company_team_shapes.xml',
+        'views/snippets/s_sidegrid.xml',
         'views/snippets/s_references.xml',
         'views/snippets/s_call_to_action.xml',
         'views/snippets/s_comparisons.xml',

--- a/theme_anelusia/views/snippets/s_sidegrid.xml
+++ b/theme_anelusia/views/snippets/s_sidegrid.xml
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+
+<template id="s_sidegrid" inherit_id="website.s_sidegrid">
+    <!-- Images -->
+    <xpath expr="//img" position="attributes">
+        <attribute name="src">/web/image/website.s_text_image_default_image</attribute>
+    </xpath>
+    <xpath expr="(//img)[2]" position="attributes">
+        <attribute name="src">/web/image/website.s_banner_default_image_2</attribute>
+    </xpath>
+    <xpath expr="(//img)[3]" position="attributes">
+        <attribute name="src">/web/image/website.s_banner_default_image</attribute>
+    </xpath>
+    <!-- Title -->
+    <xpath expr="//h1" position="replace" mode="inner">
+        Unleash your potential
+    </xpath>
+    <!-- Lead -->
+    <xpath expr="//p" position="replace" mode="inner">
+        This is a simple hero unit, a simple jumbotron-style component for calling extra attention to featured content or information.
+    </xpath>
+</template>
+
+</odoo>

--- a/theme_artists/__manifest__.py
+++ b/theme_artists/__manifest__.py
@@ -21,6 +21,7 @@
         'views/snippets/s_title.xml',
         'views/snippets/s_image_gallery.xml',
         'views/snippets/s_image_punchy.xml',
+        'views/snippets/s_sidegrid.xml',
         'views/snippets/s_banner.xml',
         'views/snippets/s_cover.xml',
         'views/snippets/s_features.xml',

--- a/theme_artists/views/snippets/s_sidegrid.xml
+++ b/theme_artists/views/snippets/s_sidegrid.xml
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+
+<template id="s_sidegrid" inherit_id="website.s_sidegrid">
+    <!-- Images -->
+    <xpath expr="//img" position="attributes">
+        <attribute name="class" remove="rounded" separator=" "/>
+        <attribute name="src">/web/image/website.s_text_image_default_image</attribute>
+    </xpath>
+    <xpath expr="(//img)[2]" position="attributes">
+        <attribute name="class" remove="rounded" separator=" "/>
+        <attribute name="src">/web/image/website.s_banner_default_image_2</attribute>
+    </xpath>
+    <xpath expr="(//img)[3]" position="attributes">
+        <attribute name="class" remove="rounded" separator=" "/>
+        <attribute name="src">/web/image/website.s_banner_default_image</attribute>
+    </xpath>
+    <xpath expr="(//img)[4]" position="attributes">
+        <attribute name="class" remove="rounded" separator=" "/>
+    </xpath>
+</template>
+
+</odoo>

--- a/theme_aviato/__manifest__.py
+++ b/theme_aviato/__manifest__.py
@@ -15,6 +15,7 @@
         'views/snippets/s_cover.xml',
         'views/snippets/s_striped_top.xml',
         'views/snippets/s_features.xml',
+        'views/snippets/s_sidegrid.xml',
         'views/snippets/s_image_text.xml',
         'views/snippets/s_freegrid.xml',
         'views/snippets/s_image_title.xml',

--- a/theme_aviato/views/snippets/s_sidegrid.xml
+++ b/theme_aviato/views/snippets/s_sidegrid.xml
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+
+<template id="s_sidegrid" inherit_id="website.s_sidegrid">
+    <!-- Images -->
+    <xpath expr="//img" position="attributes">
+        <attribute name="src">/web/image/website.s_text_image_default_image</attribute>
+    </xpath>
+    <xpath expr="(//img)[2]" position="attributes">
+        <attribute name="src">/web/image/website.s_banner_default_image_2</attribute>
+    </xpath>
+    <xpath expr="(//img)[3]" position="attributes">
+        <attribute name="src">/web/image/website.s_banner_default_image</attribute>
+    </xpath>
+    <!-- Title -->
+    <xpath expr="//h1" position="replace" mode="inner">
+        Experience the real travel experience
+    </xpath>
+    <!-- Lead -->
+    <xpath expr="//p" position="replace" mode="inner">
+        Traveling lets you explore new cultures and places while discovering more about yourself. It's a chance to connect with others and create lasting memories.
+    </xpath>
+</template>
+
+</odoo>

--- a/theme_beauty/__manifest__.py
+++ b/theme_beauty/__manifest__.py
@@ -19,6 +19,7 @@
         'views/snippets/s_company_team.xml',
         'views/snippets/s_freegrid.xml',
         'views/snippets/s_call_to_action.xml',
+        'views/snippets/s_sidegrid.xml',
         'views/snippets/s_product_list.xml',
         'views/snippets/s_banner.xml',
         'views/snippets/s_image_text.xml',

--- a/theme_beauty/views/snippets/s_sidegrid.xml
+++ b/theme_beauty/views/snippets/s_sidegrid.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+
+<template id="s_sidegrid" inherit_id="website.s_sidegrid">
+    <!-- Images -->
+    <xpath expr="//img" position="attributes">
+        <attribute name="src">/web/image/website.s_text_image_default_image</attribute>
+    </xpath>
+    <xpath expr="(//img)[2]" position="attributes">
+        <attribute name="src">/web/image/website.s_banner_default_image_2</attribute>
+    </xpath>
+    <xpath expr="(//img)[3]" position="attributes">
+        <attribute name="src">/web/image/website.s_banner_default_image</attribute>
+    </xpath>
+</template>
+
+</odoo>

--- a/theme_bewise/views/customizations.xml
+++ b/theme_bewise/views/customizations.xml
@@ -398,6 +398,20 @@
     </xpath>
 </template>
 
+<!-- ======== SIDEGRID ======== -->
+<template id="s_sidegrid" inherit_id="website.s_sidegrid">
+    <!-- Images -->
+    <xpath expr="//img" position="attributes">
+        <attribute name="src">/web/image/website.s_text_image_default_image</attribute>
+    </xpath>
+    <xpath expr="(//img)[2]" position="attributes">
+        <attribute name="src">/web/image/website.s_banner_default_image_2</attribute>
+    </xpath>
+    <xpath expr="(//img)[3]" position="attributes">
+        <attribute name="src">/web/image/website.s_banner_default_image</attribute>
+    </xpath>
+</template>
+
 <!-- ======== CAROUSEL ======== -->
 <template id="s_carousel" inherit_id="website.s_carousel" name="Be Wise s_carousel">
     <xpath expr="(//div[hasclass('carousel-item')])[2]" position="attributes">

--- a/theme_bistro/__manifest__.py
+++ b/theme_bistro/__manifest__.py
@@ -22,6 +22,7 @@
         'views/snippets/s_freegrid.xml',
         'views/snippets/s_image_punchy.xml',
         'views/snippets/s_image_title.xml',
+        'views/snippets/s_sidegrid.xml',
         'views/snippets/s_media_list.xml',
         'views/snippets/s_features_wall.xml',
         'views/snippets/s_numbers.xml',

--- a/theme_bistro/views/snippets/s_sidegrid.xml
+++ b/theme_bistro/views/snippets/s_sidegrid.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+
+<template id="s_sidegrid" inherit_id="website.s_sidegrid">
+    <!-- Images -->
+    <xpath expr="//img" position="attributes">
+        <attribute name="src">/web/image/website.s_text_image_default_image</attribute>
+    </xpath>
+    <xpath expr="(//img)[2]" position="attributes">
+        <attribute name="src">/web/image/website.s_banner_default_image_2</attribute>
+    </xpath>
+    <xpath expr="(//img)[3]" position="attributes">
+        <attribute name="src">/web/image/website.s_banner_default_image</attribute>
+    </xpath>
+</template>
+
+</odoo>

--- a/theme_bookstore/__manifest__.py
+++ b/theme_bookstore/__manifest__.py
@@ -19,6 +19,7 @@
         'views/snippets/s_text_image.xml',
         'views/snippets/s_product_list.xml',
         'views/snippets/s_call_to_action.xml',
+        'views/snippets/s_sidegrid.xml',
         'views/snippets/s_cover.xml',
         'views/snippets/s_image_text.xml',
         'views/snippets/s_image_title.xml',

--- a/theme_bookstore/views/snippets/s_sidegrid.xml
+++ b/theme_bookstore/views/snippets/s_sidegrid.xml
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+
+<template id="s_sidegrid" inherit_id="website.s_sidegrid">
+    <!-- Images -->
+    <xpath expr="//img" position="attributes">
+        <attribute name="class" remove="rounded" separator=" "/>
+        <attribute name="src">/web/image/website.s_text_image_default_image</attribute>
+    </xpath>
+    <xpath expr="(//img)[2]" position="attributes">
+        <attribute name="class" remove="rounded" separator=" "/>
+        <attribute name="src">/web/image/website.s_banner_default_image_2</attribute>
+    </xpath>
+    <xpath expr="(//img)[3]" position="attributes">
+        <attribute name="class" remove="rounded" separator=" "/>
+        <attribute name="src">/web/image/website.s_banner_default_image</attribute>
+    </xpath>
+    <xpath expr="(//img)[4]" position="attributes">
+        <attribute name="class" remove="rounded" separator=" "/>
+    </xpath>
+</template>
+
+</odoo>

--- a/theme_enark/__manifest__.py
+++ b/theme_enark/__manifest__.py
@@ -21,6 +21,7 @@
         'views/snippets/s_picture.xml',
         'views/snippets/s_pricelist_boxed.xml',
         'views/snippets/s_freegrid.xml',
+        'views/snippets/s_sidegrid.xml',
         'views/snippets/s_media_list.xml',
         'views/snippets/s_call_to_action.xml',
         'views/snippets/s_parallax.xml',

--- a/theme_enark/views/snippets/s_sidegrid.xml
+++ b/theme_enark/views/snippets/s_sidegrid.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+
+<template id="s_sidegrid" inherit_id="website.s_sidegrid">
+    <!-- Images -->
+    <xpath expr="//img" position="attributes">
+        <attribute name="class" remove="rounded" separator=" "/>
+    </xpath>
+    <xpath expr="(//img)[2]" position="attributes">
+        <attribute name="class" remove="rounded" separator=" "/>
+    </xpath>
+    <xpath expr="(//img)[3]" position="attributes">
+        <attribute name="class" remove="rounded" separator=" "/>
+    </xpath>
+    <xpath expr="(//img)[4]" position="attributes">
+        <attribute name="class" remove="rounded" separator=" "/>
+    </xpath>
+</template>
+
+</odoo>

--- a/theme_graphene/views/customizations.xml
+++ b/theme_graphene/views/customizations.xml
@@ -206,6 +206,23 @@
     </xpath>
 </template>
 
+<!-- ======== SIDEGRID ======== -->
+<template id="s_sidegrid" inherit_id="website.s_sidegrid">
+    <!-- Images -->
+    <xpath expr="//img" position="attributes">
+        <attribute name="class" remove="rounded" separator=" "/>
+    </xpath>
+    <xpath expr="(//img)[2]" position="attributes">
+        <attribute name="class" remove="rounded" separator=" "/>
+    </xpath>
+    <xpath expr="(//img)[3]" position="attributes">
+        <attribute name="class" remove="rounded" separator=" "/>
+    </xpath>
+    <xpath expr="(//img)[4]" position="attributes">
+        <attribute name="class" remove="rounded" separator=" "/>
+    </xpath>
+</template>
+
 <!-- ======== COMPARISON ======== -->
 <template id="s_comparisons" inherit_id="website.s_comparisons" name="Graphene s_comparisons">
     <xpath expr="//section" position="attributes">

--- a/theme_kiddo/__manifest__.py
+++ b/theme_kiddo/__manifest__.py
@@ -21,6 +21,7 @@
         'views/snippets/s_call_to_action.xml',
         'views/snippets/s_freegrid.xml',
         'views/snippets/s_company_team_shapes.xml',
+        'views/snippets/s_sidegrid.xml',
         'views/snippets/s_cover.xml',
         'views/snippets/s_three_columns.xml',
         'views/snippets/s_features_wall.xml',

--- a/theme_kiddo/views/snippets/s_sidegrid.xml
+++ b/theme_kiddo/views/snippets/s_sidegrid.xml
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+
+<template id="s_sidegrid" inherit_id="website.s_sidegrid">
+    <!-- Images -->
+    <xpath expr="//img" position="attributes">
+        <attribute name="src">/web/image/website.library_image_13</attribute>
+    </xpath>
+    <xpath expr="(//img)[2]" position="attributes">
+        <attribute name="src">/web/image/website.library_image_11</attribute>
+    </xpath>
+    <xpath expr="(//img)[3]" position="attributes">
+        <attribute name="src">/web/image/website.s_banner_default_image</attribute>
+    </xpath>
+    <!-- Title -->
+    <xpath expr="//h1" position="replace" mode="inner">
+        A little place of paradise
+    </xpath>
+    <!-- Lead -->
+    <xpath expr="//p" position="replace" mode="inner">
+        The countryside nursery since 2002.<br/>A truly unique service in a highly secure and tranquil setting.
+    </xpath>
+</template>
+
+</odoo>

--- a/theme_loftspace/__manifest__.py
+++ b/theme_loftspace/__manifest__.py
@@ -18,6 +18,7 @@
         'views/snippets/s_title.xml',
         'views/snippets/s_three_columns.xml',
         'views/snippets/s_call_to_action.xml',
+        'views/snippets/s_sidegrid.xml',
         'views/snippets/s_image_gallery.xml',
         'views/snippets/s_freegrid.xml',
         'views/snippets/s_banner.xml',

--- a/theme_loftspace/views/snippets/s_sidegrid.xml
+++ b/theme_loftspace/views/snippets/s_sidegrid.xml
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+
+<template id="s_sidegrid" inherit_id="website.s_sidegrid">
+    <!-- Images -->
+    <xpath expr="//img" position="attributes">
+        <attribute name="class" remove="rounded" separator=" "/>
+        <attribute name="src">/web/image/website.s_text_image_default_image</attribute>
+    </xpath>
+    <xpath expr="(//img)[2]" position="attributes">
+        <attribute name="class" remove="rounded" separator=" "/>
+        <attribute name="src">/web/image/website.s_banner_default_image_2</attribute>
+    </xpath>
+    <xpath expr="(//img)[3]" position="attributes">
+        <attribute name="class" remove="rounded" separator=" "/>
+        <attribute name="src">/web/image/website.s_banner_default_image</attribute>
+    </xpath>
+    <xpath expr="(//img)[4]" position="attributes">
+        <attribute name="class" remove="rounded" separator=" "/>
+    </xpath>
+</template>
+
+</odoo>

--- a/theme_monglia/views/customizations.xml
+++ b/theme_monglia/views/customizations.xml
@@ -77,6 +77,26 @@
     </xpath>
 </template>
 
+<!-- ======== SIDEGRID ======== -->
+<template id="s_sidegrid" inherit_id="website.s_sidegrid">
+    <!-- Images -->
+    <xpath expr="//img" position="attributes">
+        <attribute name="class" remove="rounded" separator=" "/>
+        <attribute name="src">/web/image/website.s_text_image_default_image</attribute>
+    </xpath>
+    <xpath expr="(//img)[2]" position="attributes">
+        <attribute name="class" remove="rounded" separator=" "/>
+        <attribute name="src">/web/image/website.s_banner_default_image_2</attribute>
+    </xpath>
+    <xpath expr="(//img)[3]" position="attributes">
+        <attribute name="class" remove="rounded" separator=" "/>
+        <attribute name="src">/web/image/website.s_banner_default_image</attribute>
+    </xpath>
+    <xpath expr="(//img)[4]" position="attributes">
+        <attribute name="class" remove="rounded" separator=" "/>
+    </xpath>
+</template>
+
 <!-- ======== MEDIA LIST ======== -->
  <template id="s_media_list" inherit_id="website.s_media_list" name="Monglia s_media_list">
     <xpath expr="//div[hasclass('container')]/div/div[1]//h3" position="replace" mode="inner">

--- a/theme_notes/__manifest__.py
+++ b/theme_notes/__manifest__.py
@@ -31,6 +31,7 @@
         'views/snippets/s_image_gallery.xml',
         'views/snippets/s_call_to_action.xml',
         'views/snippets/s_features_wall.xml',
+        'views/snippets/s_sidegrid.xml',
         'views/snippets/s_features_grid.xml',
         'views/snippets/s_product_list.xml',
         'views/snippets/s_parallax.xml',

--- a/theme_notes/views/snippets/s_sidegrid.xml
+++ b/theme_notes/views/snippets/s_sidegrid.xml
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+
+<template id="s_sidegrid" inherit_id="website.s_sidegrid">
+    <!-- Images -->
+    <xpath expr="//img" position="attributes">
+        <attribute name="class" remove="rounded" separator=" "/>
+        <attribute name="src">/web/image/website.s_text_image_default_image</attribute>
+    </xpath>
+    <xpath expr="(//img)[2]" position="attributes">
+        <attribute name="class" remove="rounded" separator=" "/>
+        <attribute name="src">/web/image/website.s_banner_default_image_2</attribute>
+    </xpath>
+    <xpath expr="(//img)[3]" position="attributes">
+        <attribute name="class" remove="rounded" separator=" "/>
+        <attribute name="src">/web/image/website.s_banner_default_image</attribute>
+    </xpath>
+    <xpath expr="(//img)[4]" position="attributes">
+        <attribute name="class" remove="rounded" separator=" "/>
+    </xpath>
+</template>
+
+</odoo>

--- a/theme_real_estate/__manifest__.py
+++ b/theme_real_estate/__manifest__.py
@@ -18,6 +18,7 @@
         'views/snippets/s_image_text.xml',
         'views/snippets/s_image_title.xml',
         'views/snippets/s_text_image.xml',
+        'views/snippets/s_sidegrid.xml',
         'views/snippets/s_three_columns.xml',
         'views/snippets/s_quotes_carousel.xml',
         'views/snippets/s_freegrid.xml',

--- a/theme_real_estate/views/snippets/s_sidegrid.xml
+++ b/theme_real_estate/views/snippets/s_sidegrid.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+
+<template id="s_sidegrid" inherit_id="website.s_sidegrid">
+    <!-- Images -->
+    <xpath expr="//img" position="attributes">
+        <attribute name="class" remove="rounded" separator=" "/>
+    </xpath>
+    <xpath expr="(//img)[2]" position="attributes">
+        <attribute name="class" remove="rounded" separator=" "/>
+    </xpath>
+    <xpath expr="(//img)[3]" position="attributes">
+        <attribute name="class" remove="rounded" separator=" "/>
+    </xpath>
+    <xpath expr="(//img)[4]" position="attributes">
+        <attribute name="class" remove="rounded" separator=" "/>
+    </xpath>
+</template>
+
+</odoo>

--- a/theme_vehicle/views/customizations.xml
+++ b/theme_vehicle/views/customizations.xml
@@ -247,6 +247,23 @@
     </xpath>
 </template>
 
+<!-- ======== SIDEGRID ======== -->
+<template id="s_sidegrid" inherit_id="website.s_sidegrid">
+    <!-- Images -->
+    <xpath expr="//img" position="attributes">
+        <attribute name="class" remove="rounded" separator=" "/>
+    </xpath>
+    <xpath expr="(//img)[2]" position="attributes">
+        <attribute name="class" remove="rounded" separator=" "/>
+    </xpath>
+    <xpath expr="(//img)[3]" position="attributes">
+        <attribute name="class" remove="rounded" separator=" "/>
+    </xpath>
+    <xpath expr="(//img)[4]" position="attributes">
+        <attribute name="class" remove="rounded" separator=" "/>
+    </xpath>
+</template>
+
 <!-- ======== THREE COLUMNS ======== -->
 <template id="s_three_columns" inherit_id="website.s_three_columns">
     <!-- Section -->

--- a/theme_yes/__manifest__.py
+++ b/theme_yes/__manifest__.py
@@ -15,6 +15,7 @@
         'views/snippets/s_banner.xml',
         'views/snippets/s_striped_top.xml',
         'views/snippets/s_call_to_action.xml',
+        'views/snippets/s_sidegrid.xml',
         'views/snippets/s_carousel.xml',
         'views/snippets/s_company_team.xml',
         'views/snippets/s_cover.xml',

--- a/theme_yes/views/snippets/s_sidegrid.xml
+++ b/theme_yes/views/snippets/s_sidegrid.xml
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+
+<template id="s_sidegrid" inherit_id="website.s_sidegrid">
+    <!-- Images -->
+    <xpath expr="//img" position="attributes">
+        <attribute name="src">/web/image/website.s_text_image_default_image</attribute>
+    </xpath>
+    <xpath expr="(//img)[2]" position="attributes">
+        <attribute name="src">/web/image/website.s_banner_default_image_2</attribute>
+    </xpath>
+    <xpath expr="(//img)[3]" position="attributes">
+        <attribute name="src">/web/image/website.s_banner_default_image</attribute>
+    </xpath>
+    <!-- Title -->
+    <xpath expr="//h1" position="replace" mode="inner">
+        Experience a lovely wedding experience
+    </xpath>
+    <!-- Lead -->
+    <xpath expr="//p" position="replace" mode="inner">
+        A lovely wedding is a joyful celebration of love, marked by touching vows, beautiful decor, and happy faces, creating unforgettable memories.
+    </xpath>
+</template>
+
+</odoo>

--- a/theme_zap/__manifest__.py
+++ b/theme_zap/__manifest__.py
@@ -15,6 +15,7 @@
         'views/snippets/s_banner.xml',
         'views/snippets/s_striped_top.xml',
         'views/snippets/s_call_to_action.xml',
+        'views/snippets/s_sidegrid.xml',
         'views/snippets/s_color_blocks_2.xml',
         'views/snippets/s_cover.xml',
         'views/snippets/s_features.xml',

--- a/theme_zap/views/snippets/s_sidegrid.xml
+++ b/theme_zap/views/snippets/s_sidegrid.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+
+<template id="s_sidegrid" inherit_id="website.s_sidegrid">
+    <!-- Images -->
+    <xpath expr="//img" position="attributes">
+        <attribute name="class" remove="rounded" separator=" "/>
+    </xpath>
+    <xpath expr="(//img)[2]" position="attributes">
+        <attribute name="class" remove="rounded" separator=" "/>
+    </xpath>
+    <xpath expr="(//img)[3]" position="attributes">
+        <attribute name="class" remove="rounded" separator=" "/>
+    </xpath>
+    <xpath expr="(//img)[4]" position="attributes">
+        <attribute name="class" remove="rounded" separator=" "/>
+    </xpath>
+</template>
+
+</odoo>


### PR DESCRIPTION
*: (anelusia, artists, aviato, beauty, bewise, bistro, bookstore, enark, graphene, kiddo, loftspace, monglia, notes,real_estate, vehicle, yes, zap)

This commit adapts the design of new `s_sidegrid` snippet for multiple themes.

task-4077589

requires: https://github.com/odoo/odoo/pull/175616