### PR TITLE
[IMP] theme_*: adapt themes with redesigned `s_banner` snippet

### DIFF
--- a/theme_buzzy/views/snippets/s_banner.xml
+++ b/theme_buzzy/views/snippets/s_banner.xml
@@ -11,14 +11,15 @@
    <!-- Remove grid images -->
    <xpath expr="//div[hasclass('o_grid_item_image')]" position="replace"/>
    <xpath expr="//div[hasclass('o_grid_item_image')]" position="replace"/>
-   <xpath expr="//div[hasclass('o_grid_item_image')]" position="replace"/>
+   <xpath expr="//div[hasclass('col-lg-5')]" position="replace"/>
    <!-- Row - remove grid mode -->
    <xpath expr="//div[hasclass('row')]" position="attributes">
       <attribute name="class" remove="o_grid_mode" separator=" "/>
+      <attribute name="data-row-count"/>
    </xpath>
    <!-- Jumbotron -->
-   <xpath expr="//div[hasclass('col-lg-5')]" position="attributes">
-      <attribute name="class" add="col-lg-6 o_cc o_cc1 pt32 pb32 shadow rounded" remove="o_grid_item g-height-4 g-col-lg-5 col-lg-5" separator=" "/>
+   <xpath expr="//div[hasclass('col-lg-4')]" position="attributes">
+      <attribute name="class" add="col-lg-6 o_cc o_cc1 pt32 pb32 shadow rounded" remove="o_grid_item g-height-10 g-col-lg-4 col-lg-4" separator=" "/>
       <attribute name="style"/>
    </xpath>
    <!-- Title -->

--- a/theme_cobalt/views/customizations.xml
+++ b/theme_cobalt/views/customizations.xml
@@ -10,16 +10,17 @@
     <!-- Row - remove grid mode -->
     <xpath expr="//div[hasclass('row')]" position="attributes">
         <attribute name="class" remove="o_grid_mode" separator=" "/>
+        <attribute name="data-row-count"/>
     </xpath>
     <!-- Jumbotron -->
-    <xpath expr="//div[hasclass('col-lg-5')]" position="attributes">
-        <attribute name="class" add="col-lg-6" remove="o_grid_item g-height-4 g-col-lg-5 col-lg-5" separator=" "/>
+    <xpath expr="//div[hasclass('col-lg-4')]" position="attributes">
+        <attribute name="class" add="col-lg-6" remove="o_grid_item g-height-10 g-col-lg-4 col-lg-4" separator=" "/>
         <attribute name="style"/>
     </xpath>
     <!-- Remove grid images -->
     <xpath expr="//div[hasclass('o_grid_item_image')]" position="replace"/>
     <xpath expr="//div[hasclass('o_grid_item_image')]" position="replace"/>
-    <xpath expr="//div[hasclass('o_grid_item_image')]" position="replace"/>
+    <xpath expr="//div[hasclass('col-lg-5')]" position="replace"/>
     <!-- Image -->
     <xpath expr="//div[hasclass('col-lg-6')]" position="after">
         <div class="pt16 pb16 o_colored_level col-lg-5 offset-lg-1">

--- a/theme_enark/views/snippets/s_banner.xml
+++ b/theme_enark/views/snippets/s_banner.xml
@@ -13,14 +13,15 @@
     <!-- Remove grid images -->
     <xpath expr="//div[hasclass('o_grid_item_image')]" position="replace"/>
     <xpath expr="//div[hasclass('o_grid_item_image')]" position="replace"/>
-    <xpath expr="//div[hasclass('o_grid_item_image')]" position="replace"/>
+    <xpath expr="//div[hasclass('col-lg-5')]" position="replace"/>
     <!-- Row - remove grid mode -->
     <xpath expr="//div[hasclass('row')]" position="attributes">
         <attribute name="class" remove="o_grid_mode" separator=" "/>
+        <attribute name="data-row-count"/>
     </xpath>
     <!-- Jumbotron -->
-    <xpath expr="//div[hasclass('col-lg-5')]" position="attributes">
-        <attribute name="class" add="col-lg-6 o_cc o_cc1 pt32 pb32 shadow rounded" remove="o_grid_item g-height-4 g-col-lg-5 col-lg-5" separator=" "/>
+    <xpath expr="//div[hasclass('col-lg-4')]" position="attributes">
+        <attribute name="class" add="col-lg-6 o_cc o_cc1 pt32 pb32 shadow rounded" remove="o_grid_item g-height-10 g-col-lg-4 col-lg-4" separator=" "/>
         <attribute name="style"/>
     </xpath>
     <!-- Title -->

--- a/theme_kiddo/views/snippets/s_banner.xml
+++ b/theme_kiddo/views/snippets/s_banner.xml
@@ -12,12 +12,13 @@
     <!-- Row - remove grid mode -->
     <xpath expr="//div[hasclass('row')]" position="attributes">
         <attribute name="class" remove="o_grid_mode" separator=" "/>
+        <attribute name="data-row-count"/>
     </xpath>
 
     <!-- Remove grid images -->
     <xpath expr="//div[hasclass('o_grid_item_image')]" position="replace"/>
     <xpath expr="//div[hasclass('o_grid_item_image')]" position="replace"/>
-    <xpath expr="//div[hasclass('o_grid_item_image')]" position="replace"/>
+    <xpath expr="//div[hasclass('col-lg-5')]" position="replace"/>
 
     <!-- Filter -->
     <xpath expr="//div[hasclass('container')]" position="before">
@@ -25,8 +26,8 @@
     </xpath>
 
     <!-- Paragraph -->
-    <xpath expr="//div[hasclass('col-lg-5')]" position="attributes">
-        <attribute name="class" add="col-lg-6 pt32 pb32" remove="o_grid_item g-height-4 g-col-lg-5 col-lg-5" separator=" "/>
+    <xpath expr="//div[hasclass('col-lg-4')]" position="attributes">
+        <attribute name="class" add="col-lg-6 pt32 pb32" remove="o_grid_item g-height-10 g-col-lg-4 col-lg-4" separator=" "/>
         <attribute name="style"/>
     </xpath>
     <xpath expr="//h1" position="replace" mode="inner">

--- a/theme_real_estate/views/snippets/s_banner.xml
+++ b/theme_real_estate/views/snippets/s_banner.xml
@@ -17,16 +17,17 @@
     <!-- Row - remove grid mode -->
     <xpath expr="//div[hasclass('row')]" position="attributes">
         <attribute name="class" remove="o_grid_mode" separator=" "/>
+        <attribute name="data-row-count"/>
     </xpath>
     
     <!-- Remove grid images -->
     <xpath expr="//div[hasclass('o_grid_item_image')]" position="replace"/>
     <xpath expr="//div[hasclass('o_grid_item_image')]" position="replace"/>
-    <xpath expr="//div[hasclass('o_grid_item_image')]" position="replace"/>
+    <xpath expr="//div[hasclass('col-lg-5')]" position="replace"/>
 
     <!-- Jumbotron -->
-    <xpath expr="//div[hasclass('col-lg-5')]" position="attributes">
-        <attribute name="class" add="col-lg-7 h-100 pt160 pb160" remove="o_grid_item g-height-4 g-col-lg-5 col-lg-5" separator=" "/>
+    <xpath expr="//div[hasclass('col-lg-4')]" position="attributes">
+        <attribute name="class" add="col-lg-7 pt160 pb160" remove="o_grid_item g-height-10 g-col-lg-4 col-lg-4" separator=" "/>
         <attribute name="style"/>
     </xpath>
 

--- a/theme_zap/views/snippets/s_banner.xml
+++ b/theme_zap/views/snippets/s_banner.xml
@@ -13,14 +13,15 @@
     <!-- Row - remove grid mode -->
     <xpath expr="//div[hasclass('row')]" position="attributes">
         <attribute name="class" remove="o_grid_mode" separator=" "/>
+        <attribute name="data-row-count"/>
     </xpath>
     <!-- Remove grid images -->
     <xpath expr="//div[hasclass('o_grid_item_image')]" position="replace"/>
     <xpath expr="//div[hasclass('o_grid_item_image')]" position="replace"/>
-    <xpath expr="//div[hasclass('o_grid_item_image')]" position="replace"/>
+    <xpath expr="//div[hasclass('col-lg-5')]" position="replace"/>
     <!-- Column -->
-    <xpath expr="//*[hasclass('col-lg-5')]" position="attributes">
-        <attribute name="class" add="col-lg-8 pt48 pb32 px-5 o_cc o_cc1 rounded" remove="o_grid_item g-height-4 g-col-lg-5 col-lg-5" separator=" "/>
+    <xpath expr="//*[hasclass('col-lg-4')]" position="attributes">
+        <attribute name="class" add="col-lg-8 pt48 pb32 px-5 o_cc o_cc1 rounded" remove="o_grid_item g-height-10 g-col-lg-4 col-lg-4" separator=" "/>
         <attribute name="style">box-shadow: rgba(0, 0, 0, 0.15) 0px 2px 4px 0px !important;</attribute>
     </xpath>
     <!-- Title -->


### PR DESCRIPTION
*: (buzzy, cobalt, enark, kiddo, real_estate, zap)

This commit adapts the design of new `s_banner` snippet for multiple themes.

requires: https://github.com/odoo/odoo/pull/176595

task-4109584