### PR TITLE
[IMP] theme_*: adapt themes tests for the new snippet category

### DIFF
--- a/theme_artists/static/src/js/tour.js
+++ b/theme_artists/static/src/js/tour.js
@@ -16,7 +16,7 @@ const snippets = [
     {
         id: 's_three_columns',
         name: 'Columns',
-        groupName: "Content",
+        groupName: "Columns",
     },
     {
         id: 's_title',

--- a/theme_avantgarde/static/src/js/tour.js
+++ b/theme_avantgarde/static/src/js/tour.js
@@ -15,7 +15,7 @@ const snippets = [
     {
         id: 's_three_columns',
         name: 'Columns',
-        groupName: "Content",
+        groupName: "Columns",
     },
     {
         id: 's_text_image',

--- a/theme_aviato/static/src/js/tour.js
+++ b/theme_aviato/static/src/js/tour.js
@@ -27,7 +27,7 @@ const snippets = [
     {
         id: 's_three_columns',
         name: 'Columns',
-        groupName: "Content",
+        groupName: "Columns",
     },
     {
         id: 's_picture',

--- a/theme_buzzy/static/src/js/tour.js
+++ b/theme_buzzy/static/src/js/tour.js
@@ -16,7 +16,7 @@ const snippets = [
     {
         id: 's_three_columns',
         name: 'Columns',
-        groupName: "Content",
+        groupName: "Columns",
     },
     {
         id: 's_image_text',

--- a/theme_orchid/static/src/js/tour.js
+++ b/theme_orchid/static/src/js/tour.js
@@ -22,7 +22,7 @@ const snippets = [
     {
         id: 's_three_columns',
         name: 'Columns',
-        groupName: "Content",
+        groupName: "Columns",
     },
     {
         id: 's_quotes_carousel',

--- a/theme_paptic/static/src/js/tour.js
+++ b/theme_paptic/static/src/js/tour.js
@@ -21,7 +21,7 @@ const snippets = [
     {
         id: 's_three_columns',
         name: 'Columns',
-        groupName: "Content",
+        groupName: "Columns",
     },
     {
         id: 's_comparisons',

--- a/theme_real_estate/static/src/js/tour.js
+++ b/theme_real_estate/static/src/js/tour.js
@@ -31,7 +31,7 @@ const snippets = [
     {
         id: 's_three_columns',
         name: 'Columns',
-        groupName: "Content",
+        groupName: "Columns",
     },
     {
         id: 's_title',

--- a/theme_treehouse/static/src/js/tour.js
+++ b/theme_treehouse/static/src/js/tour.js
@@ -21,7 +21,7 @@ const snippets = [
     {
         id: 's_three_columns',
         name: 'Columns',
-        groupName: "Content",
+        groupName: "Columns",
     },
     {
         id: 's_call_to_action',

--- a/theme_zap/static/src/js/tour.js
+++ b/theme_zap/static/src/js/tour.js
@@ -11,7 +11,7 @@ const snippets = [
     {
         id: 's_three_columns',
         name: 'Columns',
-        groupName: "Content",
+        groupName: "Columns",
     },
     {
         id: 's_color_blocks_2',


### PR DESCRIPTION
*: artists, avantgarde, aviato, buzzy, orchid, paptic, real_estate,
treehouse, zap

- requires https://github.com/odoo/odoo/pull/176889

This PR aims to adapt tests within each themes that uses the
`s_three_columns` snippet.

As we introduce the `Columns` category within the snippet modal, we are
moving the `s_three_columns` from the `Content` category to the `Columns`
one. This implies an adaptation of the tests where the `s_three_columns`
was defined as part of the `Content` category.

task-4119460
follow-up of task-3919405