### PR TITLE
[IMP] theme_anelusia, *: adapt `s_image_title`

### DIFF
--- a/theme_anelusia/__manifest__.py
+++ b/theme_anelusia/__manifest__.py
@@ -18,6 +18,7 @@
         'views/snippets/s_image_gallery.xml',
         'views/snippets/s_carousel.xml',
         'views/snippets/s_media_list.xml',
+        'views/snippets/s_image_title.xml',
         'views/snippets/s_text_cover.xml',
         'views/snippets/s_color_blocks_2.xml',
         'views/snippets/s_company_team_shapes.xml',

--- a/theme_anelusia/views/images_library.xml
+++ b/theme_anelusia/views/images_library.xml
@@ -252,5 +252,10 @@
     <field name="name">website.s_accordion_image_default_image</field>
     <field name="url">/theme_anelusia/static/src/img/snippets/s_picture.jpg</field>
 </record>
+<record id="s_image_title_default_image" model="theme.ir.attachment">
+    <field name="key">website.s_image_title_default_image</field>
+    <field name="name">website.s_image_title_default_image</field>
+    <field name="url">/theme_anelusia/static/src/img/snippets/s_carousel_3.jpg</field>
+</record>
 
 </odoo>

--- a/theme_anelusia/views/snippets/s_image_title.xml
+++ b/theme_anelusia/views/snippets/s_image_title.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+
+<template id="s_image_title" inherit_id="website.s_image_title">
+    <xpath expr="//h1" position="replace" mode="inner">
+        A Deep Dive into Style and Innovation
+    </xpath>
+    <xpath expr="//p[hasclass('lead')]" position="replace" mode="inner">
+        Transform your wardrobe with our latest fashion collection, where elegance meets versatility. Elevate your style with pieces that blend sophistication and comfort effortlessly.
+    </xpath>
+</template>
+
+</odoo>

--- a/theme_artists/__manifest__.py
+++ b/theme_artists/__manifest__.py
@@ -24,6 +24,7 @@
         'views/snippets/s_cover.xml',
         'views/snippets/s_features.xml',
         'views/snippets/s_media_list.xml',
+        'views/snippets/s_image_title.xml',
         'views/snippets/s_numbers.xml',
         'views/snippets/s_picture.xml',
         'views/snippets/s_image_text.xml',

--- a/theme_artists/views/images.xml
+++ b/theme_artists/views/images.xml
@@ -235,5 +235,10 @@ Check in theme_monglia's primary_variables.scss, theme.scss and theme_common's m
     <field name="name">website.s_image_hexagonal_default_image_1</field>
     <field name="url">/theme_artists/static/src/img/snippets/s_image_hexagonal_1.jpg</field>
 </record>
+<record id="s_image_title_default_image" model="theme.ir.attachment">
+    <field name="key">website.s_image_title_default_image</field>
+    <field name="name">website.s_image_title_default_image</field>
+    <field name="url">/theme_artists/static/src/img/snippets/s_carousel_1.jpg</field>
+</record>
 
 </odoo>

--- a/theme_artists/views/snippets/s_image_title.xml
+++ b/theme_artists/views/snippets/s_image_title.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+
+<template id="s_image_title" inherit_id="website.s_image_title">
+    <xpath expr="//h1" position="replace" mode="inner">
+        A Deep Dive into Creativity and Excellence
+    </xpath>
+    <xpath expr="//p[hasclass('lead')]" position="replace" mode="inner">
+        Transform your surroundings with our latest art collection, where imagination meets technique. Elevate your space with pieces that blend artistic expression and aesthetic beauty effortlessly.
+    </xpath>
+</template>
+
+</odoo>

--- a/theme_avantgarde/views/customizations.xml
+++ b/theme_avantgarde/views/customizations.xml
@@ -403,4 +403,17 @@
     </xpath>
 </template>
 
+<!-- ======== IMAGE TITLE ======== -->
+<template id="s_image_title" inherit_id="website.s_image_title">
+    <xpath expr="//section" position="attributes">
+        <attribute name="class" add="o_cc3" remove="o_cc5" separator=" "/>
+    </xpath>
+    <xpath expr="//h1" position="replace" mode="inner">
+        A Deep Dive into Boldness and Innovation
+    </xpath>
+    <xpath expr="//p[hasclass('lead')]" position="replace" mode="inner">
+        Transform your perspective with our groundbreaking collection, where unconventional meets visionary. Elevate your style with pieces that challenge norms and redefine creativity effortlessly.
+    </xpath>
+</template>
+
 </odoo>

--- a/theme_avantgarde/views/images_library.xml
+++ b/theme_avantgarde/views/images_library.xml
@@ -342,5 +342,10 @@ Check in images.scss, primary_variables.scss, main.scss and theme_common's mixin
     <field name="name">website.s_pricelist_boxed_default_background</field>
     <field name="url">/theme_avantgarde/static/src/img/pictures/s_pricelist_boxed_default_background.jpg</field>
 </record>
+<record id="s_image_title_default_image" model="theme.ir.attachment">
+    <field name="key">website.s_image_title_default_image</field>
+    <field name="name">website.s_image_title_default_image</field>
+    <field name="url">/theme_avantgarde/static/src/img/pictures/bg_image_30.jpg</field>
+</record>
 
 </odoo>

--- a/theme_aviato/__manifest__.py
+++ b/theme_aviato/__manifest__.py
@@ -16,6 +16,7 @@
         'views/snippets/s_features.xml',
         'views/snippets/s_image_text.xml',
         'views/snippets/s_freegrid.xml',
+        'views/snippets/s_image_title.xml',
         'views/snippets/s_text_image.xml',
         'views/snippets/s_image_punchy.xml',
         'views/snippets/s_three_columns.xml',

--- a/theme_aviato/views/images_library.xml
+++ b/theme_aviato/views/images_library.xml
@@ -212,5 +212,10 @@
     <field name="name">website.library_image_02</field>
     <field name="url">/theme_aviato/static/src/img/content/s_wall_04.jpg</field>
 </record>
+<record id="s_image_title_default_image" model="theme.ir.attachment">
+    <field name="key">website.s_image_title_default_image</field>
+    <field name="name">website.s_image_title_default_image</field>
+    <field name="url">/theme_aviato/static/src/img/content/s_banner.jpg</field>
+</record>
 
 </odoo>

--- a/theme_aviato/views/snippets/s_image_title.xml
+++ b/theme_aviato/views/snippets/s_image_title.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+
+<template id="s_image_title" inherit_id="website.s_image_title">
+    <xpath expr="//h1" position="replace" mode="inner">
+        A Deep Dive into Adventure and Discovery
+    </xpath>
+    <xpath expr="//p[hasclass('lead')]" position="replace" mode="inner">
+        Transform your journey with our exclusive travel experiences, where exploration meets comfort. Elevate your adventures with trips that blend excitement and relaxation seamlessly.
+    </xpath>
+</template>
+
+</odoo>

--- a/theme_beauty/__manifest__.py
+++ b/theme_beauty/__manifest__.py
@@ -22,6 +22,7 @@
         'views/snippets/s_banner.xml',
         'views/snippets/s_image_text.xml',
         'views/snippets/s_image_punchy.xml',
+        'views/snippets/s_image_title.xml',
         'views/snippets/s_numbers.xml',
         'views/snippets/s_picture.xml',
         'views/snippets/s_pricelist_boxed.xml',

--- a/theme_beauty/views/images.xml
+++ b/theme_beauty/views/images.xml
@@ -265,5 +265,10 @@ Check in theme_loftspace's primary_variables.scss and theme.scss -->
     <field name="name">website.s_image_hexagonal_default_image_1</field>
     <field name="url">/theme_beauty/static/src/img/snippets/s_image_hexagonal_1.jpg</field>
 </record>
+<record id="s_image_title_default_image" model="theme.ir.attachment">
+    <field name="key">website.s_image_title_default_image</field>
+    <field name="name">website.s_image_title_default_image</field>
+    <field name="url">/theme_beauty/static/src/img/snippets/s_carousel_1.jpg</field>
+</record>
 
 </odoo>

--- a/theme_beauty/views/snippets/s_image_title.xml
+++ b/theme_beauty/views/snippets/s_image_title.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+
+<template id="s_image_title" inherit_id="website.s_image_title">
+    <xpath expr="//h1" position="replace" mode="inner">
+        A Deep Dive into Beauty and Innovation
+    </xpath>
+    <xpath expr="//p[hasclass('lead')]" position="replace" mode="inner">
+        Transform your beauty routine with our new collection, where luxury meets effectiveness. Elevate your look with products that blend skincare and makeup seamlessly.
+    </xpath>
+</template>
+
+</odoo>

--- a/theme_bewise/views/customizations.xml
+++ b/theme_bewise/views/customizations.xml
@@ -640,4 +640,14 @@
     </xpath>
 </template>
 
+<!-- ======== IMAGE TITLE ======== -->
+<template id="s_image_title" inherit_id="website.s_image_title">
+    <xpath expr="//h1" position="replace" mode="inner">
+        A Deep Dive into Knowledge and Innovation
+    </xpath>
+    <xpath expr="//p[hasclass('lead')]" position="replace" mode="inner">
+        Transform your future with our cutting-edge programs, where education meets opportunity. Elevate your learning experience with courses that blend academic excellence and practical skills seamlessly.
+    </xpath>
+</template>
+
 </odoo>

--- a/theme_bewise/views/image_content.xml
+++ b/theme_bewise/views/image_content.xml
@@ -237,5 +237,10 @@
     <field name="name">website.s_pricelist_boxed_default_background</field>
     <field name="url">/theme_bewise/static/src/img/content/s_pricelist_boxed_default_background.jpg</field>
 </record>
+<record id="s_image_title_default_image" model="theme.ir.attachment">
+    <field name="key">website.s_image_title_default_image</field>
+    <field name="name">website.s_image_title_default_image</field>
+    <field name="url">/theme_bewise/static/src/img/backgrounds/college_bg.jpg</field>
+</record>
 
 </odoo>

--- a/theme_bistro/__manifest__.py
+++ b/theme_bistro/__manifest__.py
@@ -21,6 +21,7 @@
         'views/snippets/s_image_text.xml',
         'views/snippets/s_freegrid.xml',
         'views/snippets/s_image_punchy.xml',
+        'views/snippets/s_image_title.xml',
         'views/snippets/s_media_list.xml',
         'views/snippets/s_features_wall.xml',
         'views/snippets/s_numbers.xml',

--- a/theme_bistro/views/images_library.xml
+++ b/theme_bistro/views/images_library.xml
@@ -366,6 +366,11 @@
     <field name="name">website.s_accordion_image_default_image</field>
     <field name="url">/theme_bistro/static/src/img/backgrounds/20.jpg</field>
 </record>
+<record id="s_image_title_default_image" model="theme.ir.attachment">
+    <field name="key">website.s_image_title_default_image</field>
+    <field name="name">website.s_image_title_default_image</field>
+    <field name="url">/theme_bistro/static/src/img/backgrounds/14.jpg</field>
+</record>
 
 <!-- Pricelist boxed -->
 <record id="s_pricelist_boxed_default_background" model="theme.ir.attachment">

--- a/theme_bistro/views/snippets/s_image_title.xml
+++ b/theme_bistro/views/snippets/s_image_title.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+
+<template id="s_image_title" inherit_id="website.s_image_title">
+    <xpath expr="//h1" position="replace" mode="inner">
+        A Deep Dive into Flavor and Innovation
+    </xpath>
+    <xpath expr="//p[hasclass('lead')]" position="replace" mode="inner">
+        Transform your dining experience with our new menu, where classic dishes meet modern creativity. Elevate your palate with flavors that blend tradition and innovation seamlessly.
+    </xpath>
+</template>
+
+</odoo>

--- a/theme_bookstore/__manifest__.py
+++ b/theme_bookstore/__manifest__.py
@@ -20,6 +20,7 @@
         'views/snippets/s_call_to_action.xml',
         'views/snippets/s_cover.xml',
         'views/snippets/s_image_text.xml',
+        'views/snippets/s_image_title.xml',
         'views/snippets/s_showcase.xml',
         'views/snippets/s_freegrid.xml',
         'views/snippets/s_features_wall.xml',

--- a/theme_bookstore/views/images.xml
+++ b/theme_bookstore/views/images.xml
@@ -261,5 +261,10 @@ Check in theme_loftspace's primary_variables.scss and theme.scss -->
     <field name="name">website.s_accordion_image_default_image</field>
     <field name="url">/theme_bookstore/static/src/img/snippets/s_banner_2.jpg</field>
 </record>
+<record id="s_image_title_default_image" model="theme.ir.attachment">
+    <field name="key">website.s_image_title_default_image</field>
+    <field name="name">website.s_image_title_default_image</field>
+    <field name="url">/theme_bookstore/static/src/img/snippets/s_carousel_2.jpg</field>
+</record>
 
 </odoo>

--- a/theme_bookstore/views/snippets/s_image_title.xml
+++ b/theme_bookstore/views/snippets/s_image_title.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+
+<template id="s_image_title" inherit_id="website.s_image_title">
+    <xpath expr="//h1" position="replace" mode="inner">
+        A Deep Dive into Stories and Imagination
+    </xpath>
+    <xpath expr="//p[hasclass('lead')]" position="replace" mode="inner">
+        Transform your reading journey with our curated book collection, where timeless classics meet contemporary works. Elevate your mind with stories that blend knowledge and creativity seamlessly.
+    </xpath>
+</template>
+
+</odoo>

--- a/theme_buzzy/__manifest__.py
+++ b/theme_buzzy/__manifest__.py
@@ -49,6 +49,7 @@
         'views/snippets/s_pricelist_boxed.xml',
         'views/snippets/s_image_hexagonal.xml',
         'views/snippets/s_striped_center_top.xml',
+        'views/snippets/s_image_title.xml',
         'views/new_page_template.xml',
     ],
     'images': [

--- a/theme_buzzy/views/snippets/s_image_title.xml
+++ b/theme_buzzy/views/snippets/s_image_title.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+
+<template id="s_image_title" inherit_id="website.s_image_title">
+    <xpath expr="//section" position="attributes">
+        <attribute name="class" add="o_cc4" remove="o_cc5 oe_img_bg" separator=" "/>
+        <attribute name="style"/>
+        <attribute name="data-oe-shape-data">{'shape':'web_editor/Blobs/04','flip':[],'showOnMobile':false,'shapeAnimationSpeed':'0'}</attribute>
+    </xpath>
+    <xpath expr="//div[hasclass('container')]" position="before">
+        <div class="o_we_shape o_web_editor_Blobs_04"/>
+    </xpath>
+    <xpath expr="//div[hasclass('o_we_bg_filter')]" position="replace"/>
+</template>
+
+</odoo>

--- a/theme_clean/views/image_content.xml
+++ b/theme_clean/views/image_content.xml
@@ -192,5 +192,10 @@
     <field name="name">website.library_image_08</field>
     <field name="url">/theme_clean/static/src/img/content/image_content_39.jpg</field>
 </record>
+<record id="s_image_title_default_image" model="theme.ir.attachment">
+    <field name="key">website.s_image_title_default_image</field>
+    <field name="name">website.s_image_title_default_image</field>
+    <field name="url">/theme_clean/static/src/img/backgrounds/bg_snippet_05.jpg</field>
+</record>
 
 </odoo>

--- a/theme_cobalt/views/customizations.xml
+++ b/theme_cobalt/views/customizations.xml
@@ -434,4 +434,17 @@
     </xpath>
 </template>
 
+<!-- ======== IMAGE TITLE ======== -->
+<template id="s_image_title" inherit_id="website.s_image_title" name="Cobalt s_image_title">
+    <xpath expr="//section" position="attributes">
+        <attribute name="class" add="o_cc2" remove="o_cc5 oe_img_bg" separator=" "/>
+        <attribute name="style"/>
+        <attribute name="data-oe-shape-data">{'shape':'web_editor/Airy/10','flip':[],'showOnMobile':false,'shapeAnimationSpeed':'0'}</attribute>
+    </xpath>
+    <xpath expr="//div[hasclass('container')]" position="before">
+        <div class="o_we_shape o_web_editor_Airy_10"/>
+    </xpath>
+    <xpath expr="//div[hasclass('o_we_bg_filter')]" position="replace"/>
+</template>
+
 </odoo>

--- a/theme_enark/__manifest__.py
+++ b/theme_enark/__manifest__.py
@@ -24,6 +24,7 @@
         'views/snippets/s_parallax.xml',
         'views/snippets/s_image_gallery.xml',
         'views/snippets/s_features_wall.xml',
+        'views/snippets/s_image_title.xml',
         'views/snippets/s_unveil.xml',
         'views/snippets/s_key_benefits.xml',
         'views/snippets/s_carousel.xml',

--- a/theme_enark/views/image_library.xml
+++ b/theme_enark/views/image_library.xml
@@ -195,5 +195,10 @@
     <field name="name">website.s_pricelist_boxed_default_background</field>
     <field name="url">/theme_enark/static/src/img/snippets/s_pricelist_boxed_default_background.jpg</field>
 </record>
+<record id="s_image_title_default_image" model="theme.ir.attachment">
+    <field name="key">website.s_image_title_default_image</field>
+    <field name="name">website.s_image_title_default_image</field>
+    <field name="url">/theme_enark/static/src/img/snippets/library_image_10.jpg</field>
+</record>
 
 </odoo>

--- a/theme_enark/views/snippets/s_image_title.xml
+++ b/theme_enark/views/snippets/s_image_title.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+
+<template id="s_image_title" inherit_id="website.s_image_title">
+    <xpath expr="//h1" position="replace" mode="inner">
+        A Deep Dive into Design and Excellence
+    </xpath>
+    <xpath expr="//p[hasclass('lead')]" position="replace" mode="inner">
+        Transform your environment with our innovative building solutions, where architectural beauty meets structural integrity. Elevate your projects with designs that blend aesthetics and functionality seamlessly.
+    </xpath>
+</template>
+
+</odoo>

--- a/theme_graphene/views/customizations.xml
+++ b/theme_graphene/views/customizations.xml
@@ -436,4 +436,11 @@
     </xpath>
 </template>
 
+<!-- ======== IMAGE TITLE ======== -->
+<template id="s_image_title" inherit_id="website.s_image_title">
+    <xpath expr="//section" position="attributes">
+        <attribute name="class" add="o_cc3" remove="o_cc5" separator=" "/>
+    </xpath>
+</template>
+
 </odoo>

--- a/theme_graphene/views/images_library.xml
+++ b/theme_graphene/views/images_library.xml
@@ -354,6 +354,11 @@ Check in images.scss, primary_variables.scss, main.scss and theme_common's mixin
     <field name="name">website.s_accordion_image_default_image</field>
     <field name="url">/theme_graphene/static/src/img/pictures/content_06.jpg</field>
 </record>
+<record id="s_image_title_default_image" model="theme.ir.attachment">
+    <field name="key">website.s_image_title_default_image</field>
+    <field name="name">website.s_image_title_default_image</field>
+    <field name="url">/theme_graphene/static/src/img/pictures/content_01.jpg</field>
+</record>
 
 <record id="library_image_02" model="theme.ir.attachment">
     <field name="key">website.library_image_02</field>

--- a/theme_kea/__manifest__.py
+++ b/theme_kea/__manifest__.py
@@ -35,6 +35,7 @@
         'views/snippets/s_pricelist_boxed.xml',
         'views/snippets/s_image_hexagonal.xml',
         'views/snippets/s_striped_center_top.xml',
+        'views/snippets/s_image_title.xml',
         'views/new_page_template.xml',
     ],
     'images': [

--- a/theme_kea/views/images_content.xml
+++ b/theme_kea/views/images_content.xml
@@ -275,5 +275,10 @@ Check in primary_variables.scss, theme.scss and theme_common's mixins.scss -->
     <field name="name">website.s_accordion_image_default_image</field>
     <field name="url">/theme_kea/static/src/img/snippets/s_media_list_2.jpg</field>
 </record>
+<record id="s_image_title_default_image" model="theme.ir.attachment">
+    <field name="key">website.s_image_title_default_image</field>
+    <field name="name">website.s_image_title_default_image</field>
+    <field name="url">/theme_kea/static/src/img/snippets/s_color_blocks_1.jpg</field>
+</record>
 
 </odoo>

--- a/theme_kea/views/snippets/s_image_title.xml
+++ b/theme_kea/views/snippets/s_image_title.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+
+<template id="s_image_title" inherit_id="website.s_image_title">
+    <xpath expr="//section" position="attributes">
+        <attribute name="data-oe-shape-data">{'shape':'web_editor/Blobs/12','flip':[],'showOnMobile':false,'shapeAnimationSpeed':'0'}</attribute>
+    </xpath>
+    <xpath expr="//div[hasclass('container')]" position="before">
+        <div class="o_we_shape o_web_editor_Blobs_12"/>
+    </xpath>
+    <xpath expr="//h1" position="replace" mode="inner">
+        A Deep Dive into Virtual Reality and Innovation
+    </xpath>
+    <xpath expr="//p[hasclass('lead')]" position="replace" mode="inner">
+        Transform your digital experience with our latest VR solutions, where immersive technology meets creativity. Elevate your reality with experiences that blend innovation and interactivity seamlessly.
+    </xpath>
+</template>
+
+</odoo>

--- a/theme_kiddo/__manifest__.py
+++ b/theme_kiddo/__manifest__.py
@@ -35,6 +35,7 @@
         'views/snippets/s_pricelist_boxed.xml',
         'views/snippets/s_image_hexagonal.xml',
         'views/snippets/s_striped_center_top.xml',
+        'views/snippets/s_image_title.xml',
         'views/new_page_template.xml',
     ],
     'images': [

--- a/theme_kiddo/views/images_library.xml
+++ b/theme_kiddo/views/images_library.xml
@@ -249,5 +249,10 @@
     <field name="name">website.s_accordion_image_default_image</field>
     <field name="url">/theme_kiddo/static/src/img/snippets/library_image_14.jpg</field>
 </record>
+<record id="s_image_title_default_image" model="theme.ir.attachment">
+    <field name="key">website.s_image_title_default_image</field>
+    <field name="name">website.s_image_title_default_image</field>
+    <field name="url">/theme_kiddo/static/src/img/snippets/s_banner.jpg</field>
+</record>
 
 </odoo>

--- a/theme_kiddo/views/snippets/s_image_title.xml
+++ b/theme_kiddo/views/snippets/s_image_title.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+
+<template id="s_image_title" inherit_id="website.s_image_title">
+    <xpath expr="//section" position="attributes">
+        <attribute name="data-oe-shape-data">{'shape':'web_editor/Floats/12','flip':[],'showOnMobile':false,'shapeAnimationSpeed':'0','animated':'true'}</attribute>
+    </xpath>
+    <xpath expr="//div[hasclass('container')]" position="before">
+        <div class="o_we_shape o_web_editor_Floats_12 o_we_animated"/>
+    </xpath>
+    <xpath expr="//h1" position="replace" mode="inner">
+        A Deep Dive into Play and Learning
+    </xpath>
+    <xpath expr="//p[hasclass('lead')]" position="replace" mode="inner">
+        Transform your child’s day with our engaging programs, where fun meets discovery. Elevate their growth with activities that blend playfulness and learning seamlessly.
+    </xpath>
+</template>
+
+</odoo>

--- a/theme_loftspace/__manifest__.py
+++ b/theme_loftspace/__manifest__.py
@@ -21,6 +21,7 @@
         'views/snippets/s_freegrid.xml',
         'views/snippets/s_banner.xml',
         'views/snippets/s_image_text.xml',
+        'views/snippets/s_image_title.xml',
         'views/snippets/s_numbers.xml',
         'views/snippets/s_pricelist_boxed.xml',
         'views/snippets/s_color_blocks_2.xml',

--- a/theme_loftspace/views/images_content.xml
+++ b/theme_loftspace/views/images_content.xml
@@ -286,5 +286,10 @@ Check in primary_variables.scss and theme.scss -->
     <field name="name">website.s_pricelist_boxed_default_background</field>
     <field name="url">/theme_loftspace/static/src/img/snippets/s_pricelist_boxed_default_background.jpg</field>
 </record>
+<record id="s_image_title_default_image" model="theme.ir.attachment">
+    <field name="key">website.s_image_title_default_image</field>
+    <field name="name">website.s_image_title_default_image</field>
+    <field name="url">/theme_loftspace/static/src/img/snippets/s_banner.jpg</field>
+</record>
 
 </odoo>

--- a/theme_loftspace/views/snippets/s_image_title.xml
+++ b/theme_loftspace/views/snippets/s_image_title.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+
+<template id="s_image_title" inherit_id="website.s_image_title">
+    <xpath expr="//h1" position="replace" mode="inner">
+        A Deep Dive into Design and Craftsmanship
+    </xpath>
+    <xpath expr="//p[hasclass('lead')]" position="replace" mode="inner">
+        Transform your space with our exceptional furniture collection, where style meets functionality. Elevate your home with pieces that blend elegant design and quality craftsmanship seamlessly.
+    </xpath>
+</template>
+
+</odoo>

--- a/theme_monglia/views/customizations.xml
+++ b/theme_monglia/views/customizations.xml
@@ -470,5 +470,23 @@
     </xpath>
 </template>
 
+<!-- ======== IMAGE TITLE ======== -->
+<template id="s_image_title" inherit_id="website.s_image_title">
+    <xpath expr="//section" position="attributes">
+        <attribute name="class" remove="oe_img_bg" separator=" "/>
+        <attribute name="style"/>
+        <attribute name="data-oe-shape-data">{'shape':'web_editor/Bold/08','flip':[],'showOnMobile':false,'shapeAnimationSpeed':'0'}</attribute>
+    </xpath>
+    <xpath expr="//div[hasclass('container')]" position="before">
+        <div class="o_we_shape o_web_editor_Bold_08"/>
+    </xpath>
+    <xpath expr="//div[hasclass('o_we_bg_filter')]" position="replace"/>
+    <xpath expr="//h1" position="replace" mode="inner">
+        A Deep Dive into Fun and Innovation
+    </xpath>
+    <xpath expr="//p[hasclass('lead')]" position="replace" mode="inner">
+        Transform your experience with our vibrant festival lineup, where entertainment meets creativity. Elevate your celebration with events that blend excitement and artistry seamlessly.
+    </xpath>
+</template>
 
 </odoo>

--- a/theme_nano/views/images_library.xml
+++ b/theme_nano/views/images_library.xml
@@ -388,6 +388,11 @@
     <field name="name">website.library_image_08</field>
     <field name="url">/theme_nano/static/src/img/snippets/s_images_gallery_02.jpg</field>
 </record>
+<record id="s_image_title_default_image" model="theme.ir.attachment">
+    <field name="key">website.s_image_title_default_image</field>
+    <field name="name">website.s_image_title_default_image</field>
+    <field name="url">/theme_nano/static/src/img/snippets/s_masonry_block_2.jpg</field>
+</record>
 
 <!-- Pricelist Boxed -->
 <record id="s_pricelist_boxed_default_background" model="theme.ir.attachment">

--- a/theme_notes/__manifest__.py
+++ b/theme_notes/__manifest__.py
@@ -22,6 +22,7 @@
         'views/snippets/s_banner.xml',
         'views/snippets/s_cover.xml',
         'views/snippets/s_text_image.xml',
+        'views/snippets/s_image_title.xml',
         'views/snippets/s_numbers.xml',
         'views/snippets/s_three_columns.xml',
         'views/snippets/s_color_blocks_2.xml',

--- a/theme_notes/views/images_library.xml
+++ b/theme_notes/views/images_library.xml
@@ -262,5 +262,10 @@
     <field name="name">website.s_image_hexagonal_default_image_1</field>
     <field name="url">/theme_notes/static/src/img/content/s_image_hexagonal_1.jpg</field>
 </record>
+<record id="s_image_title_default_image" model="theme.ir.attachment">
+    <field name="key">website.s_image_title_default_image</field>
+    <field name="name">website.s_image_title_default_image</field>
+    <field name="url">/theme_notes/static/src/img/content/content_img_24.jpg</field>
+</record>
 
 </odoo>

--- a/theme_notes/views/snippets/s_image_title.xml
+++ b/theme_notes/views/snippets/s_image_title.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+
+<template id="s_image_title" inherit_id="website.s_image_title">
+    <xpath expr="//h1" position="replace" mode="inner">
+        A Deep Dive into Rock and Energy
+    </xpath>
+    <xpath expr="//p[hasclass('lead')]" position="replace" mode="inner">
+        Transform your experience with our electrifying rock festival, where powerful performances meet raw energy. Elevate your vibe with shows that blend intense music and unforgettable moments seamlessly.
+    </xpath>
+</template>
+
+</odoo>

--- a/theme_odoo_experts/__manifest__.py
+++ b/theme_odoo_experts/__manifest__.py
@@ -37,6 +37,7 @@
         'views/snippets/s_carousel.xml',
         'views/snippets/s_pricelist_boxed.xml',
         'views/snippets/s_striped_center_top.xml',
+        'views/snippets/s_image_title.xml',
         'views/new_page_template.xml',
     ],
     'images': [

--- a/theme_odoo_experts/views/snippets/s_image_title.xml
+++ b/theme_odoo_experts/views/snippets/s_image_title.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+
+<template id="s_image_title" inherit_id="website.s_image_title">
+    <xpath expr="//section" position="attributes">
+        <attribute name="class" add="o_cc1" remove="o_cc5 oe_img_bg" separator=" "/>
+        <attribute name="style"/>
+        <attribute name="data-oe-shape-data">{'shape':'web_editor/Origins/09_001','colors':{'c3':'o-color-3'},'flip':[],'showOnMobile':false,'shapeAnimationSpeed':'0'}</attribute>
+    </xpath>
+    <xpath expr="//div[hasclass('container')]" position="before">
+        <div class="o_we_shape o_web_editor_Origins_09_001" style="background-image: url('/web_editor/shape/web_editor%2FOrigins%2F09_001.svg?c3=o-color-3');"></div>
+    </xpath>
+    <xpath expr="//div[hasclass('o_we_bg_filter')]" position="replace"/>
+</template>
+
+</odoo>

--- a/theme_orchid/__manifest__.py
+++ b/theme_orchid/__manifest__.py
@@ -17,6 +17,7 @@
         'views/snippets/s_motto.xml',
         'views/snippets/s_image_text.xml',
         'views/snippets/s_image_punchy.xml',
+        'views/snippets/s_image_title.xml',
         'views/snippets/s_three_columns.xml',
         'views/snippets/s_quotes_carousel.xml',
         'views/snippets/s_features_wall.xml',

--- a/theme_orchid/views/images.xml
+++ b/theme_orchid/views/images.xml
@@ -235,5 +235,10 @@ Check in theme_loftspace's primary_variables.scss and theme.scss -->
     <field name="name">website.s_pricelist_boxed_default_background</field>
     <field name="url">/theme_orchid/static/src/img/snippets/s_pricelist_boxed_default_background.jpg</field>
 </record>
+<record id="s_image_title_default_image" model="theme.ir.attachment">
+    <field name="key">website.s_image_title_default_image</field>
+    <field name="name">website.s_image_title_default_image</field>
+    <field name="url">/theme_orchid/static/src/img/snippets/library_image_02.jpg</field>
+</record>
 
 </odoo>

--- a/theme_orchid/views/snippets/s_image_title.xml
+++ b/theme_orchid/views/snippets/s_image_title.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+
+<template id="s_image_title" inherit_id="website.s_image_title">
+    <xpath expr="//h1" position="replace" mode="inner">
+        A Deep Dive into Blooms and Beauty
+    </xpath>
+    <xpath expr="//p[hasclass('lead')]" position="replace" mode="inner">
+        Transform your space with our stunning floral arrangements, where elegance meets freshness. Elevate your environment with bouquets that blend natural beauty and artistic design seamlessly.
+    </xpath>
+</template>
+
+</odoo>

--- a/theme_paptic/views/customizations.xml
+++ b/theme_paptic/views/customizations.xml
@@ -631,5 +631,17 @@
     </xpath>
 </template>
 
+<!-- ==== Image Title ===== -->
+<template id="s_image_title" inherit_id="website.s_image_title" name="Paptic s_image_title">
+    <xpath expr="//section" position="attributes">
+        <attribute name="class" add="o_cc3" remove="o_cc5 oe_img_bg" separator=" "/>
+        <attribute name="style"/>
+        <attribute name="data-oe-shape-data">{'shape':'web_editor/Origins/02_001','flip':[],'showOnMobile':false,'shapeAnimationSpeed':'0'}</attribute>
+    </xpath>
+    <xpath expr="//div[hasclass('container')]" position="before">
+        <div class="o_we_shape o_web_editor_Origins_02_001"/>
+    </xpath>
+    <xpath expr="//div[hasclass('o_we_bg_filter')]" position="replace"/>
+</template>
 
 </odoo>

--- a/theme_real_estate/__manifest__.py
+++ b/theme_real_estate/__manifest__.py
@@ -15,6 +15,7 @@
         'views/snippets/s_banner.xml',
         'views/snippets/s_picture.xml',
         'views/snippets/s_image_text.xml',
+        'views/snippets/s_image_title.xml',
         'views/snippets/s_text_image.xml',
         'views/snippets/s_three_columns.xml',
         'views/snippets/s_quotes_carousel.xml',

--- a/theme_real_estate/views/images.xml
+++ b/theme_real_estate/views/images.xml
@@ -226,5 +226,10 @@ Check in theme_monglia's primary_variables.scss, theme.scss and theme_common's m
     <field name="name">website.library_image_08</field>
     <field name="url">/theme_real_estate/static/src/img/snippets/s_images_gallery_2.jpg</field>
 </record>
+<record id="s_image_title_default_image" model="theme.ir.attachment">
+    <field name="key">website.s_image_title_default_image</field>
+    <field name="name">website.s_image_title_default_image</field>
+    <field name="url">/theme_real_estate/static/src/img/snippets/s_banner.jpg</field>
+</record>
 
 </odoo>

--- a/theme_real_estate/views/snippets/s_image_title.xml
+++ b/theme_real_estate/views/snippets/s_image_title.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+
+<template id="s_image_title" inherit_id="website.s_image_title">
+    <xpath expr="//h1" position="replace" mode="inner">
+        A Deep Dive into Properties and Innovation
+    </xpath>
+    <xpath expr="//p[hasclass('lead')]" position="replace" mode="inner">
+        Transform your real estate journey with our exceptional listings, where modern design meets practicality. Elevate your property search with options that blend style and functionality seamlessly.
+    </xpath>
+</template>
+
+</odoo>

--- a/theme_treehouse/__manifest__.py
+++ b/theme_treehouse/__manifest__.py
@@ -21,6 +21,7 @@
         'views/snippets/s_faq_collapse.xml',
         'views/snippets/s_features.xml',
         'views/snippets/s_image_text.xml',
+        'views/snippets/s_image_title.xml',
         'views/snippets/s_media_list.xml',
         'views/snippets/s_picture.xml',
         'views/snippets/s_freegrid.xml',

--- a/theme_treehouse/views/images_library.xml
+++ b/theme_treehouse/views/images_library.xml
@@ -298,5 +298,10 @@
     <field name="name">website.s_pricelist_boxed_default_background</field>
     <field name="url">/theme_treehouse/static/src/img/backgrounds/s_pricelist_boxed_default_background.jpg</field>
 </record>
+<record id="s_image_title_default_image" model="theme.ir.attachment">
+    <field name="key">website.s_image_title_default_image</field>
+    <field name="name">website.s_image_title_default_image</field>
+    <field name="url">/theme_treehouse/static/src/img/backgrounds/02.jpg</field>
+</record>
 
 </odoo>

--- a/theme_treehouse/views/snippets/s_image_title.xml
+++ b/theme_treehouse/views/snippets/s_image_title.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+
+<template id="s_image_title" inherit_id="website.s_image_title">
+    <xpath expr="//h1" position="replace" mode="inner">
+        A Deep Dive into Conservation and Impact
+    </xpath>
+    <xpath expr="//p[hasclass('lead')]" position="replace" mode="inner">
+        Transform your environmental efforts with our dedicated initiatives, where protection meets sustainability. Elevate your impact with projects that blend ecological responsibility and effective conservation seamlessly.
+    </xpath>
+</template>
+
+</odoo>

--- a/theme_vehicle/views/customizations.xml
+++ b/theme_vehicle/views/customizations.xml
@@ -588,5 +588,17 @@
     </xpath>
 </template>
 
+<!-- ======== IMAGE TITLE ======== -->
+<template id="s_image_title" inherit_id="website.s_image_title">
+    <xpath expr="//div[hasclass('o_we_bg_filter')]" position="attributes">
+        <attribute name="class" add="bg-black-75" remove="bg-black-50" separator=" "/>
+    </xpath>
+    <xpath expr="//h1" position="replace" mode="inner">
+        A Deep Dive into Luxury and Innovation
+    </xpath>
+    <xpath expr="//p[hasclass('lead')]" position="replace" mode="inner">
+        Transform your driving experience with our exclusive collection, where opulence meets cutting-edge technology. Elevate your journey with vehicles that blend sophistication and performance seamlessly.
+    </xpath>
+</template>
 
 </odoo>

--- a/theme_vehicle/views/images.xml
+++ b/theme_vehicle/views/images.xml
@@ -230,5 +230,10 @@ Check in theme_monglia's primary_variables.scss, theme.scss and theme_common's m
     <field name="name">website.s_pricelist_boxed_default_background</field>
     <field name="url">/theme_vehicle/static/src/img/snippets/s_pricelist_boxed_default_background.jpg</field>
 </record>
+<record id="s_image_title_default_image" model="theme.ir.attachment">
+    <field name="key">website.s_image_title_default_image</field>
+    <field name="name">website.s_image_title_default_image</field>
+    <field name="url">/theme_vehicle/static/src/img/snippets/s_cover.jpg</field>
+</record>
 
 </odoo>

--- a/theme_yes/__manifest__.py
+++ b/theme_yes/__manifest__.py
@@ -18,6 +18,7 @@
         'views/snippets/s_company_team.xml',
         'views/snippets/s_cover.xml',
         'views/snippets/s_image_text.xml',
+        'views/snippets/s_image_title.xml',
         'views/snippets/s_image_gallery.xml',
         'views/snippets/s_images_wall.xml',
         'views/snippets/s_image_punchy.xml',

--- a/theme_yes/views/images.xml
+++ b/theme_yes/views/images.xml
@@ -316,5 +316,11 @@ Check in theme_kea's primary_variables.scss, theme.scss and theme_common's mixin
     <field name="name">website.s_image_hexagonal_default_image_1</field>
     <field name="url">/theme_yes/static/src/img/snippets/s_image_hexagonal_1.jpg</field>
 </record>
+<!-- // Image Title // -->
+<record id="s_image_title_default_image" model="theme.ir.attachment">
+    <field name="key">website.s_image_title_default_image</field>
+    <field name="name">website.s_image_title_default_image</field>
+    <field name="url">/theme_yes/static/src/img/snippets/s_quotes_carousel_3.jpg</field>
+</record>
 
 </odoo>

--- a/theme_yes/views/snippets/s_image_title.xml
+++ b/theme_yes/views/snippets/s_image_title.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+
+<template id="s_image_title" inherit_id="website.s_image_title">
+    <xpath expr="//h1" position="replace" mode="inner">
+        A Deep Dive into Romance and Excellence
+    </xpath>
+    <xpath expr="//p[hasclass('lead')]" position="replace" mode="inner">
+        Transform your special day with our bespoke wedding services, where elegance meets personalized touches. Elevate your celebration with arrangements that blend sophistication and love seamlessly.
+    </xpath>
+</template>
+
+</odoo>

--- a/theme_zap/__manifest__.py
+++ b/theme_zap/__manifest__.py
@@ -30,6 +30,7 @@
         'views/snippets/s_key_benefits.xml',
         'views/snippets/s_pricelist_boxed.xml',
         'views/snippets/s_striped_center_top.xml',
+        'views/snippets/s_image_title.xml',
         'views/new_page_template.xml',
     ],
     'images': [

--- a/theme_zap/views/images_library.xml
+++ b/theme_zap/views/images_library.xml
@@ -293,4 +293,11 @@
     <field name="url">/theme_zap/static/src/img/backgrounds/04.jpg</field>
 </record>
 
+<!-- Image Title -->
+<record id="s_image_title_default_image" model="theme.ir.attachment">
+    <field name="key">website.s_image_title_default_image</field>
+    <field name="name">website.s_image_title_default_image</field>
+    <field name="url">/theme_zap/static/src/img/backgrounds/01.jpg</field>
+</record>
+
 </odoo>

--- a/theme_zap/views/snippets/s_image_title.xml
+++ b/theme_zap/views/snippets/s_image_title.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+
+<template id="s_image_title" inherit_id="website.s_image_title">
+    <xpath expr="//section" position="attributes">
+        <attribute name="class" add="o_cc4" remove="o_cc5" separator=" "/>
+    </xpath>
+</template>
+
+</odoo>


### PR DESCRIPTION
*: theme_artists, theme_avantgarde, theme_aviato, theme_beauty, theme_bewise, theme_bistro, theme_bookstore, theme_buzzy, theme_clean, theme_cobalt, theme_enark, theme_graphene, theme_kea, theme_kiddo, theme_monglia, theme_nano, theme_notes, theme_odoo_experts, theme_orchid, theme_paptic, theme_real_estate, theme_treehouse, theme_vehicle, theme_yes, theme_zap, theme_loftspace

This commit adapts customizations for `s_image_title`, added in https://github.com/odoo/odoo/pull/176631

task-4105319
Part of task-4077427

Requires:
- https://github.com/odoo/odoo/pull/176631