### PR TITLE
[IMP] theme_*: adapt themes with new `s_image_punchy` snippet

### DIFF
--- a/theme_artists/__manifest__.py
+++ b/theme_artists/__manifest__.py
@@ -19,6 +19,7 @@
         'views/snippets/s_carousel.xml',
         'views/snippets/s_title.xml',
         'views/snippets/s_image_gallery.xml',
+        'views/snippets/s_image_punchy.xml',
         'views/snippets/s_banner.xml',
         'views/snippets/s_cover.xml',
         'views/snippets/s_features.xml',

--- a/theme_artists/views/snippets/s_image_punchy.xml
+++ b/theme_artists/views/snippets/s_image_punchy.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+
+<template id="s_image_punchy" inherit_id="website.s_image_punchy">
+    <!-- Section -->
+    <xpath expr="//section" position="attributes">
+        <attribute name="class" remove="o_cc2" add="o_cc5" separator=" "/>
+    </xpath>
+    <!-- Image -->
+    <xpath expr="//img" position="attributes">
+        <attribute name="src">/web/image/website.s_carousel_default_image_3</attribute>
+    </xpath>
+</template>
+
+</odoo>

--- a/theme_aviato/__manifest__.py
+++ b/theme_aviato/__manifest__.py
@@ -17,6 +17,7 @@
         'views/snippets/s_image_text.xml',
         'views/snippets/s_freegrid.xml',
         'views/snippets/s_text_image.xml',
+        'views/snippets/s_image_punchy.xml',
         'views/snippets/s_three_columns.xml',
         'views/snippets/s_picture.xml',
         'views/snippets/s_popup.xml',

--- a/theme_aviato/views/snippets/s_image_punchy.xml
+++ b/theme_aviato/views/snippets/s_image_punchy.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+
+<template id="s_image_punchy" inherit_id="website.s_image_punchy">
+    <!-- Section -->
+    <xpath expr="//section" position="attributes">
+        <attribute name="class" remove="o_cc2" add="o_cc5" separator=" "/>
+    </xpath>
+    <!-- Image -->
+    <xpath expr="//img" position="attributes">
+        <attribute name="src">/web/image/website.s_carousel_default_image_3</attribute>
+    </xpath>
+</template>
+
+</odoo>

--- a/theme_beauty/__manifest__.py
+++ b/theme_beauty/__manifest__.py
@@ -21,6 +21,7 @@
         'views/snippets/s_product_list.xml',
         'views/snippets/s_banner.xml',
         'views/snippets/s_image_text.xml',
+        'views/snippets/s_image_punchy.xml',
         'views/snippets/s_numbers.xml',
         'views/snippets/s_picture.xml',
         'views/snippets/s_pricelist_boxed.xml',

--- a/theme_beauty/views/snippets/s_image_punchy.xml
+++ b/theme_beauty/views/snippets/s_image_punchy.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+
+<template id="s_image_punchy" inherit_id="website.s_image_punchy">
+    <!-- Image -->
+    <xpath expr="//img" position="attributes">
+        <attribute name="src">/web/image/website.s_carousel_default_image_3</attribute>
+    </xpath>
+</template>
+
+</odoo>

--- a/theme_bewise/views/customizations.xml
+++ b/theme_bewise/views/customizations.xml
@@ -349,6 +349,17 @@
         Immerse yourself in a diverse campus community with opportunities for international exchange, cultural enrichment, and personal growth.
     </xpath>
 </template>
+<!-- ======== IMAGE PUNCHY ======== -->
+<template id="s_image_punchy" inherit_id="website.s_image_punchy">
+    <!-- Section -->
+    <xpath expr="//section" position="attributes">
+        <attribute name="class" remove="o_cc2" add="o_cc3" separator=" "/>
+    </xpath>
+    <!-- Image -->
+    <xpath expr="//img" position="attributes">
+        <attribute name="src">/web/image/website.s_carousel_default_image_1</attribute>
+    </xpath>
+</template>
 
 <!-- ======== FEATURES ======== -->
 <template id="s_features" inherit_id="website.s_features" name="Be Wise s_features">

--- a/theme_bistro/__manifest__.py
+++ b/theme_bistro/__manifest__.py
@@ -20,6 +20,7 @@
         'views/snippets/s_features.xml',
         'views/snippets/s_image_text.xml',
         'views/snippets/s_freegrid.xml',
+        'views/snippets/s_image_punchy.xml',
         'views/snippets/s_media_list.xml',
         'views/snippets/s_features_wall.xml',
         'views/snippets/s_numbers.xml',

--- a/theme_bistro/views/snippets/s_image_punchy.xml
+++ b/theme_bistro/views/snippets/s_image_punchy.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+
+<template id="s_image_punchy" inherit_id="website.s_image_punchy">
+    <!-- Section -->
+    <xpath expr="//section" position="attributes">
+        <attribute name="class" remove="o_cc2" add="o_cc5" separator=" "/>
+    </xpath>
+    <!-- Image -->
+    <xpath expr="//img" position="attributes">
+        <attribute name="src">/web/image/website.s_text_image_default_image</attribute>
+    </xpath>
+</template>
+
+</odoo>

--- a/theme_bookstore/__manifest__.py
+++ b/theme_bookstore/__manifest__.py
@@ -23,6 +23,7 @@
         'views/snippets/s_showcase.xml',
         'views/snippets/s_freegrid.xml',
         'views/snippets/s_features_wall.xml',
+        'views/snippets/s_image_punchy.xml',
         'views/snippets/s_masonry_block.xml',
         'views/snippets/s_banner.xml',
         'views/snippets/s_numbers.xml',

--- a/theme_bookstore/views/snippets/s_image_punchy.xml
+++ b/theme_bookstore/views/snippets/s_image_punchy.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+
+<template id="s_image_punchy" inherit_id="website.s_image_punchy">
+    <!-- Image -->
+    <xpath expr="//img" position="attributes">
+        <attribute name="src">/web/image/website.s_carousel_default_image_3</attribute>
+    </xpath>
+</template>
+
+</odoo>

--- a/theme_cobalt/views/customizations.xml
+++ b/theme_cobalt/views/customizations.xml
@@ -426,5 +426,12 @@
         Technology that drives success
     </xpath>
 </template>
+<!-- ======== IMAGE PUNCHY ======== -->
+<template id="s_image_punchy" inherit_id="website.s_image_punchy">
+    <!-- Section -->
+    <xpath expr="//section" position="attributes">
+        <attribute name="class" remove="o_cc2" add="o_cc1" separator=" "/>
+    </xpath>
+</template>
 
 </odoo>

--- a/theme_kiddo/__manifest__.py
+++ b/theme_kiddo/__manifest__.py
@@ -24,6 +24,7 @@
         'views/snippets/s_features_wall.xml',
         'views/snippets/s_quotes_carousel.xml',
         'views/snippets/s_text_image.xml',
+        'views/snippets/s_image_punchy.xml',
         'views/snippets/s_product_catalog.xml',
         'views/snippets/s_unveil.xml',
         'views/snippets/s_numbers_showcase.xml',

--- a/theme_kiddo/views/snippets/s_image_punchy.xml
+++ b/theme_kiddo/views/snippets/s_image_punchy.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+
+<template id="s_image_punchy" inherit_id="website.s_image_punchy">
+    <!-- Section -->
+    <xpath expr="//section" position="attributes">
+        <attribute name="class" remove="o_cc2" add="o_cc5" separator=" "/>
+    </xpath>
+    <!-- Image -->
+    <xpath expr="//img" position="attributes">
+        <attribute name="src">/web/image/website.s_carousel_default_image_3</attribute>
+    </xpath>
+</template>
+
+</odoo>

--- a/theme_orchid/__manifest__.py
+++ b/theme_orchid/__manifest__.py
@@ -15,6 +15,7 @@
         'views/snippets/s_cover.xml',
         'views/snippets/s_text_image.xml',
         'views/snippets/s_image_text.xml',
+        'views/snippets/s_image_punchy.xml',
         'views/snippets/s_three_columns.xml',
         'views/snippets/s_quotes_carousel.xml',
         'views/snippets/s_features_wall.xml',

--- a/theme_orchid/views/snippets/s_image_punchy.xml
+++ b/theme_orchid/views/snippets/s_image_punchy.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+
+<template id="s_image_punchy" inherit_id="website.s_image_punchy">
+    <!-- Section -->
+    <xpath expr="//section" position="attributes">
+        <attribute name="class" remove="o_cc2" add="o_cc1" separator=" "/>
+    </xpath>
+    <!-- Image -->
+    <xpath expr="//img" position="attributes">
+        <attribute name="src">/web/image/website.s_carousel_default_image_3</attribute>
+    </xpath>
+</template>
+
+</odoo>

--- a/theme_paptic/views/customizations.xml
+++ b/theme_paptic/views/customizations.xml
@@ -277,6 +277,18 @@
     </xpath>
 </template>
 
+<!-- ==== Image Punchy ===== -->
+<template id="s_image_punchy" inherit_id="website.s_image_punchy">
+    <!-- Section -->
+    <xpath expr="//section" position="attributes">
+        <attribute name="class" remove="o_cc2" add="o_cc4" separator=" "/>
+    </xpath>
+    <!-- Image -->
+    <xpath expr="//img" position="attributes">
+        <attribute name="src">/web/image/website.s_parallax_default_image</attribute>
+    </xpath>
+</template>
+
 <!-- ==== Comparisons ===== -->
 <template id="s_comparisons" inherit_id="website.s_comparisons" name="Paptic s_comparisons">
     <xpath expr="//section" position="attributes">

--- a/theme_vehicle/views/customizations.xml
+++ b/theme_vehicle/views/customizations.xml
@@ -99,6 +99,18 @@
     </xpath>
 </template>
 
+<!-- ======== IMAGE PUNCHY ======== -->
+<template id="s_image_punchy" inherit_id="website.s_image_punchy">
+    <!-- Section -->
+    <xpath expr="//section" position="attributes">
+        <attribute name="class" remove="o_cc2" add="o_cc3" separator=" "/>
+    </xpath>
+    <!-- Image -->
+    <xpath expr="//img" position="attributes">
+        <attribute name="src">/web/image/website.s_carousel_default_image_2</attribute>
+    </xpath>
+</template>
+
 <!-- ======== NUMBERS ======== -->
 <template id="s_numbers" inherit_id="website.s_numbers">
     <!-- Section -->

--- a/theme_yes/__manifest__.py
+++ b/theme_yes/__manifest__.py
@@ -20,6 +20,7 @@
         'views/snippets/s_image_text.xml',
         'views/snippets/s_image_gallery.xml',
         'views/snippets/s_images_wall.xml',
+        'views/snippets/s_image_punchy.xml',
         'views/snippets/s_masonry_block.xml',
         'views/snippets/s_media_list.xml',
         'views/snippets/s_picture.xml',

--- a/theme_yes/views/snippets/s_image_punchy.xml
+++ b/theme_yes/views/snippets/s_image_punchy.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+
+<template id="s_image_punchy" inherit_id="website.s_image_punchy">
+    <!-- Section -->
+    <xpath expr="//section" position="attributes">
+        <attribute name="class" remove="o_cc2" add="o_cc5" separator=" "/>
+    </xpath>
+    <!-- Image -->
+    <xpath expr="//img" position="attributes">
+        <attribute name="src">/web/image/website.s_carousel_default_image_1</attribute>
+    </xpath>
+</template>
+
+</odoo>


### PR DESCRIPTION
*: (artists, aviato, beauty, bistro, bewise, bookstore, cobalt, kiddo, orchid, paptic, vehicle, yes)

This commit adapts the design of new `s_image_punchy` snippet for multiple themes.

requires: https://github.com/odoo/odoo/pull/176290

Part of task-4077427
task-4105331