### PR TITLE
[IMP] theme_*: adapt themes with new `s_image_frame` design

### DIFF
--- a/theme_anelusia/__manifest__.py
+++ b/theme_anelusia/__manifest__.py
@@ -46,6 +46,7 @@
         'views/snippets/s_striped_center_top.xml',
         'views/snippets/s_key_images.xml',
         'views/snippets/s_big_number.xml',
+        'views/snippets/s_image_frame.xml',
         'views/new_page_template.xml',
     ],
     'images': [

--- a/theme_anelusia/views/snippets/s_image_frame.xml
+++ b/theme_anelusia/views/snippets/s_image_frame.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+
+<template id="s_image_frame" inherit_id="website.s_image_frame">
+    <!-- Image -->
+    <xpath expr="//img" position="attributes">
+        <attribute name="src">/web/image/website.s_carousel_default_image_3</attribute>
+    </xpath>
+</template>
+
+</odoo>

--- a/theme_artists/__manifest__.py
+++ b/theme_artists/__manifest__.py
@@ -50,6 +50,7 @@
         'views/snippets/s_striped_center_top.xml',
         'views/snippets/s_key_images.xml',
         'views/snippets/s_big_number.xml',
+        'views/snippets/s_image_frame.xml',
         'views/new_page_template.xml',
     ],
     'images': [

--- a/theme_artists/views/snippets/s_image_frame.xml
+++ b/theme_artists/views/snippets/s_image_frame.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+
+<template id="s_image_frame" inherit_id="website.s_image_frame">
+    <!-- Section -->
+    <xpath expr="//section" position="attributes">
+        <attribute name="class" remove="o_cc1" add="o_cc5" separator=" "/>
+    </xpath>
+    <!-- Image -->
+    <xpath expr="//img" position="attributes">
+        <attribute name="src">/web/image/website.library_image_16</attribute>
+    </xpath>
+</template>
+
+</odoo>

--- a/theme_avantgarde/views/customizations.xml
+++ b/theme_avantgarde/views/customizations.xml
@@ -474,6 +474,18 @@
     </xpath>
 </template>
 
+<!-- ======== IMAGE FRAME ======== -->
+<template id="s_image_frame" inherit_id="website.s_image_frame">
+    <!-- Section -->
+    <xpath expr="//section" position="attributes">
+        <attribute name="class" remove="o_cc1" add="o_cc5" separator=" "/>
+    </xpath>
+    <!-- Image -->
+    <xpath expr="//img" position="attributes">
+        <attribute name="src">/web/image/website.s_carousel_default_image_3</attribute>
+    </xpath>
+</template>
+
 <!-- ======== BIG NUMBER ======== -->
 <template id="s_big_number" inherit_id="website.s_big_number">
     <!-- Section -->

--- a/theme_aviato/__manifest__.py
+++ b/theme_aviato/__manifest__.py
@@ -37,6 +37,7 @@
         'views/snippets/s_image_hexagonal.xml',
         'views/snippets/s_key_images.xml',
         'views/snippets/s_big_number.xml',
+        'views/snippets/s_image_frame.xml',
         'views/new_page_template.xml',
     ],
     'images': [

--- a/theme_aviato/views/snippets/s_image_frame.xml
+++ b/theme_aviato/views/snippets/s_image_frame.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+
+<template id="s_image_frame" inherit_id="website.s_image_frame">
+    <!-- Section -->
+    <xpath expr="//section" position="attributes">
+        <attribute name="class" remove="o_cc1" add="o_cc3" separator=" "/>
+    </xpath>
+    <!-- Image -->
+    <xpath expr="//img" position="attributes">
+        <attribute name="src">/web/image/website.library_image_14</attribute>
+    </xpath>
+</template>
+
+</odoo>

--- a/theme_beauty/__manifest__.py
+++ b/theme_beauty/__manifest__.py
@@ -45,6 +45,7 @@
         'views/snippets/s_key_images.xml',
         'views/snippets/s_intro_pill.xml',
         'views/snippets/s_big_number.xml',
+        'views/snippets/s_image_frame.xml',
         'views/new_page_template.xml',
     ],
     'images': [

--- a/theme_beauty/views/snippets/s_image_frame.xml
+++ b/theme_beauty/views/snippets/s_image_frame.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+
+<template id="s_image_frame" inherit_id="website.s_image_frame">
+    <!-- Image -->
+    <xpath expr="//img" position="attributes">
+        <attribute name="src">/web/image/website.s_carousel_default_image_3</attribute>
+    </xpath>
+</template>
+
+</odoo>

--- a/theme_bewise/views/customizations.xml
+++ b/theme_bewise/views/customizations.xml
@@ -728,6 +728,18 @@
     </xpath>
 </template>
 
+<!-- ======== IMAGE FRAME ======== -->
+<template id="s_image_frame" inherit_id="website.s_image_frame">
+    <!-- Section -->
+    <xpath expr="//section" position="attributes">
+        <attribute name="class" remove="o_cc1" add="o_cc4" separator=" "/>
+    </xpath>
+    <!-- Image -->
+    <xpath expr="//img" position="attributes">
+        <attribute name="src">/web/image/website.s_quotes_carousel_demo_image_1</attribute>
+    </xpath>
+</template>
+
 <!-- ======== INTRO PILL ======== -->
 <template id="s_intro_pill" inherit_id="website.s_intro_pill">
     <!-- Title -->

--- a/theme_bistro/__manifest__.py
+++ b/theme_bistro/__manifest__.py
@@ -42,6 +42,7 @@
         'views/snippets/s_quadrant.xml',
         'views/snippets/s_intro_pill.xml',
         'views/snippets/s_big_number.xml',
+        'views/snippets/s_image_frame.xml',
         'views/new_page_template.xml',
 
     ],

--- a/theme_bistro/views/snippets/s_image_frame.xml
+++ b/theme_bistro/views/snippets/s_image_frame.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+
+<template id="s_image_frame" inherit_id="website.s_image_frame">
+    <!-- Image -->
+    <xpath expr="//img" position="attributes">
+        <attribute name="src">/web/image/theme_bistro.bg_img_08</attribute>
+    </xpath>
+</template>
+
+</odoo>

--- a/theme_bookstore/__manifest__.py
+++ b/theme_bookstore/__manifest__.py
@@ -47,6 +47,7 @@
         'views/snippets/s_striped_center_top.xml',
         'views/snippets/s_intro_pill.xml',
         'views/snippets/s_big_number.xml',
+        'views/snippets/s_image_frame.xml',
         'views/new_page_template.xml',
     ],
     'images': [

--- a/theme_bookstore/views/snippets/s_image_frame.xml
+++ b/theme_bookstore/views/snippets/s_image_frame.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+
+<template id="s_image_frame" inherit_id="website.s_image_frame">
+    <!-- Section -->
+    <xpath expr="//section" position="attributes">
+        <attribute name="class" remove="o_cc1" add="o_cc3" separator=" "/>
+    </xpath>
+    <!-- Image -->
+    <xpath expr="//img" position="attributes">
+        <attribute name="src">/web/image/website.s_parallax_default_image</attribute>
+    </xpath>
+</template>
+
+</odoo>

--- a/theme_buzzy/__manifest__.py
+++ b/theme_buzzy/__manifest__.py
@@ -53,6 +53,7 @@
         'views/snippets/s_image_title.xml',
         'views/snippets/s_key_images.xml',
         'views/snippets/s_big_number.xml',
+        'views/snippets/s_image_frame.xml',
         'views/new_page_template.xml',
     ],
     'images': [

--- a/theme_buzzy/views/snippets/s_image_frame.xml
+++ b/theme_buzzy/views/snippets/s_image_frame.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+
+<template id="s_image_frame" inherit_id="website.s_image_frame">
+    <!-- Image -->
+    <xpath expr="//img" position="attributes">
+        <attribute name="src">/web/image/website.library_image_08</attribute>
+    </xpath>
+</template>
+
+</odoo>

--- a/theme_clean/__manifest__.py
+++ b/theme_clean/__manifest__.py
@@ -33,6 +33,7 @@
         'views/snippets/s_pricelist_boxed.xml',
         'views/snippets/s_striped_center_top.xml',
         'views/snippets/s_big_number.xml',
+        'views/snippets/s_image_frame.xml',
         'views/new_page_template.xml',
     ],
     'images': [

--- a/theme_clean/views/snippets/s_image_frame.xml
+++ b/theme_clean/views/snippets/s_image_frame.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+
+<template id="s_image_frame" inherit_id="website.s_image_frame">
+    <!-- Section -->
+    <xpath expr="//section" position="attributes">
+        <attribute name="class" remove="o_cc1" add="o_cc3" separator=" "/>
+    </xpath>
+    <!-- Image -->
+    <xpath expr="//img" position="attributes">
+        <attribute name="src">/web/image/website.s_quotes_carousel_demo_image_1</attribute>
+    </xpath>
+</template>
+
+</odoo>

--- a/theme_cobalt/views/customizations.xml
+++ b/theme_cobalt/views/customizations.xml
@@ -478,6 +478,14 @@
     </xpath>
 </template>
 
+<!-- ======== IMAGE FRAME ======== -->
+<template id="s_image_frame" inherit_id="website.s_image_frame">
+    <!-- Image -->
+    <xpath expr="//img" position="attributes">
+        <attribute name="src">/web/image/website.s_carousel_default_image_1</attribute>
+    </xpath>
+</template>
+
 <!-- ======== BIG NUMBER ======== -->
 <template id="s_big_number" inherit_id="website.s_big_number">
     <!-- Section -->

--- a/theme_enark/__manifest__.py
+++ b/theme_enark/__manifest__.py
@@ -36,6 +36,7 @@
         'views/snippets/s_striped_center_top.xml',
         'views/snippets/s_intro_pill.xml',
         'views/snippets/s_big_number.xml',
+        'views/snippets/s_image_frame.xml',
         'views/new_page_template.xml',
     ],
     'images': [

--- a/theme_enark/views/snippets/s_image_frame.xml
+++ b/theme_enark/views/snippets/s_image_frame.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+
+<template id="s_image_frame" inherit_id="website.s_image_frame">
+    <!-- Image -->
+    <xpath expr="//img" position="attributes">
+        <attribute name="src">/web/image/website.s_carousel_default_image_3</attribute>
+    </xpath>
+</template>
+
+</odoo>

--- a/theme_graphene/views/customizations.xml
+++ b/theme_graphene/views/customizations.xml
@@ -489,6 +489,18 @@
     </xpath>
 </template>
 
+<!-- ======== IMAGE FRAME ======== -->
+<template id="s_image_frame" inherit_id="website.s_image_frame">
+    <!-- Section -->
+    <xpath expr="//section" position="attributes">
+        <attribute name="class" remove="o_cc1" add="o_cc3" separator=" "/>
+    </xpath>
+    <!-- Image -->
+    <xpath expr="//img" position="attributes">
+        <attribute name="src">/web/image/theme_graphene.image_content_10</attribute>
+    </xpath>
+</template>
+
 <!-- ======== BIG NUMBER ======== -->
 <template id="s_big_number" inherit_id="website.s_big_number">
     <!-- Section -->

--- a/theme_kiddo/__manifest__.py
+++ b/theme_kiddo/__manifest__.py
@@ -42,6 +42,7 @@
         'views/snippets/s_key_images.xml',
         'views/snippets/s_intro_pill.xml',
         'views/snippets/s_big_number.xml',
+        'views/snippets/s_image_frame.xml',
         'views/new_page_template.xml',
     ],
     'images': [

--- a/theme_kiddo/views/snippets/s_image_frame.xml
+++ b/theme_kiddo/views/snippets/s_image_frame.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+
+<template id="s_image_frame" inherit_id="website.s_image_frame">
+    <!-- Image -->
+    <xpath expr="//img" position="attributes">
+        <attribute name="src">/web/image/website.library_image_10</attribute>
+    </xpath>
+</template>
+
+</odoo>

--- a/theme_monglia/views/customizations.xml
+++ b/theme_monglia/views/customizations.xml
@@ -593,5 +593,12 @@
     </xpath>
 </template>
 
+<!-- ======== IMAGE FRAME ======== -->
+<template id="s_image_frame" inherit_id="website.s_image_frame">
+    <!-- Image -->
+    <xpath expr="//img" position="attributes">
+        <attribute name="src">/web/image/website.s_quotes_carousel_demo_image_1</attribute>
+    </xpath>
+</template>
 
 </odoo>

--- a/theme_nano/__manifest__.py
+++ b/theme_nano/__manifest__.py
@@ -33,6 +33,7 @@
         'views/snippets/s_key_benefits.xml',
         'views/snippets/s_striped_center_top.xml',
         'views/snippets/s_big_number.xml',
+        'views/snippets/s_image_frame.xml',
         'views/new_page_template.xml',
     ],
     'images': [

--- a/theme_nano/views/snippets/s_image_frame.xml
+++ b/theme_nano/views/snippets/s_image_frame.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+
+<template id="s_image_frame" inherit_id="website.s_image_frame">
+    <!-- Section -->
+    <xpath expr="//section" position="attributes">
+        <attribute name="class" remove="o_cc1" add="o_cc5" separator=" "/>
+    </xpath>
+</template>
+
+</odoo>

--- a/theme_notes/__manifest__.py
+++ b/theme_notes/__manifest__.py
@@ -46,6 +46,7 @@
         'views/snippets/s_quadrant.xml',
         'views/snippets/s_intro_pill.xml',
         'views/snippets/s_big_number.xml',
+        'views/snippets/s_image_frame.xml',
         'views/new_page_template.xml',
     ],
     'images': [

--- a/theme_notes/views/snippets/s_image_frame.xml
+++ b/theme_notes/views/snippets/s_image_frame.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+
+<template id="s_image_frame" inherit_id="website.s_image_frame">
+    <!-- Section -->
+    <xpath expr="//section" position="attributes">
+        <attribute name="class" remove="o_cc1" add="o_cc5" separator=" "/>
+    </xpath>
+    <!-- Image -->
+    <xpath expr="//img" position="attributes">
+        <attribute name="src">/web/image/website.library_image_10</attribute>
+    </xpath>
+</template>
+
+</odoo>

--- a/theme_paptic/views/customizations.xml
+++ b/theme_paptic/views/customizations.xml
@@ -691,6 +691,14 @@
     </xpath>
 </template>
 
+<!-- ======== IMAGE FRAME ======== -->
+<template id="s_image_frame" inherit_id="website.s_image_frame">
+    <!-- Image -->
+    <xpath expr="//img" position="attributes">
+        <attribute name="src">/web/image/website.s_carousel_default_image_3</attribute>
+    </xpath>
+</template>
+
 <!-- ==== Big Number ===== -->
 <template id="s_big_number" inherit_id="website.s_big_number">
     <!-- Section -->

--- a/theme_treehouse/__manifest__.py
+++ b/theme_treehouse/__manifest__.py
@@ -40,6 +40,7 @@
         'views/snippets/s_striped_center_top.xml',
         'views/snippets/s_intro_pill.xml',
         'views/snippets/s_big_number.xml',
+        'views/snippets/s_image_frame.xml',
         'views/new_page_template.xml',
     ],
     'images': [

--- a/theme_treehouse/views/snippets/s_image_frame.xml
+++ b/theme_treehouse/views/snippets/s_image_frame.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+
+<template id="s_image_frame" inherit_id="website.s_image_frame">
+    <!-- Image -->
+    <xpath expr="//img" position="attributes">
+        <attribute name="src">/web/image/website.s_three_columns_default_image_3</attribute>
+    </xpath>
+</template>
+
+</odoo>

--- a/theme_vehicle/views/customizations.xml
+++ b/theme_vehicle/views/customizations.xml
@@ -685,4 +685,17 @@
         customer satisfaction
     </xpath>
 </template>
+
+<!-- ======== IMAGE FRAME ======== -->
+<template id="s_image_frame" inherit_id="website.s_image_frame">
+    <!-- Section -->
+    <xpath expr="//section" position="attributes">
+        <attribute name="class" remove="o_cc1" add="o_cc5" separator=" "/>
+    </xpath>
+    <!-- Image -->
+    <xpath expr="//img" position="attributes">
+        <attribute name="src">/web/image/website.library_image_05</attribute>
+    </xpath>
+</template>
+
 </odoo>

--- a/theme_yes/__manifest__.py
+++ b/theme_yes/__manifest__.py
@@ -44,6 +44,7 @@
         'views/snippets/s_kickoff.xml',
         'views/snippets/s_intro_pill.xml',
         'views/snippets/s_big_number.xml',
+        'views/snippets/s_image_frame.xml',
         'views/new_page_template.xml',
     ],
     'images': [

--- a/theme_yes/views/snippets/s_image_frame.xml
+++ b/theme_yes/views/snippets/s_image_frame.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+
+<template id="s_image_frame" inherit_id="website.s_image_frame">
+    <!-- Section -->
+    <xpath expr="//section" position="attributes">
+        <attribute name="class" remove="o_cc1" add="o_cc5" separator=" "/>
+    </xpath>
+    <!-- Image -->
+    <xpath expr="//img" position="attributes">
+        <attribute name="src">/web/image/website.s_carousel_default_image_3</attribute>
+    </xpath>
+</template>
+
+</odoo>


### PR DESCRIPTION
*: anelusia, artists, avantgarde, aviato, beauty, bewise, bistro, bookstore, buzzy, clean, cobalt, enark, graphene, kiddo, monglia, nano, notes, paptic, treehouse, vehicle, yes

This commit adapts the design of `s_image_frame` for multiple themes, based on the new Odoo 18 snippet redesign.

require: https://github.com/odoo/odoo/pull/176562

task-4105328
Part-of: task-4077427