### PR TITLE
[IMP] theme_*: adapt themes with new `s_striped_centertop` snippet

### DIFF
--- a/theme_anelusia/__manifest__.py
+++ b/theme_anelusia/__manifest__.py
@@ -39,6 +39,7 @@
         'views/snippets/s_numbers_showcase.xml',
         'views/snippets/s_accordion_image.xml',
         'views/snippets/s_pricelist_boxed.xml',
+        'views/snippets/s_striped_center_top.xml',
         'views/new_page_template.xml',
     ],
     'images': [

--- a/theme_anelusia/views/snippets/s_striped_center_top.xml
+++ b/theme_anelusia/views/snippets/s_striped_center_top.xml
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+
+<template id="s_striped_center_top" inherit_id="website.s_striped_center_top">
+    <!-- Title -->
+    <xpath expr="//h1" position="replace" mode="inner">
+        Embrace the Future of Fashion
+    </xpath>
+    <!-- Paragraph -->
+    <xpath expr="//p[hasclass('lead')]" position="replace" mode="inner">
+        Discover the latest trends in fashion, sports, and fitness, designed to empower your unique style and elevate your active lifestyle.
+    </xpath>
+    <!-- Button -->
+    <xpath expr="//a[hasclass('btn')]/t" position="replace" mode="inner">
+        Shop Now
+    </xpath>
+    <!-- Figcaption -->
+    <xpath expr="//figcaption" position="replace" mode="inner">
+        Crafted with passion for every season
+    </xpath>
+</template>
+
+</odoo>

--- a/theme_artists/__manifest__.py
+++ b/theme_artists/__manifest__.py
@@ -41,6 +41,7 @@
         'views/snippets/s_image_hexagonal.xml',
         'views/snippets/s_key_benefits.xml',
         'views/snippets/s_pricelist_boxed.xml',
+        'views/snippets/s_striped_center_top.xml',
         'views/new_page_template.xml',
     ],
     'images': [

--- a/theme_artists/views/snippets/s_striped_center_top.xml
+++ b/theme_artists/views/snippets/s_striped_center_top.xml
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+
+<template id="s_striped_center_top" inherit_id="website.s_striped_center_top">
+    <!-- Title -->
+    <xpath expr="//h1" position="replace" mode="inner">
+        Unleash Your Creative
+    </xpath>
+    <!-- Paragraph -->
+    <xpath expr="//p[hasclass('lead')]" position="replace" mode="inner">
+        Dive into a world of creativity where art meets innovation, and find inspiration through galleries, exhibitions, and unique artistic expressions.
+    </xpath>
+    <!-- Button -->
+    <xpath expr="//a[hasclass('btn')]/t" position="replace" mode="inner">
+        Explore Now
+    </xpath>
+    <!-- Figcaption -->
+    <xpath expr="//figcaption" position="replace" mode="inner">
+        Art that speaks to your soul
+    </xpath>
+</template>
+
+</odoo>

--- a/theme_avantgarde/views/customizations.xml
+++ b/theme_avantgarde/views/customizations.xml
@@ -383,5 +383,24 @@
         Artistic portrait photography with creative lighting and backgrounds, ideal for personal projects or portfolio work.
     </xpath>
 </template>
+ <!-- ======== STRIPED CENTER TOP ======== -->
+<template id="s_striped_center_top" inherit_id="website.s_striped_center_top">
+    <!-- Title -->
+    <xpath expr="//h1" position="replace" mode="inner">
+        Design Your World with Creativity
+    </xpath>
+    <!-- Paragraph -->
+    <xpath expr="//p[hasclass('lead')]" position="replace" mode="inner">
+        Stay ahead with cutting-edge design trends, fine art, and creative inspirations that shape the future of galleries, shows, and digital media.
+    </xpath>
+    <!-- Button -->
+    <xpath expr="//a[hasclass('btn')]/t" position="replace" mode="inner">
+        Discover More
+    </xpath>
+    <!-- Figcaption -->
+    <xpath expr="//figcaption" position="replace" mode="inner">
+        Where creativity knows no bounds
+    </xpath>
+</template>
 
 </odoo>

--- a/theme_aviato/__manifest__.py
+++ b/theme_aviato/__manifest__.py
@@ -23,6 +23,7 @@
         'views/snippets/s_title.xml',
         'views/snippets/s_quotes_carousel.xml',
         'views/snippets/s_features_wall.xml',
+        'views/snippets/s_striped_center_top.xml',
         'views/snippets/s_unveil.xml',
         'views/snippets/s_accordion_image.xml',
         'views/snippets/s_key_benefits.xml',

--- a/theme_aviato/views/snippets/s_striped_center_top.xml
+++ b/theme_aviato/views/snippets/s_striped_center_top.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+
+<template id="s_striped_center_top" inherit_id="website.s_striped_center_top">
+    <!-- Title -->
+    <xpath expr="//h1" position="replace" mode="inner">
+        Adventure Awaits
+    </xpath>
+    <!-- Paragraph -->
+    <xpath expr="//p[hasclass('lead')]" position="replace" mode="inner">
+        Embark on unforgettable journeys with our tailored travel experiences, designed to explore the world’s most breathtaking destinations.
+    </xpath>
+    <!-- Button -->
+    <xpath expr="//a[hasclass('btn')]/t" position="replace" mode="inner">
+        Book Your Trip
+    </xpath>
+    <!-- Figcaption -->
+    <xpath expr="//figcaption" position="replace" mode="inner">
+        Your gateway to the world
+    </xpath>
+    <!-- Image -->
+    <xpath expr="//img" position="attributes">
+        <attribute name="src">/web/image/website.s_popup_default_image</attribute>
+    </xpath>
+</template>
+
+</odoo>

--- a/theme_beauty/__manifest__.py
+++ b/theme_beauty/__manifest__.py
@@ -36,6 +36,7 @@
         'views/snippets/s_key_benefits.xml',
         'views/snippets/s_carousel.xml',
         'views/snippets/s_image_hexagonal.xml',
+        'views/snippets/s_striped_center_top.xml',
         'views/new_page_template.xml',
     ],
     'images': [

--- a/theme_beauty/views/snippets/s_striped_center_top.xml
+++ b/theme_beauty/views/snippets/s_striped_center_top.xml
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+
+<template id="s_striped_center_top" inherit_id="website.s_striped_center_top">
+    <!-- Title -->
+    <xpath expr="//h1" position="replace" mode="inner">
+        Embrace Your Genuine Glow
+    </xpath>
+    <!-- Paragraph -->
+    <xpath expr="//p[hasclass('lead')]" position="replace" mode="inner">
+        Indulge in the finest beauty and health products, where expert care meets luxurious cosmetics to enhance your natural glow.
+    </xpath>
+    <!-- Button -->
+    <xpath expr="//a[hasclass('btn')]/t" position="replace" mode="inner">
+        Get the Look
+    </xpath>
+    <!-- Figcaption -->
+    <xpath expr="//figcaption" position="replace" mode="inner">
+        Beauty perfected with care
+    </xpath>
+</template>
+
+</odoo>

--- a/theme_bewise/views/customizations.xml
+++ b/theme_bewise/views/customizations.xml
@@ -605,4 +605,28 @@
     </xpath>
 </template>
 
+<!-- ======== STRIPED CENTER TOP ======== -->
+<template id="s_striped_center_top" inherit_id="website.s_striped_center_top">
+    <!-- Section -->
+    <xpath expr="//section" position="attributes">
+        <attribute name="class" add="o_cc3" remove="o_cc5" separator=" "/>
+    </xpath>
+    <!-- Title -->
+    <xpath expr="//h1" position="replace" mode="inner">
+        Shaping Tomorrow's <br/>Game Changers
+    </xpath>
+    <!-- Paragraph -->
+    <xpath expr="//p[hasclass('lead')]" position="replace" mode="inner">
+        Empower young minds with quality education and engaging learning experiences that nurture creativity, play, and academic excellence.
+    </xpath>
+    <!-- Button -->
+    <xpath expr="//a[hasclass('btn')]/t" position="replace" mode="inner">
+        Enroll Today
+    </xpath>
+    <!-- Figcaption -->
+    <xpath expr="//figcaption" position="replace" mode="inner">
+        Where learning meets fun
+    </xpath>
+</template>
+
 </odoo>

--- a/theme_bistro/__manifest__.py
+++ b/theme_bistro/__manifest__.py
@@ -32,6 +32,7 @@
         'views/snippets/s_key_benefits.xml',
         'views/snippets/s_carousel.xml',
         'views/snippets/s_image_hexagonal.xml',
+        'views/snippets/s_striped_center_top.xml',
         'views/new_page_template.xml',
 
     ],

--- a/theme_bistro/views/snippets/s_striped_center_top.xml
+++ b/theme_bistro/views/snippets/s_striped_center_top.xml
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+
+<template id="s_striped_center_top" inherit_id="website.s_striped_center_top">
+    <!-- Title -->
+    <xpath expr="//h1" position="replace" mode="inner">
+        Taste the Difference
+    </xpath>
+    <!-- Paragraph -->
+    <xpath expr="//p[hasclass('lead')]" position="replace" mode="inner">
+        Savor the finest culinary delights at our bistro, where exceptional food meets an unforgettable dining experience.
+    </xpath>
+    <!-- Button -->
+    <xpath expr="//a[hasclass('btn')]/t" position="replace" mode="inner">
+        Reserve Your Table
+    </xpath>
+    <!-- Figcaption -->
+    <xpath expr="//figcaption" position="replace" mode="inner">
+        Crafted with flavors of passion
+    </xpath>
+</template>
+
+</odoo>

--- a/theme_bookstore/__manifest__.py
+++ b/theme_bookstore/__manifest__.py
@@ -38,6 +38,7 @@
         'views/snippets/s_carousel.xml',
         'views/snippets/s_pricelist_boxed.xml',
         'views/snippets/s_image_hexagonal.xml',
+        'views/snippets/s_striped_center_top.xml',
         'views/new_page_template.xml',
     ],
     'images': [

--- a/theme_bookstore/views/snippets/s_striped_center_top.xml
+++ b/theme_bookstore/views/snippets/s_striped_center_top.xml
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+
+<template id="s_striped_center_top" inherit_id="website.s_striped_center_top">
+    <!-- Title -->
+    <xpath expr="//h1" position="replace" mode="inner">
+        A World of Knowledge Awaits
+    </xpath>
+    <!-- Paragraph -->
+    <xpath expr="//p[hasclass('lead')]" position="replace" mode="inner">
+        Immerse yourself in a rich collection of books, magazines, and media that inspire learning, imagination, and creativity.
+    </xpath>
+    <!-- Button -->
+    <xpath expr="//a[hasclass('btn')]/t" position="replace" mode="inner">
+        Browse the Collection
+    </xpath>
+    <!-- Figcaption -->
+    <xpath expr="//figcaption" position="replace" mode="inner">
+        Knowledge curated with care
+    </xpath>
+</template>
+
+</odoo>

--- a/theme_buzzy/__manifest__.py
+++ b/theme_buzzy/__manifest__.py
@@ -48,6 +48,7 @@
         'views/snippets/s_carousel.xml',
         'views/snippets/s_pricelist_boxed.xml',
         'views/snippets/s_image_hexagonal.xml',
+        'views/snippets/s_striped_center_top.xml',
         'views/new_page_template.xml',
     ],
     'images': [

--- a/theme_buzzy/views/snippets/s_striped_center_top.xml
+++ b/theme_buzzy/views/snippets/s_striped_center_top.xml
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+
+<template id="s_striped_center_top" inherit_id="website.s_striped_center_top">
+    <!-- Title -->
+    <xpath expr="//h1" position="replace" mode="inner">
+        Innovative Solutions for Your Business
+    </xpath>
+    <!-- Paragraph -->
+    <xpath expr="//p[hasclass('lead')]" position="replace" mode="inner">
+        Drive success with our cutting-edge corporate services, blending technology and creative design to deliver impactful results.
+    </xpath>
+    <!-- Button -->
+    <xpath expr="//a[hasclass('btn')]/t" position="replace" mode="inner">
+        Get Started
+    </xpath>
+    <!-- Figcaption -->
+    <xpath expr="//figcaption" position="replace" mode="inner">
+        Solutions crafted with precision
+    </xpath>
+</template>
+
+</odoo>

--- a/theme_clean/__manifest__.py
+++ b/theme_clean/__manifest__.py
@@ -29,6 +29,7 @@
         'views/snippets/s_unveil.xml',
         'views/snippets/s_key_benefits.xml',
         'views/snippets/s_pricelist_boxed.xml',
+        'views/snippets/s_striped_center_top.xml',
         'views/new_page_template.xml',
     ],
     'images': [

--- a/theme_clean/views/snippets/s_striped_center_top.xml
+++ b/theme_clean/views/snippets/s_striped_center_top.xml
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+
+<template id="s_striped_center_top" inherit_id="website.s_striped_center_top">
+    <!-- Title -->
+    <xpath expr="//h1" position="replace" mode="inner">
+        Expert Legal Services for <br/>Business Success
+    </xpath>
+    <!-- Paragraph -->
+    <xpath expr="//p[hasclass('lead')]" position="replace" mode="inner">
+        Navigate the complexities of the business world with our expert legal services, tailored to ensure your corporate success.
+    </xpath>
+    <!-- Button -->
+    <xpath expr="//a[hasclass('btn')]/t" position="replace" mode="inner">
+        Learn More
+    </xpath>
+    <!-- Figcaption -->
+    <xpath expr="//figcaption" position="replace" mode="inner">
+        Trust, integrity, and results
+    </xpath>
+</template>
+
+</odoo>

--- a/theme_cobalt/views/customizations.xml
+++ b/theme_cobalt/views/customizations.xml
@@ -403,4 +403,28 @@
     </xpath>
 </template>
 
+<!-- ======== STRIPED CENTER TOP ======== -->
+<template id="s_striped_center_top" inherit_id="website.s_striped_center_top">
+    <!-- Section -->
+    <xpath expr="//section" position="attributes">
+        <attribute name="class" remove="o_cc5" add="o_cc3" separator=" "/>
+    </xpath>
+    <!-- Title -->
+    <xpath expr="//h1" position="replace" mode="inner">
+        Innovative IT Solutions for Your Growth
+    </xpath>
+    <!-- Paragraph -->
+    <xpath expr="//p[hasclass('lead')]" position="replace" mode="inner">
+        Transform your business with cutting-edge IT development and design solutions that drive efficiency and growth.
+    </xpath>
+    <!-- Button -->
+    <xpath expr="//a[hasclass('btn')]/t" position="replace" mode="inner">
+        Discover Our Services
+    </xpath>
+    <!-- Figcaption -->
+    <xpath expr="//figcaption" position="replace" mode="inner">
+        Technology that drives success
+    </xpath>
+</template>
+
 </odoo>

--- a/theme_enark/__manifest__.py
+++ b/theme_enark/__manifest__.py
@@ -27,6 +27,7 @@
         'views/snippets/s_unveil.xml',
         'views/snippets/s_key_benefits.xml',
         'views/snippets/s_carousel.xml',
+        'views/snippets/s_striped_center_top.xml',
         'views/new_page_template.xml',
     ],
     'images': [

--- a/theme_enark/views/snippets/s_striped_center_top.xml
+++ b/theme_enark/views/snippets/s_striped_center_top.xml
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+
+<template id="s_striped_center_top" inherit_id="website.s_striped_center_top">
+    <!-- Title -->
+    <xpath expr="//h1" position="replace" mode="inner">
+        Redefining Spaces with Architectural Innovation
+    </xpath>
+    <!-- Paragraph -->
+    <xpath expr="//p[hasclass('lead')]" position="replace" mode="inner">
+        Elevate your corporate space with innovative architectural solutions that blend functionality and aesthetics.
+    </xpath>
+    <!-- Button -->
+    <xpath expr="//a[hasclass('btn')]/t" position="replace" mode="inner">
+        Start Your Project
+    </xpath>
+    <!-- Figcaption -->
+    <xpath expr="//figcaption" position="replace" mode="inner">
+        Design that defines your vision
+    </xpath>
+</template>
+
+</odoo>

--- a/theme_graphene/views/customizations.xml
+++ b/theme_graphene/views/customizations.xml
@@ -416,4 +416,24 @@
     </xpath>
 </template>
 
+<!-- ======== STRIPED CENTER TOP ======== -->
+<template id="s_striped_center_top" inherit_id="website.s_striped_center_top">
+    <!-- Title -->
+    <xpath expr="//h1" position="replace" mode="inner">
+        Robotics and Technology Driving Innovation
+    </xpath>
+    <!-- Paragraph -->
+    <xpath expr="//p[hasclass('lead')]" position="replace" mode="inner">
+        Lead the future with cutting-edge robotics and technology solutions, designed to revolutionize your business operations.
+    </xpath>
+    <!-- Button -->
+    <xpath expr="//a[hasclass('btn')]/t" position="replace" mode="inner">
+        Explore Our Technology
+    </xpath>
+    <!-- Figcaption -->
+    <xpath expr="//figcaption" position="replace" mode="inner">
+        Innovation through advanced tech
+    </xpath>
+</template>
+
 </odoo>

--- a/theme_kea/__manifest__.py
+++ b/theme_kea/__manifest__.py
@@ -33,6 +33,7 @@
         'views/snippets/s_quotes_carousel.xml',
         'views/snippets/s_pricelist_boxed.xml',
         'views/snippets/s_image_hexagonal.xml',
+        'views/snippets/s_striped_center_top.xml',
         'views/new_page_template.xml',
     ],
     'images': [

--- a/theme_kea/views/snippets/s_striped_center_top.xml
+++ b/theme_kea/views/snippets/s_striped_center_top.xml
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+
+<template id="s_striped_center_top" inherit_id="website.s_striped_center_top">
+    <!-- Title -->
+    <xpath expr="//h1" position="replace" mode="inner">
+        Virtual Reality: The Future of Technology
+    </xpath>
+    <!-- Paragraph -->
+    <xpath expr="//p[hasclass('lead')]" position="replace" mode="inner">
+        Experience the future with immersive virtual reality solutions that transform how you interact with technology and the world.
+    </xpath>
+    <!-- Button -->
+    <xpath expr="//a[hasclass('btn')]/t" position="replace" mode="inner">
+        Dive Into VR
+    </xpath>
+    <!-- Figcaption -->
+    <xpath expr="//figcaption" position="replace" mode="inner">
+        Reality redefined with VR
+    </xpath>
+</template>
+
+</odoo>

--- a/theme_kiddo/__manifest__.py
+++ b/theme_kiddo/__manifest__.py
@@ -32,6 +32,7 @@
         'views/snippets/s_carousel.xml',
         'views/snippets/s_pricelist_boxed.xml',
         'views/snippets/s_image_hexagonal.xml',
+        'views/snippets/s_striped_center_top.xml',
         'views/new_page_template.xml',
     ],
     'images': [

--- a/theme_kiddo/views/snippets/s_striped_center_top.xml
+++ b/theme_kiddo/views/snippets/s_striped_center_top.xml
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+
+<template id="s_striped_center_top" inherit_id="website.s_striped_center_top">
+    <!-- Title -->
+    <xpath expr="//h1" position="replace" mode="inner">
+        Imaginative Playgrounds, Games and Costumes for Kids
+    </xpath>
+    <!-- Paragraph -->
+    <xpath expr="//p[hasclass('lead')]" position="replace" mode="inner">
+        Dive into a world where playgrounds come to life and costumes turn dreams into reality, sparking endless adventures for kids of all ages.
+    </xpath>
+    <!-- Button -->
+    <xpath expr="//a[hasclass('btn')]/t" position="replace" mode="inner">
+        Explore the Fun
+    </xpath>
+    <!-- Figcaption -->
+    <xpath expr="//figcaption" position="replace" mode="inner">
+        Where every child becomes the hero of their story
+    </xpath>
+</template>
+
+</odoo>

--- a/theme_loftspace/__manifest__.py
+++ b/theme_loftspace/__manifest__.py
@@ -33,6 +33,7 @@
         'views/snippets/s_unveil.xml',
         'views/snippets/s_key_benefits.xml',
         'views/snippets/s_carousel.xml',
+        'views/snippets/s_striped_center_top.xml',
         'views/new_page_template.xml',
     ],
     'images': [

--- a/theme_loftspace/views/snippets/s_striped_center_top.xml
+++ b/theme_loftspace/views/snippets/s_striped_center_top.xml
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+
+<template id="s_striped_center_top" inherit_id="website.s_striped_center_top">
+    <!-- Title -->
+    <xpath expr="//h1" position="replace" mode="inner">
+        Elegant Furniture for a Stylish Home
+    </xpath>
+    <!-- Paragraph -->
+    <xpath expr="//p[hasclass('lead')]" position="replace" mode="inner">
+        Create a beautiful home with our curated selection of furniture that combines comfort, style, and quality.
+    </xpath>
+    <!-- Button -->
+    <xpath expr="//a[hasclass('btn')]/t" position="replace" mode="inner">
+        Furnish Your Home
+    </xpath>
+    <!-- Figcaption -->
+    <xpath expr="//figcaption" position="replace" mode="inner">
+        Elegance in every piece
+    </xpath>
+</template>
+
+</odoo>

--- a/theme_monglia/views/customizations.xml
+++ b/theme_monglia/views/customizations.xml
@@ -450,4 +450,25 @@
     </xpath>
 </template>
 
+<!-- ======== STRIPED CENTER TOP ======== -->
+<template id="s_striped_center_top" inherit_id="website.s_striped_center_top">
+    <!-- Title -->
+    <xpath expr="//h1" position="replace" mode="inner">
+        Savor the Night: Food, Fun, and Music
+    </xpath>
+    <!-- Paragraph -->
+    <xpath expr="//p[hasclass('lead')]" position="replace" mode="inner">
+        Experience unforgettable moments with our events, offering a blend of food, music, and entertainment to elevate your nights.
+    </xpath>
+    <!-- Button -->
+    <xpath expr="//a[hasclass('btn')]/t" position="replace" mode="inner">
+        Plan Your Night Out
+    </xpath>
+    <!-- Figcaption -->
+    <xpath expr="//figcaption" position="replace" mode="inner">
+        Where every moment counts
+    </xpath>
+</template>
+
+
 </odoo>

--- a/theme_nano/__manifest__.py
+++ b/theme_nano/__manifest__.py
@@ -28,6 +28,7 @@
         'views/snippets/s_unveil.xml',
         'views/snippets/s_numbers_showcase.xml',
         'views/snippets/s_key_benefits.xml',
+        'views/snippets/s_striped_center_top.xml',
         'views/new_page_template.xml',
     ],
     'images': [

--- a/theme_nano/views/snippets/s_striped_center_top.xml
+++ b/theme_nano/views/snippets/s_striped_center_top.xml
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+
+<template id="s_striped_center_top" inherit_id="website.s_striped_center_top">
+    <!-- Title -->
+    <xpath expr="//h1" position="replace" mode="inner">
+        Creative Solutions for Agencies
+    </xpath>
+    <!-- Paragraph -->
+    <xpath expr="//p[hasclass('lead')]" position="replace" mode="inner">
+        Partner with us for innovative design and IT services that bring your creative visions to life in the digital world.
+    </xpath>
+    <!-- Button -->
+    <xpath expr="//a[hasclass('btn')]/t" position="replace" mode="inner">
+        Discover Our Services
+    </xpath>
+    <!-- Figcaption -->
+    <xpath expr="//figcaption" position="replace" mode="inner">
+        Creativity that drives success
+    </xpath>
+</template>
+
+</odoo>

--- a/theme_notes/__manifest__.py
+++ b/theme_notes/__manifest__.py
@@ -38,6 +38,7 @@
         'views/snippets/s_key_benefits.xml',
         'views/snippets/s_pricelist_boxed.xml',
         'views/snippets/s_image_hexagonal.xml',
+        'views/snippets/s_striped_center_top.xml',
         'views/new_page_template.xml',
     ],
     'images': [

--- a/theme_notes/views/snippets/s_striped_center_top.xml
+++ b/theme_notes/views/snippets/s_striped_center_top.xml
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+
+<template id="s_striped_center_top" inherit_id="website.s_striped_center_top">
+    <!-- Title -->
+    <xpath expr="//h1" position="replace" mode="inner">
+        Unleash the Power of Live Music
+    </xpath>
+    <!-- Paragraph -->
+    <xpath expr="//p[hasclass('lead')]" position="replace" mode="inner">
+        Experience the thrill of live music with our curated events, featuring top artists and unforgettable performances.
+    </xpath>
+    <!-- Button -->
+    <xpath expr="//a[hasclass('btn')]/t" position="replace" mode="inner">
+        See Upcoming Events
+    </xpath>
+    <!-- Figcaption -->
+    <xpath expr="//figcaption" position="replace" mode="inner">
+        Where music meets passion
+    </xpath>
+</template>
+
+</odoo>

--- a/theme_odoo_experts/__manifest__.py
+++ b/theme_odoo_experts/__manifest__.py
@@ -36,6 +36,7 @@
         'views/snippets/s_key_benefits.xml',
         'views/snippets/s_carousel.xml',
         'views/snippets/s_pricelist_boxed.xml',
+        'views/snippets/s_striped_center_top.xml',
         'views/new_page_template.xml',
     ],
     'images': [

--- a/theme_odoo_experts/views/snippets/s_striped_center_top.xml
+++ b/theme_odoo_experts/views/snippets/s_striped_center_top.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+
+<template id="s_striped_center_top" inherit_id="website.s_striped_center_top">
+    <!-- Title -->
+    <xpath expr="//h1" position="replace" mode="inner">
+        Trusted Advisors for Corporate Growth
+    </xpath>
+    <!-- Paragraph -->
+    <xpath expr="//p[hasclass('lead')]" position="replace" mode="inner">
+        Achieve your business goals with our expert advisory services, offering strategic insights and financial guidance.
+    </xpath>
+    <!-- Button -->
+    <xpath expr="//a[hasclass('btn')]/t" position="replace" mode="inner">
+        Consult Our Experts
+    </xpath>
+    <!-- Figcaption -->
+    <xpath expr="//figcaption" position="replace" mode="inner">
+        Strategy crafted for success
+    </xpath>
+    <!-- Image -->
+    <xpath expr="//img" position="attributes">
+        <attribute name="src">/web/image/website.library_image_02</attribute>
+    </xpath>
+</template>
+
+</odoo>

--- a/theme_orchid/__manifest__.py
+++ b/theme_orchid/__manifest__.py
@@ -29,6 +29,7 @@
         'views/snippets/s_numbers_showcase.xml',
         'views/snippets/s_key_benefits.xml',
         'views/snippets/s_image_hexagonal.xml',
+        'views/snippets/s_striped_center_top.xml',
         'views/new_page_template.xml',
     ],
     'images': [

--- a/theme_orchid/views/snippets/s_striped_center_top.xml
+++ b/theme_orchid/views/snippets/s_striped_center_top.xml
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+
+<template id="s_striped_center_top" inherit_id="website.s_striped_center_top">
+    <!-- Title -->
+    <xpath expr="//h1" position="replace" mode="inner">
+        Bring Nature to Your Space
+    </xpath>
+    <!-- Paragraph -->
+    <xpath expr="//p[hasclass('lead')]" position="replace" mode="inner">
+        Transform your surroundings with stunning floral arrangements and garden designs that celebrate the beauty of nature.
+    </xpath>
+    <!-- Button -->
+    <xpath expr="//a[hasclass('btn')]/t" position="replace" mode="inner">
+        Explore Our Collections
+    </xpath>
+    <!-- Figcaption -->
+    <xpath expr="//figcaption" position="replace" mode="inner">
+        Crafted with nature’s finest
+    </xpath>
+</template>
+
+</odoo>

--- a/theme_paptic/views/customizations.xml
+++ b/theme_paptic/views/customizations.xml
@@ -588,4 +588,25 @@
     </xpath>
 </template>
 
+<!-- ==== Striped Center Top ===== -->
+<template id="s_striped_center_top" inherit_id="website.s_striped_center_top">
+    <!-- Title -->
+    <xpath expr="//h1" position="replace" mode="inner">
+        Expert Consultancy for Digital Success
+    </xpath>
+    <!-- Paragraph -->
+    <xpath expr="//p[hasclass('lead')]" position="replace" mode="inner">
+        Leverage our expertise in design and technology to drive innovation and digital transformation in your business.
+    </xpath>
+    <!-- Button -->
+    <xpath expr="//a[hasclass('btn')]/t" position="replace" mode="inner">
+        Get Expert Advice
+    </xpath>
+    <!-- Figcaption -->
+    <xpath expr="//figcaption" position="replace" mode="inner">
+        Expertise that transforms ideas
+    </xpath>
+</template>
+
+
 </odoo>

--- a/theme_real_estate/__manifest__.py
+++ b/theme_real_estate/__manifest__.py
@@ -25,6 +25,7 @@
         'views/snippets/s_numbers.xml',
         'views/snippets/s_title.xml',
         'views/snippets/s_image_gallery.xml',
+        'views/snippets/s_striped_center_top.xml',
         'views/snippets/s_call_to_action.xml',
         'views/snippets/s_unveil.xml',
         'views/snippets/s_key_benefits.xml',

--- a/theme_real_estate/views/snippets/s_striped_center_top.xml
+++ b/theme_real_estate/views/snippets/s_striped_center_top.xml
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+
+<template id="s_striped_center_top" inherit_id="website.s_striped_center_top">
+    <!-- Title -->
+    <xpath expr="//h1" position="replace" mode="inner">
+        Find Your Dream Home
+    </xpath>
+    <!-- Paragraph -->
+    <xpath expr="//p[hasclass('lead')]" position="replace" mode="inner">
+        Discover premium real estate services, from buying and selling homes to vacation accommodations and property management.
+    </xpath>
+    <!-- Button -->
+    <xpath expr="//a[hasclass('btn')]/t" position="replace" mode="inner">
+        View Listings
+    </xpath>
+    <!-- Figcaption -->
+    <xpath expr="//figcaption" position="replace" mode="inner">
+        Homes built with care
+    </xpath>
+</template>
+
+</odoo>

--- a/theme_treehouse/__manifest__.py
+++ b/theme_treehouse/__manifest__.py
@@ -34,6 +34,7 @@
         'views/snippets/s_unveil.xml',
         'views/snippets/s_key_benefits.xml',
         'views/snippets/s_pricelist_boxed.xml',
+        'views/snippets/s_striped_center_top.xml',
         'views/new_page_template.xml',
     ],
     'images': [

--- a/theme_treehouse/views/snippets/s_striped_center_top.xml
+++ b/theme_treehouse/views/snippets/s_striped_center_top.xml
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+
+<template id="s_striped_center_top" inherit_id="website.s_striped_center_top">
+    <!-- Title -->
+    <xpath expr="//h1" position="replace" mode="inner">
+        Leading the Way in Sustainability for a Brighter Tomorrow
+    </xpath>
+    <!-- Paragraph -->
+    <xpath expr="//p[hasclass('lead')]" position="replace" mode="inner">
+        Join us in making a difference with eco-friendly initiatives and sustainable development practices that protect our planet.
+    </xpath>
+    <!-- Button -->
+    <xpath expr="//a[hasclass('btn')]/t" position="replace" mode="inner">
+        Get Involved
+    </xpath>
+    <!-- Figcaption -->
+    <xpath expr="//figcaption" position="replace" mode="inner">
+        Sustainability crafted with care
+    </xpath>
+</template>
+
+</odoo>

--- a/theme_vehicle/views/customizations.xml
+++ b/theme_vehicle/views/customizations.xml
@@ -548,4 +548,25 @@
     </xpath>
 </template>
 
+<!-- ======== STRIPED CENTER TOP ======== -->
+<template id="s_striped_center_top" inherit_id="website.s_striped_center_top">
+    <!-- Title -->
+    <xpath expr="//h1" position="replace" mode="inner">
+        Drive with Confidence and Style
+    </xpath>
+    <!-- Paragraph -->
+    <xpath expr="//p[hasclass('lead')]" position="replace" mode="inner">
+        Keep your vehicles running smoothly with our expert repair and maintenance services, designed for performance and reliability.
+    </xpath>
+    <!-- Button -->
+    <xpath expr="//a[hasclass('btn')]/t" position="replace" mode="inner">
+        Book a Service
+    </xpath>
+    <!-- Figcaption -->
+    <xpath expr="//figcaption" position="replace" mode="inner">
+        Precision in every detail
+    </xpath>
+</template>
+
+
 </odoo>

--- a/theme_yes/__manifest__.py
+++ b/theme_yes/__manifest__.py
@@ -34,6 +34,7 @@
         'views/snippets/s_key_benefits.xml',
         'views/snippets/s_pricelist_boxed.xml',
         'views/snippets/s_image_hexagonal.xml',
+        'views/snippets/s_striped_center_top.xml',
         'views/new_page_template.xml',
     ],
     'images': [

--- a/theme_yes/views/snippets/s_striped_center_top.xml
+++ b/theme_yes/views/snippets/s_striped_center_top.xml
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+
+<template id="s_striped_center_top" inherit_id="website.s_striped_center_top">
+    <!-- Title -->
+    <xpath expr="//h1" position="replace" mode="inner">
+        Capture Your Love Story Beautifully
+    </xpath>
+    <!-- Paragraph -->
+    <xpath expr="//p[hasclass('lead')]" position="replace" mode="inner">
+        Let us help you capture the magic of your special day with stunning photography and personalized wedding services.
+    </xpath>
+    <!-- Button -->
+    <xpath expr="//a[hasclass('btn')]/t" position="replace" mode="inner">
+        View Our Portfolio
+    </xpath>
+    <!-- Figcaption -->
+    <xpath expr="//figcaption" position="replace" mode="inner">
+        Moments crafted with love
+    </xpath>
+</template>
+
+</odoo>

--- a/theme_zap/__manifest__.py
+++ b/theme_zap/__manifest__.py
@@ -29,6 +29,7 @@
         'views/snippets/s_numbers_showcase.xml',
         'views/snippets/s_key_benefits.xml',
         'views/snippets/s_pricelist_boxed.xml',
+        'views/snippets/s_striped_center_top.xml',
         'views/new_page_template.xml',
     ],
     'images': [

--- a/theme_zap/views/snippets/s_striped_center_top.xml
+++ b/theme_zap/views/snippets/s_striped_center_top.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+
+<template id="s_striped_center_top" inherit_id="website.s_striped_center_top">
+    <!-- Title -->
+    <xpath expr="//h1" position="replace" mode="inner">
+        Elevate Your Brand with Digital Marketing
+    </xpath>
+    <!-- Paragraph -->
+    <xpath expr="//p[hasclass('lead')]" position="replace" mode="inner">
+        Boost your brand’s presence with our expert digital marketing services, tailored to drive engagement and results.
+    </xpath>
+    <!-- Button -->
+    <xpath expr="//a[hasclass('btn')]/t" position="replace" mode="inner">
+        Start Your Campaign
+    </xpath>
+    <!-- Figcaption -->
+    <xpath expr="//figcaption" position="replace" mode="inner">
+        Marketing crafted for impact
+    </xpath>
+    <!-- Image -->
+    <xpath expr="//img" position="attributes">
+        <attribute name="src">/web/image/website.s_three_columns_default_image_2</attribute>
+    </xpath>
+</template>
+
+</odoo>


### PR DESCRIPTION
*: anelusia, artists, avantgarde, aviato, beauty, bewise, bistro, bookstore, enark, graphene, kea, kiddo, loftspace, monglia, nano, notes, odoo experts, orchid, paptic, real_estate, treehouse, vehicle, yes, zap

This commit adapts the design of new `s_striped_centertop` snippet for multiple themes.

task-4105455
part-of: task-4077427

requires: https://github.com/odoo/odoo/pull/176739
