### PR TITLE
[IMP] theme_*: adapt themes with new `s_quadrant` snippet

### DIFF
--- a/theme_anelusia/__manifest__.py
+++ b/theme_anelusia/__manifest__.py
@@ -35,6 +35,7 @@
         'views/snippets/s_features_wall.xml',
         'views/snippets/s_image_text.xml',
         'views/snippets/s_numbers.xml',
+        'views/snippets/s_quadrant.xml',
         'views/snippets/s_three_columns.xml',
         'views/snippets/s_quotes_carousel.xml',
         'views/snippets/s_unveil.xml',

--- a/theme_anelusia/views/images_library.xml
+++ b/theme_anelusia/views/images_library.xml
@@ -282,5 +282,25 @@
     <field name="name">website.s_kickoff_default_image</field>
     <field name="url">/theme_anelusia/static/src/img/snippets/s_kickoff_default_image.jpg</field>
 </record>
+<record id="s_quadrant_default_image_1" model="theme.ir.attachment">
+    <field name="key">website.s_quadrant_default_image_1</field>
+    <field name="name">website.s_quadrant_default_image_1</field>
+    <field name="url">/theme_anelusia/static/src/img/snippets/s_carousel_3.jpg</field>
+</record>
+<record id="s_quadrant_default_image_2" model="theme.ir.attachment">
+    <field name="key">website.s_quadrant_default_image_2</field>
+    <field name="name">website.s_quadrant_default_image_2</field>
+    <field name="url">/theme_anelusia/static/src/img/snippets/library_image_10.jpg</field>
+</record>
+<record id="s_quadrant_default_image_3" model="theme.ir.attachment">
+    <field name="key">website.s_quadrant_default_image_3</field>
+    <field name="name">website.s_quadrant_default_image_3</field>
+    <field name="url">/theme_anelusia/static/src/img/snippets/library_image_08.jpg</field>
+</record>
+<record id="s_quadrant_default_image_4" model="theme.ir.attachment">
+    <field name="key">website.s_quadrant_default_image_4</field>
+    <field name="name">website.s_quadrant_default_image_4</field>
+    <field name="url">/theme_anelusia/static/src/img/snippets/library_image_02.jpg</field>
+</record>
 
 </odoo>

--- a/theme_anelusia/views/snippets/s_quadrant.xml
+++ b/theme_anelusia/views/snippets/s_quadrant.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+
+<template id="s_quadrant" inherit_id="website.s_quadrant">
+    <!-- Title -->
+    <xpath expr="//h2" position="replace" mode="inner">
+        Elevating Fashion Trends
+    </xpath>
+    <!-- Paragraph -->
+    <xpath expr="//p[hasclass('lead')]" position="replace" mode="inner">
+        Discover the latest in fashion and sportswear, where style meets performance. Our curated collections are designed to inspire and empower your active lifestyle.<br/><br/> Experience the perfect blend of form and function.
+    </xpath>
+    <!-- Button -->
+    <xpath expr="//a[hasclass('btn')]/t" position="replace" mode="inner">
+        Explore Collections
+    </xpath>
+</template>
+
+</odoo>

--- a/theme_artists/__manifest__.py
+++ b/theme_artists/__manifest__.py
@@ -28,6 +28,7 @@
         'views/snippets/s_media_list.xml',
         'views/snippets/s_image_title.xml',
         'views/snippets/s_numbers.xml',
+        'views/snippets/s_quadrant.xml',
         'views/snippets/s_picture.xml',
         'views/snippets/s_image_text.xml',
         'views/snippets/s_features_grid.xml',

--- a/theme_artists/views/images.xml
+++ b/theme_artists/views/images.xml
@@ -225,6 +225,26 @@ Check in theme_monglia's primary_variables.scss, theme.scss and theme_common's m
     <field name="name">website.library_image_16</field>
     <field name="url">/theme_artists/static/src/img/snippets/library_image_16.jpg</field>
 </record>
+<record id="s_quadrant_default_image_1" model="theme.ir.attachment">
+    <field name="key">website.s_quadrant_default_image_1</field>
+    <field name="name">website.s_quadrant_default_image_1</field>
+    <field name="url">/theme_artists/static/src/img/snippets/library_image_08.jpg</field>
+</record>
+<record id="s_quadrant_default_image_2" model="theme.ir.attachment">
+    <field name="key">website.s_quadrant_default_image_2</field>
+    <field name="name">website.s_quadrant_default_image_2</field>
+    <field name="url">/theme_artists/static/src/img/snippets/library_image_10.jpg</field>
+</record>
+<record id="s_quadrant_default_image_3" model="theme.ir.attachment">
+    <field name="key">website.s_quadrant_default_image_3</field>
+    <field name="name">website.s_quadrant_default_image_3</field>
+    <field name="url">/theme_artists/static/src/img/snippets/library_image_14.jpg</field>
+</record>
+<record id="s_quadrant_default_image_4" model="theme.ir.attachment">
+    <field name="key">website.s_quadrant_default_image_4</field>
+    <field name="name">website.s_quadrant_default_image_4</field>
+    <field name="url">/theme_artists/static/src/img/snippets/s_picture.jpg</field>
+</record>
 <record id="s_accordion_image_default_image" model="theme.ir.attachment">
     <field name="key">website.s_accordion_image_default_image</field>
     <field name="name">website.s_accordion_image_default_image</field>

--- a/theme_artists/views/snippets/s_quadrant.xml
+++ b/theme_artists/views/snippets/s_quadrant.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+
+<template id="s_quadrant" inherit_id="website.s_quadrant">
+    <!-- Title -->
+    <xpath expr="//h2" position="replace" mode="inner">
+        Celebrating Artistic Expression
+    </xpath>
+    <!-- Paragraph -->
+    <xpath expr="//p[hasclass('lead')]" position="replace" mode="inner">
+        Immerse yourself in the world of art. Our galleries showcase a diverse range of creativity, from paintings to photography.<br/><br/> Discover the works that speak to your soul and elevate your space.
+    </xpath>
+    <!-- Button -->
+    <xpath expr="//a[hasclass('btn')]/t" position="replace" mode="inner">
+        Visit Galleries
+    </xpath>
+</template>
+
+</odoo>

--- a/theme_avantgarde/views/customizations.xml
+++ b/theme_avantgarde/views/customizations.xml
@@ -286,6 +286,22 @@
     <xpath expr="//div[hasclass('o_we_bg_filter')]" position="replace"/>
 </template>
 
+<!-- ======== QUADRANT ======== -->
+<template id="s_quadrant" inherit_id="website.s_quadrant">
+    <!-- Title -->
+    <xpath expr="//h2" position="replace" mode="inner">
+        Innovating Through Art
+    </xpath>
+    <!-- Paragraph -->
+    <xpath expr="//p[hasclass('lead')]" position="replace" mode="inner">
+        Stay ahead of the curve with our latest insights in design and fine art. Our content explores the intersection of creativity and trends, offering fresh perspectives for galleries and digital media.<br/><br/> Engage with the future of art.
+    </xpath>
+    <!-- Button -->
+    <xpath expr="//a[hasclass('btn')]/t" position="replace" mode="inner">
+        Read More
+    </xpath>
+</template>
+
 <!-- ======== UNVEIL ======== -->
 <template id="s_unveil" inherit_id="website.s_unveil">
     <!-- Section -->

--- a/theme_avantgarde/views/images_library.xml
+++ b/theme_avantgarde/views/images_library.xml
@@ -317,6 +317,26 @@ Check in images.scss, primary_variables.scss, main.scss and theme_common's mixin
     <field name="name">website.library_image_17</field>
     <field name="url">/theme_avantgarde/static/src/img/pictures/bg_image_33.jpg</field>
 </record>
+<record id="s_quadrant_default_image_1" model="theme.ir.attachment">
+    <field name="key">website.s_quadrant_default_image_1</field>
+    <field name="name">website.s_quadrant_default_image_1</field>
+    <field name="url">/theme_avantgarde/static/src/img/pictures/bg_image_20.jpg</field>
+</record>
+<record id="s_quadrant_default_image_2" model="theme.ir.attachment">
+    <field name="key">website.s_quadrant_default_image_2</field>
+    <field name="name">website.s_quadrant_default_image_2</field>
+    <field name="url">/theme_avantgarde/static/src/img/pictures/bg_image_08.jpg</field>
+</record>
+<record id="s_quadrant_default_image_3" model="theme.ir.attachment">
+    <field name="key">website.s_quadrant_default_image_3</field>
+    <field name="name">website.s_quadrant_default_image_3</field>
+    <field name="url">/theme_avantgarde/static/src/img/pictures/bg_image_04.jpg</field>
+</record>
+<record id="s_quadrant_default_image_4" model="theme.ir.attachment">
+    <field name="key">website.s_quadrant_default_image_4</field>
+    <field name="name">website.s_quadrant_default_image_4</field>
+    <field name="url">/theme_avantgarde/static/src/img/pictures/bg_image_30.jpg</field>
+</record>
 <record id="s_accordion_image_default_image" model="theme.ir.attachment">
     <field name="key">website.s_accordion_image_default_image</field>
     <field name="name">website.s_accordion_image_default_image</field>

--- a/theme_aviato/__manifest__.py
+++ b/theme_aviato/__manifest__.py
@@ -29,6 +29,7 @@
         'views/snippets/s_quotes_carousel.xml',
         'views/snippets/s_features_wall.xml',
         'views/snippets/s_striped_center_top.xml',
+        'views/snippets/s_quadrant.xml',
         'views/snippets/s_unveil.xml',
         'views/snippets/s_accordion_image.xml',
         'views/snippets/s_key_benefits.xml',

--- a/theme_aviato/views/images_library.xml
+++ b/theme_aviato/views/images_library.xml
@@ -246,4 +246,27 @@
     <field name="name">website.s_kickoff_default_image</field>
     <field name="url">/theme_aviato/static/src/img/content/s_kickoff_default_image.jpg</field>
 </record>
+
+<!-- Quadrant -->
+<record id="s_quadrant_default_image_1" model="theme.ir.attachment">
+    <field name="key">website.s_quadrant_default_image_1</field>
+    <field name="name">website.s_quadrant_default_image_1</field>
+    <field name="url">/theme_aviato/static/src/img/content/s_banner.jpg</field>
+</record>
+<record id="s_quadrant_default_image_2" model="theme.ir.attachment">
+    <field name="key">website.s_quadrant_default_image_2</field>
+    <field name="name">website.s_quadrant_default_image_2</field>
+    <field name="url">/theme_aviato/static/src/img/content/s_carousel_1.jpg</field>
+</record>
+<record id="s_quadrant_default_image_3" model="theme.ir.attachment">
+    <field name="key">website.s_quadrant_default_image_3</field>
+    <field name="name">website.s_quadrant_default_image_3</field>
+    <field name="url">/theme_aviato/static/src/img/content/s_carousel_3.jpg</field>
+</record>
+<record id="s_quadrant_default_image_4" model="theme.ir.attachment">
+    <field name="key">website.s_quadrant_default_image_4</field>
+    <field name="name">website.s_quadrant_default_image_4</field>
+    <field name="url">/theme_aviato/static/src/img/content/s_quote_bg_3.jpg</field>
+</record>
+
 </odoo>

--- a/theme_aviato/views/snippets/s_quadrant.xml
+++ b/theme_aviato/views/snippets/s_quadrant.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+
+<template id="s_quadrant" inherit_id="website.s_quadrant">
+    <!-- Title -->
+    <xpath expr="//h2" position="replace" mode="inner">
+        Travel Awaits
+    </xpath>
+    <!-- Paragraph -->
+    <xpath expr="//p[hasclass('lead')]" position="replace" mode="inner">
+        Discover the world with our bespoke travel services. From plane tours to unique excursions, we create experiences that leave a lasting impression.<br/><br/> Let us be your guide to extraordinary adventures.
+    </xpath>
+    <!-- Button -->
+    <xpath expr="//a[hasclass('btn')]/t" position="replace" mode="inner">
+        Start Exploring
+    </xpath>
+</template>
+
+</odoo>

--- a/theme_beauty/__manifest__.py
+++ b/theme_beauty/__manifest__.py
@@ -33,6 +33,7 @@
         'views/snippets/s_media_list.xml',
         'views/snippets/s_comparisons.xml',
         'views/snippets/s_product_catalog.xml',
+        'views/snippets/s_quadrant.xml',
         'views/snippets/s_unveil.xml',
         'views/snippets/s_numbers_showcase.xml',
         'views/snippets/s_features_wall.xml',

--- a/theme_beauty/views/images.xml
+++ b/theme_beauty/views/images.xml
@@ -255,6 +255,26 @@ Check in theme_loftspace's primary_variables.scss and theme.scss -->
     <field name="name">website.library_image_17</field>
     <field name="url">/theme_beauty/static/src/img/snippets/s_newsletter.jpg</field>
 </record>
+<record id="s_quadrant_default_image_1" model="theme.ir.attachment">
+    <field name="key">website.s_quadrant_default_image_1</field>
+    <field name="name">website.s_quadrant_default_image_1</field>
+    <field name="url">/theme_beauty/static/src/img/snippets/s_masonry_block.jpg</field>
+</record>
+<record id="s_quadrant_default_image_2" model="theme.ir.attachment">
+    <field name="key">website.s_quadrant_default_image_2</field>
+    <field name="name">website.s_quadrant_default_image_2</field>
+    <field name="url">/theme_beauty/static/src/img/snippets/library_image_02.jpg</field>
+</record>
+<record id="s_quadrant_default_image_3" model="theme.ir.attachment">
+    <field name="key">website.s_quadrant_default_image_3</field>
+    <field name="name">website.s_quadrant_default_image_3</field>
+    <field name="url">/theme_beauty/static/src/img/content/content_img_09.jpg</field>
+</record>
+<record id="s_quadrant_default_image_4" model="theme.ir.attachment">
+    <field name="key">website.s_quadrant_default_image_4</field>
+    <field name="name">website.s_quadrant_default_image_4</field>
+    <field name="url">/theme_beauty/static/src/img/content/content_img_07.jpg</field>
+</record>
 <record id="s_accordion_image_default_image" model="theme.ir.attachment">
     <field name="key">website.s_accordion_image_default_image</field>
     <field name="name">website.s_accordion_image_default_image</field>

--- a/theme_beauty/views/snippets/s_quadrant.xml
+++ b/theme_beauty/views/snippets/s_quadrant.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+
+<template id="s_quadrant" inherit_id="website.s_quadrant">
+    <!-- Title -->
+    <xpath expr="//h2" position="replace" mode="inner">
+        Beauty &amp; Care
+    </xpath>
+    <!-- Paragraph -->
+    <xpath expr="//p[hasclass('lead')]" position="replace" mode="inner">
+        Indulge in the ultimate beauty and health experience. Our range of products and services, from cosmetics to hair care, are designed to enhance your natural beauty.<br/><br/> Discover your glow with us.
+    </xpath>
+    <!-- Button -->
+    <xpath expr="//a[hasclass('btn')]/t" position="replace" mode="inner">
+        Discover Beauty
+    </xpath>
+</template>
+
+</odoo>

--- a/theme_bewise/views/customizations.xml
+++ b/theme_bewise/views/customizations.xml
@@ -562,6 +562,22 @@
     </xpath>
 </template>
 
+<!-- ======== QUADRANT ======== -->
+<template id="s_quadrant" inherit_id="website.s_quadrant">
+    <!-- Title -->
+    <xpath expr="//h2" position="replace" mode="inner">
+        Academic Excellence
+    </xpath>
+    <!-- Paragraph -->
+    <xpath expr="//p[hasclass('lead')]" position="replace" mode="inner">
+        Empower your academic journey with our comprehensive programs designed for university students. From research opportunities to campus life, we foster an environment where knowledge and innovation thrive.<br/><br/> Prepare for a future of success.
+    </xpath>
+    <!-- Button -->
+    <xpath expr="//a[hasclass('btn')]/t" position="replace" mode="inner">
+        Explore Programs
+    </xpath>
+</template>
+
 <!-- ======== KEY BENEFITS ======== -->
 <template id="s_key_benefits" inherit_id="website.s_key_benefits">
     <!-- Titles -->

--- a/theme_bewise/views/image_content.xml
+++ b/theme_bewise/views/image_content.xml
@@ -227,6 +227,26 @@
     <field name="name">website.library_image_16</field>
     <field name="url">/theme_bewise/static/src/img/content/library_image_16.jpg</field>
 </record>
+<record id="s_quadrant_default_image_1" model="theme.ir.attachment">
+    <field name="key">website.s_quadrant_default_image_1</field>
+    <field name="name">website.s_quadrant_default_image_1</field>
+    <field name="url">/theme_bewise/static/src/img/content/college_carousel_2.jpg</field>
+</record>
+<record id="s_quadrant_default_image_2" model="theme.ir.attachment">
+    <field name="key">website.s_quadrant_default_image_2</field>
+    <field name="name">website.s_quadrant_default_image_2</field>
+    <field name="url">/theme_bewise/static/src/img/content/library_image_02.jpg</field>
+</record>
+<record id="s_quadrant_default_image_3" model="theme.ir.attachment">
+    <field name="key">website.s_quadrant_default_image_3</field>
+    <field name="name">website.s_quadrant_default_image_3</field>
+    <field name="url">/theme_bewise/static/src/img/content/college_lab_2.jpg</field>
+</record>
+<record id="s_quadrant_default_image_4" model="theme.ir.attachment">
+    <field name="key">website.s_quadrant_default_image_4</field>
+    <field name="name">website.s_quadrant_default_image_4</field>
+    <field name="url">/theme_bewise/static/src/img/content/college_carousel_1.jpg</field>
+</record>
 <record id="s_accordion_image_default_image" model="theme.ir.attachment">
     <field name="key">website.s_accordion_image_default_image</field>
     <field name="name">website.s_accordion_image_default_image</field>

--- a/theme_bistro/__manifest__.py
+++ b/theme_bistro/__manifest__.py
@@ -39,6 +39,7 @@
         'views/snippets/s_motto.xml',
         'views/snippets/s_key_images.xml',
         'views/snippets/s_striped_top.xml',
+        'views/snippets/s_quadrant.xml',
         'views/new_page_template.xml',
 
     ],

--- a/theme_bistro/views/images_library.xml
+++ b/theme_bistro/views/images_library.xml
@@ -379,6 +379,28 @@
     <field name="url">/theme_bistro/static/src/img/backgrounds/s_pricelist_boxed_default_background.jpg</field>
 </record>
 
+<!-- Quadrant -->
+<record id="s_quadrant_default_image_1" model="theme.ir.attachment">
+    <field name="key">website.s_quadrant_default_image_1</field>
+    <field name="name">website.s_quadrant_default_image_1</field>
+    <field name="url">/theme_bistro/static/src/img/backgrounds/10.jpg</field>
+</record>
+<record id="s_quadrant_default_image_2" model="theme.ir.attachment">
+    <field name="key">website.s_quadrant_default_image_2</field>
+    <field name="name">website.s_quadrant_default_image_2</field>
+    <field name="url">/theme_bistro/static/src/img/backgrounds/16.jpg</field>
+</record>
+<record id="s_quadrant_default_image_3" model="theme.ir.attachment">
+    <field name="key">website.s_quadrant_default_image_3</field>
+    <field name="name">website.s_quadrant_default_image_3</field>
+    <field name="url">/theme_bistro/static/src/img/backgrounds/08.jpg</field>
+</record>
+<record id="s_quadrant_default_image_4" model="theme.ir.attachment">
+    <field name="key">website.s_quadrant_default_image_4</field>
+    <field name="name">website.s_quadrant_default_image_4</field>
+    <field name="url">/theme_bistro/static/src/img/content/picture.jpg</field>
+</record>
+
 <!-- Image Hexagonal -->
 <record id="s_image_hexagonal_default_image_1" model="theme.ir.attachment">
     <field name="key">website.s_image_hexagonal_default_image_1</field>

--- a/theme_bistro/views/snippets/s_quadrant.xml
+++ b/theme_bistro/views/snippets/s_quadrant.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+
+<template id="s_quadrant" inherit_id="website.s_quadrant">
+    <!-- Title -->
+    <xpath expr="//h2" position="replace" mode="inner">
+        Taste &amp; Enjoy
+    </xpath>
+    <!-- Paragraph -->
+    <xpath expr="//p[hasclass('lead')]" position="replace" mode="inner">
+        Experience the finest in dining with our carefully curated menus. Whether you’re at a bistro, bar, or cafe, our culinary offerings are sure to delight.<br/><br/> Taste the difference in every dish.
+    </xpath>
+    <!-- Button -->
+    <xpath expr="//a[hasclass('btn')]/t" position="replace" mode="inner">
+        Reserve a Table
+    </xpath>
+</template>
+
+</odoo>

--- a/theme_bookstore/__manifest__.py
+++ b/theme_bookstore/__manifest__.py
@@ -38,6 +38,7 @@
         'views/snippets/s_product_catalog.xml',
         'views/snippets/s_quotes_carousel.xml',
         'views/snippets/s_unveil.xml',
+        'views/snippets/s_quadrant.xml',
         'views/snippets/s_numbers_showcase.xml',
         'views/snippets/s_key_benefits.xml',
         'views/snippets/s_carousel.xml',

--- a/theme_bookstore/views/images.xml
+++ b/theme_bookstore/views/images.xml
@@ -292,4 +292,26 @@ Check in theme_loftspace's primary_variables.scss and theme.scss -->
     <field name="url">/theme_bookstore/static/src/img/snippets/s_kickoff_default_image.jpg</field>
 </record>
 
+<!-- Quadrant -->
+<record id="s_quadrant_default_image_1" model="theme.ir.attachment">
+    <field name="key">website.s_quadrant_default_image_1</field>
+    <field name="name">website.s_quadrant_default_image_1</field>
+    <field name="url">/theme_bookstore/static/src/img/snippets/s_carousel_2.jpg</field>
+</record>
+<record id="s_quadrant_default_image_2" model="theme.ir.attachment">
+    <field name="key">website.s_quadrant_default_image_2</field>
+    <field name="name">website.s_quadrant_default_image_2</field>
+    <field name="url">/theme_bookstore/static/src/img/snippets/s_carousel_1.jpg</field>
+</record>
+<record id="s_quadrant_default_image_3" model="theme.ir.attachment">
+    <field name="key">website.s_quadrant_default_image_3</field>
+    <field name="name">website.s_quadrant_default_image_3</field>
+    <field name="url">/theme_bookstore/static/src/img/snippets/s_carousel_3.jpg</field>
+</record>
+<record id="s_quadrant_default_image_4" model="theme.ir.attachment">
+    <field name="key">website.s_quadrant_default_image_4</field>
+    <field name="name">website.s_quadrant_default_image_4</field>
+    <field name="url">/theme_bookstore/static/src/img/snippets/s_picture.jpg</field>
+</record>
+
 </odoo>

--- a/theme_bookstore/views/snippets/s_quadrant.xml
+++ b/theme_bookstore/views/snippets/s_quadrant.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+
+<template id="s_quadrant" inherit_id="website.s_quadrant">
+    <!-- Title -->
+    <xpath expr="//h2" position="replace" mode="inner">
+        Read &amp; Listen
+    </xpath>
+    <!-- Paragraph -->
+    <xpath expr="//p[hasclass('lead')]" position="replace" mode="inner">
+        Immerse yourself in our vast collection of books and music. From timeless classics to contemporary works, we offer a sanctuary for the literary and musical soul.<br/><br/> Find your next inspiration here.
+    </xpath>
+    <!-- Button -->
+    <xpath expr="//a[hasclass('btn')]/t" position="replace" mode="inner">
+        Browse the Collection
+    </xpath>
+</template>
+
+</odoo>

--- a/theme_buzzy/views/images_library.xml
+++ b/theme_buzzy/views/images_library.xml
@@ -88,6 +88,27 @@
     <field name="name">website.s_cover_default_image</field>
     <field name="url">/theme_buzzy/static/src/img/photos/s_cover_default_image.jpg</field>
 </record>
+<!-- Quadrant -->
+<record id="s_quadrant_default_image_1" model="theme.ir.attachment">
+    <field name="key">website.s_quadrant_default_image_1</field>
+    <field name="name">website.s_quadrant_default_image_1</field>
+    <field name="url">/theme_buzzy/static/src/img/photos/library_image_14.jpg</field>
+</record>
+<record id="s_quadrant_default_image_2" model="theme.ir.attachment">
+    <field name="key">website.s_quadrant_default_image_2</field>
+    <field name="name">website.s_quadrant_default_image_2</field>
+    <field name="url">/theme_buzzy/static/src/img/photos/library_image_05.jpg</field>
+</record>
+<record id="s_quadrant_default_image_3" model="theme.ir.attachment">
+    <field name="key">website.s_quadrant_default_image_3</field>
+    <field name="name">website.s_quadrant_default_image_3</field>
+    <field name="url">/theme_buzzy/static/src/img/photos/library_image_10.jpg</field>
+</record>
+<record id="s_quadrant_default_image_4" model="theme.ir.attachment">
+    <field name="key">website.s_quadrant_default_image_4</field>
+    <field name="name">website.s_quadrant_default_image_4</field>
+    <field name="url">/theme_buzzy/static/src/img/photos/s_carousel_default_image_1.jpg</field>
+</record>
 <!-- Accordion Image -->
 <record id="s_accordion_image_default_image" model="theme.ir.attachment">
     <field name="key">website.s_accordion_image_default_image</field>

--- a/theme_clean/views/image_content.xml
+++ b/theme_clean/views/image_content.xml
@@ -182,6 +182,26 @@
     <field name="name">website.library_image_16</field>
     <field name="url">/theme_clean/static/src/img/content/library_image_16.jpg</field>
 </record>
+<record id="s_quadrant_default_image_1" model="theme.ir.attachment">
+    <field name="key">website.s_quadrant_default_image_1</field>
+    <field name="name">website.s_quadrant_default_image_1</field>
+    <field name="url">/theme_clean/static/src/img/backgrounds/bg_snippet_10.jpg</field>
+</record>
+<record id="s_quadrant_default_image_2" model="theme.ir.attachment">
+    <field name="key">website.s_quadrant_default_image_2</field>
+    <field name="name">website.s_quadrant_default_image_2</field>
+    <field name="url">/theme_clean/static/src/img/content/image_content_22.jpg</field>
+</record>
+<record id="s_quadrant_default_image_3" model="theme.ir.attachment">
+    <field name="key">website.s_quadrant_default_image_3</field>
+    <field name="name">website.s_quadrant_default_image_3</field>
+    <field name="url">/theme_clean/static/src/img/content/image_content_23.jpg</field>
+</record>
+<record id="s_quadrant_default_image_4" model="theme.ir.attachment">
+    <field name="key">website.s_quadrant_default_image_4</field>
+    <field name="name">website.s_quadrant_default_image_4</field>
+    <field name="url">/theme_clean/static/src/img/content/image_content_27.jpg</field>
+</record>
 <record id="s_accordion_image_default_image" model="theme.ir.attachment">
     <field name="key">website.s_accordion_image_default_image</field>
     <field name="name">website.s_accordion_image_default_image</field>

--- a/theme_cobalt/views/images.xml
+++ b/theme_cobalt/views/images.xml
@@ -240,6 +240,27 @@
     <field name="name">website.library_image_02</field>
     <field name="url">/theme_cobalt/static/src/img/pictures/s_gallery_3.jpg</field>
 </record>
+<!-- Quadrant -->
+<record id="s_quadrant_default_image_1" model="theme.ir.attachment">
+    <field name="key">website.s_quadrant_default_image_1</field>
+    <field name="name">website.s_quadrant_default_image_1</field>
+    <field name="url">/theme_cobalt/static/src/img/pictures/s_media_list_1.jpg</field>
+</record>
+<record id="s_quadrant_default_image_2" model="theme.ir.attachment">
+    <field name="key">website.s_quadrant_default_image_2</field>
+    <field name="name">website.s_quadrant_default_image_2</field>
+    <field name="url">/theme_cobalt/static/src/img/pictures/s_product_catalog.jpg</field>
+</record>
+<record id="s_quadrant_default_image_3" model="theme.ir.attachment">
+    <field name="key">website.s_quadrant_default_image_3</field>
+    <field name="name">website.s_quadrant_default_image_3</field>
+    <field name="url">/theme_cobalt/static/src/img/pictures/s_popup.jpeg</field>
+</record>
+<record id="s_quadrant_default_image_4" model="theme.ir.attachment">
+    <field name="key">website.s_quadrant_default_image_4</field>
+    <field name="name">website.s_quadrant_default_image_4</field>
+    <field name="url">/theme_cobalt/static/src/img/pictures/s_carousel_1.jpg</field>
+</record>
 <record id="s_accordion_image_default_image" model="theme.ir.attachment">
     <field name="key">website.s_accordion_image_default_image</field>
     <field name="name">website.s_accordion_image_default_image</field>

--- a/theme_enark/__manifest__.py
+++ b/theme_enark/__manifest__.py
@@ -29,6 +29,7 @@
         'views/snippets/s_features_wall.xml',
         'views/snippets/s_image_title.xml',
         'views/snippets/s_key_images.xml',
+        'views/snippets/s_quadrant.xml',
         'views/snippets/s_unveil.xml',
         'views/snippets/s_key_benefits.xml',
         'views/snippets/s_carousel.xml',

--- a/theme_enark/views/image_library.xml
+++ b/theme_enark/views/image_library.xml
@@ -185,6 +185,26 @@
     <field name="name">website.s_three_columns_default_image_2</field>
     <field name="url">/theme_enark/static/src/img/snippets/library_image_13.jpg</field>
 </record>
+<record id="s_quadrant_default_image_1" model="theme.ir.attachment">
+    <field name="key">website.s_quadrant_default_image_1</field>
+    <field name="name">website.s_quadrant_default_image_1</field>
+    <field name="url">/theme_enark/static/src/img/snippets/s_cover.jpg</field>
+</record>
+<record id="s_quadrant_default_image_2" model="theme.ir.attachment">
+    <field name="key">website.s_quadrant_default_image_2</field>
+    <field name="name">website.s_quadrant_default_image_2</field>
+    <field name="url">/theme_enark/static/src/img/snippets/library_image_07.jpg</field>
+</record>
+<record id="s_quadrant_default_image_3" model="theme.ir.attachment">
+    <field name="key">website.s_quadrant_default_image_3</field>
+    <field name="name">website.s_quadrant_default_image_3</field>
+    <field name="url">/theme_enark/static/src/img/snippets/library_image_11.jpg</field>
+</record>
+<record id="s_quadrant_default_image_4" model="theme.ir.attachment">
+    <field name="key">website.s_quadrant_default_image_4</field>
+    <field name="name">website.s_quadrant_default_image_4</field>
+    <field name="url">/theme_enark/static/src/img/snippets/library_image_13.jpg</field>
+</record>
 <record id="s_accordion_image_default_image" model="theme.ir.attachment">
     <field name="key">website.s_accordion_image_default_image</field>
     <field name="name">website.s_accordion_image_default_image</field>

--- a/theme_enark/views/snippets/s_quadrant.xml
+++ b/theme_enark/views/snippets/s_quadrant.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+
+<template id="s_quadrant" inherit_id="website.s_quadrant">
+    <!-- Title -->
+    <xpath expr="//h2" position="replace" mode="inner">
+        Architecture &amp; Business
+    </xpath>
+    <!-- Paragraph -->
+    <xpath expr="//p[hasclass('lead')]" position="replace" mode="inner">
+        Transform your corporate spaces with architectural excellence. Our designs integrate functionality and aesthetics to support your business goals and enhance your working environment.<br/><br/> Build the future with us.
+    </xpath>
+    <!-- Button -->
+    <xpath expr="//a[hasclass('btn')]/t" position="replace" mode="inner">
+        Start a Project
+    </xpath>
+</template>
+
+</odoo>

--- a/theme_graphene/views/images_library.xml
+++ b/theme_graphene/views/images_library.xml
@@ -323,6 +323,28 @@ Check in images.scss, primary_variables.scss, main.scss and theme_common's mixin
     <field name="url">/theme_graphene/static/src/img/pictures/s_numbers.jpg</field>
 </record>
 
+<!-- Quadrant -->
+<record id="s_quadrant_default_image_1" model="theme.ir.attachment">
+    <field name="key">website.s_quadrant_default_image_1</field>
+    <field name="name">website.s_quadrant_default_image_1</field>
+    <field name="url">/theme_graphene/static/src/img/pictures/content_03.jpg</field>
+</record>
+<record id="s_quadrant_default_image_2" model="theme.ir.attachment">
+    <field name="key">website.s_quadrant_default_image_2</field>
+    <field name="name">website.s_quadrant_default_image_2</field>
+    <field name="url">/theme_graphene/static/src/img/pictures/content_04.jpg</field>
+</record>
+<record id="s_quadrant_default_image_3" model="theme.ir.attachment">
+    <field name="key">website.s_quadrant_default_image_3</field>
+    <field name="name">website.s_quadrant_default_image_3</field>
+    <field name="url">/theme_graphene/static/src/img/pictures/bg_image_10.jpg</field>
+</record>
+<record id="s_quadrant_default_image_4" model="theme.ir.attachment">
+    <field name="key">website.s_quadrant_default_image_4</field>
+    <field name="name">website.s_quadrant_default_image_4</field>
+    <field name="url">/theme_graphene/static/src/img/pictures/content_22.jpg</field>
+</record>
+
 <!-- Gallery wall -->
 <record id="library_image_03" model="theme.ir.attachment">
     <field name="key">website.library_image_03</field>

--- a/theme_kea/__manifest__.py
+++ b/theme_kea/__manifest__.py
@@ -38,6 +38,7 @@
         'views/snippets/s_striped_center_top.xml',
         'views/snippets/s_image_title.xml',
         'views/snippets/s_key_images.xml',
+        'views/snippets/s_quadrant.xml',
         'views/new_page_template.xml',
     ],
     'images': [

--- a/theme_kea/views/images_content.xml
+++ b/theme_kea/views/images_content.xml
@@ -270,6 +270,26 @@ Check in primary_variables.scss, theme.scss and theme_common's mixins.scss -->
     <field name="name">website.s_banner_default_image_3</field>
     <field name="url">/theme_kea/static/src/img/snippets/s_banner_3.jpg</field>
 </record>
+<record id="s_quadrant_default_image_1" model="theme.ir.attachment">
+    <field name="key">website.s_quadrant_default_image_1</field>
+    <field name="name">website.s_quadrant_default_image_1</field>
+    <field name="url">/theme_kea/static/src/img/snippets/s_carousel_3.jpg</field>
+</record>
+<record id="s_quadrant_default_image_2" model="theme.ir.attachment">
+    <field name="key">website.s_quadrant_default_image_2</field>
+    <field name="name">website.s_quadrant_default_image_2</field>
+    <field name="url">/theme_kea/static/src/img/snippets/s_carousel_1.jpg</field>
+</record>
+<record id="s_quadrant_default_image_3" model="theme.ir.attachment">
+    <field name="key">website.s_quadrant_default_image_3</field>
+    <field name="name">website.s_quadrant_default_image_3</field>
+    <field name="url">/theme_kea/static/src/img/snippets/s_media_list_1.jpg</field>
+</record>
+<record id="s_quadrant_default_image_4" model="theme.ir.attachment">
+    <field name="key">website.s_quadrant_default_image_4</field>
+    <field name="name">website.s_quadrant_default_image_4</field>
+    <field name="url">/theme_kea/static/src/img/snippets/s_carousel_2.jpg</field>
+</record>
 <record id="s_accordion_image_default_image" model="theme.ir.attachment">
     <field name="key">website.s_accordion_image_default_image</field>
     <field name="name">website.s_accordion_image_default_image</field>

--- a/theme_kea/views/snippets/s_quadrant.xml
+++ b/theme_kea/views/snippets/s_quadrant.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+
+<template id="s_quadrant" inherit_id="website.s_quadrant">
+    <!-- Title -->
+    <xpath expr="//h2" position="replace" mode="inner">
+        Virtual Reality
+    </xpath>
+    <!-- Paragraph -->
+    <xpath expr="//p[hasclass('lead')]" position="replace" mode="inner">
+        Step into the future with our immersive virtual reality solutions. From gaming to business applications, VR is transforming how we interact with the digital world.<br/><br/> Experience the next level of technology with us.
+    </xpath>
+    <!-- Button -->
+    <xpath expr="//a[hasclass('btn')]/t" position="replace" mode="inner">
+        Explore VR
+    </xpath>
+</template>
+
+</odoo>

--- a/theme_kiddo/__manifest__.py
+++ b/theme_kiddo/__manifest__.py
@@ -30,6 +30,7 @@
         'views/snippets/s_image_punchy.xml',
         'views/snippets/s_product_catalog.xml',
         'views/snippets/s_unveil.xml',
+        'views/snippets/s_quadrant.xml',
         'views/snippets/s_numbers_showcase.xml',
         'views/snippets/s_accordion_image.xml',
         'views/snippets/s_key_benefits.xml',

--- a/theme_kiddo/views/images_library.xml
+++ b/theme_kiddo/views/images_library.xml
@@ -244,6 +244,26 @@
     <field name="name">theme_common.image_content_10</field>
     <field name="url">/theme_kiddo/static/src/img/content/content_img_26.jpg</field>
 </record>
+<record id="s_quadrant_default_image_1" model="theme.ir.attachment">
+    <field name="key">website.s_quadrant_default_image_1</field>
+    <field name="name">website.s_quadrant_default_image_1</field>
+    <field name="url">/theme_kiddo/static/src/img/content/content_img_36.jpg</field>
+</record>
+<record id="s_quadrant_default_image_2" model="theme.ir.attachment">
+    <field name="key">website.s_quadrant_default_image_2</field>
+    <field name="name">website.s_quadrant_default_image_2</field>
+    <field name="url">/theme_kiddo/static/src/img/content/content_img_37.jpg</field>
+</record>
+<record id="s_quadrant_default_image_3" model="theme.ir.attachment">
+    <field name="key">website.s_quadrant_default_image_3</field>
+    <field name="name">website.s_quadrant_default_image_3</field>
+    <field name="url">/theme_kiddo/static/src/img/content/content_img_38.jpg</field>
+</record>
+<record id="s_quadrant_default_image_4" model="theme.ir.attachment">
+    <field name="key">website.s_quadrant_default_image_4</field>
+    <field name="name">website.s_quadrant_default_image_4</field>
+    <field name="url">/theme_kiddo/static/src/img/content/content_img_39.jpg</field>
+</record>
 <record id="s_accordion_image_default_image" model="theme.ir.attachment">
     <field name="key">website.s_accordion_image_default_image</field>
     <field name="name">website.s_accordion_image_default_image</field>

--- a/theme_kiddo/views/snippets/s_quadrant.xml
+++ b/theme_kiddo/views/snippets/s_quadrant.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+
+<template id="s_quadrant" inherit_id="website.s_quadrant">
+    <!-- Title -->
+    <xpath expr="//h2" position="replace" mode="inner">
+        Toys &amp; Fun
+    </xpath>
+    <!-- Paragraph -->
+    <xpath expr="//p[hasclass('lead')]" position="replace" mode="inner">
+        Ignite your child's imagination with our range of toys and games. Designed for creativity and fun, our products bring joy to kids of all ages.<br/><br/> Explore the magic of playtime.
+    </xpath>
+    <!-- Button -->
+    <xpath expr="//a[hasclass('btn')]/t" position="replace" mode="inner">
+        Shop Now
+    </xpath>
+</template>
+
+</odoo>

--- a/theme_loftspace/__manifest__.py
+++ b/theme_loftspace/__manifest__.py
@@ -38,6 +38,7 @@
         'views/snippets/s_carousel.xml',
         'views/snippets/s_striped_center_top.xml',
         'views/snippets/s_key_images.xml',
+        'views/snippets/s_quadrant.xml',
         'views/new_page_template.xml',
     ],
     'images': [

--- a/theme_loftspace/views/images_content.xml
+++ b/theme_loftspace/views/images_content.xml
@@ -266,6 +266,26 @@ Check in primary_variables.scss and theme.scss -->
     <field name="name">website.s_blockquote_default_image</field>
     <field name="url">/theme_loftspace/static/src/img/snippets/uiface_2.jpg</field>
 </record>
+<record id="s_quadrant_default_image_1" model="theme.ir.attachment">
+    <field name="key">website.s_quadrant_default_image_1</field>
+    <field name="name">website.s_quadrant_default_image_1</field>
+    <field name="url">/theme_loftspace/static/src/img/content/content_img_12.jpg</field>
+</record>
+<record id="s_quadrant_default_image_2" model="theme.ir.attachment">
+    <field name="key">website.s_quadrant_default_image_2</field>
+    <field name="name">website.s_quadrant_default_image_2</field>
+    <field name="url">/theme_loftspace/static/src/img/content/content_img_09.jpg</field>
+</record>
+<record id="s_quadrant_default_image_3" model="theme.ir.attachment">
+    <field name="key">website.s_quadrant_default_image_3</field>
+    <field name="name">website.s_quadrant_default_image_3</field>
+    <field name="url">/theme_loftspace/static/src/img/snippets/s_images_wall_03.jpg</field>
+</record>
+<record id="s_quadrant_default_image_4" model="theme.ir.attachment">
+    <field name="key">website.s_quadrant_default_image_4</field>
+    <field name="name">website.s_quadrant_default_image_4</field>
+    <field name="url">/theme_loftspace/static/src/img/content/content_img_07.jpg</field>
+</record>
 <record id="s_accordion_image_default_image" model="theme.ir.attachment">
     <field name="key">website.s_accordion_image_default_image</field>
     <field name="name">website.s_accordion_image_default_image</field>

--- a/theme_loftspace/views/snippets/s_quadrant.xml
+++ b/theme_loftspace/views/snippets/s_quadrant.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+
+<template id="s_quadrant" inherit_id="website.s_quadrant">
+    <!-- Title -->
+    <xpath expr="//h2" position="replace" mode="inner">
+        Home Interiors
+    </xpath>
+    <!-- Paragraph -->
+    <xpath expr="//p[hasclass('lead')]" position="replace" mode="inner">
+        Create the perfect living space with our expertly designed furniture and home interiors. Combining comfort and style, our collections are made to transform your home.<br/><br/> Find your inspiration here.
+    </xpath>
+    <!-- Button -->
+    <xpath expr="//a[hasclass('btn')]/t" position="replace" mode="inner">
+        View Collection
+    </xpath>
+</template>
+
+</odoo>

--- a/theme_monglia/views/customizations.xml
+++ b/theme_monglia/views/customizations.xml
@@ -354,6 +354,22 @@
     </xpath>
 </template>
 
+<!-- ======== QUADRANT ======== -->
+<template id="s_quadrant" inherit_id="website.s_quadrant">
+    <!-- Title -->
+    <xpath expr="//h2" position="replace" mode="inner">
+        Events &amp; Dining
+    </xpath>
+    <!-- Paragraph -->
+    <xpath expr="//p[hasclass('lead')]" position="replace" mode="inner">
+        Experience unforgettable moments at our events. From fine dining to live music, we create the perfect atmosphere for any occasion.<br/><br/> Let us make your event one to remember.
+    </xpath>
+    <!-- Button -->
+    <xpath expr="//a[hasclass('btn')]/t" position="replace" mode="inner">
+        Plan an Event
+    </xpath>
+</template>
+
 <!-- ======== KEY BENEFITS ======== -->
 <template id="s_key_benefits" inherit_id="website.s_key_benefits">
     <!-- Titles -->

--- a/theme_monglia/views/images_content.xml
+++ b/theme_monglia/views/images_content.xml
@@ -270,6 +270,27 @@ Check in primary_variables.scss, theme.scss and theme_common's mixins.scss -->
     <field name="name">website.s_blockquote_default_image</field>
     <field name="url">/theme_monglia/static/src/img/snippets/uiface_2.jpg</field>
 </record>
+<!-- Quadrant -->
+<record id="s_quadrant_default_image_1" model="theme.ir.attachment">
+    <field name="key">website.s_quadrant_default_image_1</field>
+    <field name="name">website.s_quadrant_default_image_1</field>
+    <field name="url">/theme_monglia/static/src/img/content/content_img_11.jpg</field>
+</record>
+<record id="s_quadrant_default_image_2" model="theme.ir.attachment">
+    <field name="key">website.s_quadrant_default_image_2</field>
+    <field name="name">website.s_quadrant_default_image_2</field>
+    <field name="url">/theme_monglia/static/src/img/snippets/s_quotes_carousel_2.jpg</field>
+</record>
+<record id="s_quadrant_default_image_3" model="theme.ir.attachment">
+    <field name="key">website.s_quadrant_default_image_3</field>
+    <field name="name">website.s_quadrant_default_image_3</field>
+    <field name="url">/theme_monglia/static/src/img/snippets/s_product_catalog.jpg</field>
+</record>
+<record id="s_quadrant_default_image_4" model="theme.ir.attachment">
+    <field name="key">website.s_quadrant_default_image_4</field>
+    <field name="name">website.s_quadrant_default_image_4</field>
+    <field name="url">/theme_monglia/static/src/img/snippets/s_picture.jpg</field>
+</record>
 <record id="s_accordion_image_default_image" model="theme.ir.attachment">
     <field name="key">website.s_accordion_image_default_image</field>
     <field name="name">website.s_accordion_image_default_image</field>

--- a/theme_nano/__manifest__.py
+++ b/theme_nano/__manifest__.py
@@ -28,6 +28,7 @@
         'views/snippets/s_text_image.xml',
         'views/snippets/s_three_columns.xml',
         'views/snippets/s_unveil.xml',
+        'views/snippets/s_quadrant.xml',
         'views/snippets/s_numbers_showcase.xml',
         'views/snippets/s_key_benefits.xml',
         'views/snippets/s_striped_center_top.xml',

--- a/theme_nano/views/images_library.xml
+++ b/theme_nano/views/images_library.xml
@@ -430,4 +430,26 @@
     <field name="url">/theme_nano/static/src/img/snippets/s_kickoff_default_image.jpg</field>
 </record>
 
+<!-- Quadrant -->
+<record id="s_quadrant_default_image_1" model="theme.ir.attachment">
+    <field name="key">website.s_quadrant_default_image_1</field>
+    <field name="name">website.s_quadrant_default_image_1</field>
+    <field name="url">/theme_nano/static/src/img/snippets/s_carousel_02.jpg</field>
+</record>
+<record id="s_quadrant_default_image_2" model="theme.ir.attachment">
+    <field name="key">website.s_quadrant_default_image_2</field>
+    <field name="name">website.s_quadrant_default_image_2</field>
+    <field name="url">/theme_nano/static/src/img/snippets/s_masonry_block.jpg</field>
+</record>
+<record id="s_quadrant_default_image_3" model="theme.ir.attachment">
+    <field name="key">website.s_quadrant_default_image_3</field>
+    <field name="name">website.s_quadrant_default_image_3</field>
+    <field name="url">/theme_nano/static/src/img/snippets/s_picture.jpg</field>
+</record>
+<record id="s_quadrant_default_image_4" model="theme.ir.attachment">
+    <field name="key">website.s_quadrant_default_image_4</field>
+    <field name="name">website.s_quadrant_default_image_4</field>
+    <field name="url">/theme_nano/static/src/img/snippets/s_media_list_02.jpg</field>
+</record>
+
 </odoo>

--- a/theme_nano/views/snippets/s_quadrant.xml
+++ b/theme_nano/views/snippets/s_quadrant.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+
+<template id="s_quadrant" inherit_id="website.s_quadrant">
+    <!-- Title -->
+    <xpath expr="//h2" position="replace" mode="inner">
+        Creative Agency
+    </xpath>
+    <!-- Paragraph -->
+    <xpath expr="//p[hasclass('lead')]" position="replace" mode="inner">
+        Partner with our creative agency for cutting-edge design and IT services. We bring your vision to life with innovative solutions tailored to your needs.<br/><br/> Let's create something extraordinary together.
+    </xpath>
+    <!-- Button -->
+    <xpath expr="//a[hasclass('btn')]/t" position="replace" mode="inner">
+        Contact Us
+    </xpath>
+</template>
+
+</odoo>

--- a/theme_notes/__manifest__.py
+++ b/theme_notes/__manifest__.py
@@ -43,6 +43,7 @@
         'views/snippets/s_image_hexagonal.xml',
         'views/snippets/s_striped_center_top.xml',
         'views/snippets/s_key_images.xml',
+        'views/snippets/s_quadrant.xml',
         'views/new_page_template.xml',
     ],
     'images': [

--- a/theme_notes/views/images_library.xml
+++ b/theme_notes/views/images_library.xml
@@ -252,6 +252,26 @@
     <field name="name">website.s_call_to_action_default_image</field>
     <field name="url">/theme_notes/static/src/img/content/s_call_to_action_default_image.jpg</field>
 </record>
+<record id="s_quadrant_default_image_1" model="theme.ir.attachment">
+    <field name="key">website.s_quadrant_default_image_1</field>
+    <field name="name">website.s_quadrant_default_image_1</field>
+    <field name="url">/theme_notes/static/src/img/content/content_img_14.jpg</field>
+</record>
+<record id="s_quadrant_default_image_2" model="theme.ir.attachment">
+    <field name="key">website.s_quadrant_default_image_2</field>
+    <field name="name">website.s_quadrant_default_image_2</field>
+    <field name="url">/theme_notes/static/src/img/content/library_image_03.jpg</field>
+</record>
+<record id="s_quadrant_default_image_3" model="theme.ir.attachment">
+    <field name="key">website.s_quadrant_default_image_3</field>
+    <field name="name">website.s_quadrant_default_image_3</field>
+    <field name="url">/theme_notes/static/src/img/content/content_img_24.jpg</field>
+</record>
+<record id="s_quadrant_default_image_4" model="theme.ir.attachment">
+    <field name="key">website.s_quadrant_default_image_4</field>
+    <field name="name">website.s_quadrant_default_image_4</field>
+    <field name="url">/theme_notes/static/src/img/content/s_quotes_carousel_demo_image_3.jpg</field>
+</record>
 <record id="s_accordion_image_default_image" model="theme.ir.attachment">
     <field name="key">website.s_accordion_image_default_image</field>
     <field name="name">website.s_accordion_image_default_image</field>

--- a/theme_notes/views/snippets/s_quadrant.xml
+++ b/theme_notes/views/snippets/s_quadrant.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+
+<template id="s_quadrant" inherit_id="website.s_quadrant">
+    <!-- Title -->
+    <xpath expr="//h2" position="replace" mode="inner">
+        Music &amp; Concerts
+    </xpath>
+    <!-- Paragraph -->
+    <xpath expr="//p[hasclass('lead')]" position="replace" mode="inner">
+        Dive into the world of music with our live concerts and artist events. From sound to stage, we bring you the best in music entertainment.<br/><br/> Experience the magic of live performances.
+    </xpath>
+    <!-- Button -->
+    <xpath expr="//a[hasclass('btn')]/t" position="replace" mode="inner">
+        See Events
+    </xpath>
+</template>
+
+</odoo>

--- a/theme_odoo_experts/__manifest__.py
+++ b/theme_odoo_experts/__manifest__.py
@@ -40,6 +40,7 @@
         'views/snippets/s_striped_center_top.xml',
         'views/snippets/s_image_title.xml',
         'views/snippets/s_key_images.xml',
+        'views/snippets/s_quadrant.xml',
         'views/new_page_template.xml',
     ],
     'images': [

--- a/theme_odoo_experts/views/images.xml
+++ b/theme_odoo_experts/views/images.xml
@@ -215,6 +215,26 @@ Check in theme_loftspace's primary_variables.scss and theme.scss -->
     <field name="name">website.s_product_catalog_default_image</field>
     <field name="url">/theme_odoo_experts/static/src/img/snippets/s_product_catalog_default_image.jpg</field>
 </record>
+<record id="s_quadrant_default_image_1" model="theme.ir.attachment">
+    <field name="key">website.s_quadrant_default_image_1</field>
+    <field name="name">website.s_quadrant_default_image_1</field>
+    <field name="url">/theme_odoo_experts/static/src/img/snippets/s_parallax.jpg</field>
+</record>
+<record id="s_quadrant_default_image_2" model="theme.ir.attachment">
+    <field name="key">website.s_quadrant_default_image_2</field>
+    <field name="name">website.s_quadrant_default_image_2</field>
+    <field name="url">/theme_odoo_experts/static/src/img/snippets/s_popup.jpg</field>
+</record>
+<record id="s_quadrant_default_image_3" model="theme.ir.attachment">
+    <field name="key">website.s_quadrant_default_image_3</field>
+    <field name="name">website.s_quadrant_default_image_3</field>
+    <field name="url">/theme_odoo_experts/static/src/img/snippets/s_quotes_carousel_2.jpg</field>
+</record>
+<record id="s_quadrant_default_image_4" model="theme.ir.attachment">
+    <field name="key">website.s_quadrant_default_image_4</field>
+    <field name="name">website.s_quadrant_default_image_4</field>
+    <field name="url">/theme_odoo_experts/static/src/img/snippets/s_carousel_3.jpg</field>
+</record>
 <record id="s_accordion_image_default_image" model="theme.ir.attachment">
     <field name="key">website.s_accordion_image_default_image</field>
     <field name="name">website.s_accordion_image_default_image</field>

--- a/theme_odoo_experts/views/snippets/s_quadrant.xml
+++ b/theme_odoo_experts/views/snippets/s_quadrant.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+
+<template id="s_quadrant" inherit_id="website.s_quadrant">
+    <!-- Title -->
+    <xpath expr="//h2" position="replace" mode="inner">
+        Business Advisory
+    </xpath>
+    <!-- Paragraph -->
+    <xpath expr="//p[hasclass('lead')]" position="replace" mode="inner">
+        Optimize your business strategy with our expert advisory services. We provide the insights and support your need to navigate the corporate world with confidence.<br/><br/> Let’s achieve your business goals together.
+    </xpath>
+    <!-- Button -->
+    <xpath expr="//a[hasclass('btn')]/t" position="replace" mode="inner">
+        Get Advice
+    </xpath>
+</template>
+
+</odoo>

--- a/theme_orchid/__manifest__.py
+++ b/theme_orchid/__manifest__.py
@@ -30,6 +30,7 @@
         'views/snippets/s_media_list.xml',
         'views/snippets/s_product_catalog.xml',
         'views/snippets/s_unveil.xml',
+        'views/snippets/s_quadrant.xml',
         'views/snippets/s_numbers_showcase.xml',
         'views/snippets/s_key_benefits.xml',
         'views/snippets/s_image_hexagonal.xml',

--- a/theme_orchid/views/images.xml
+++ b/theme_orchid/views/images.xml
@@ -225,6 +225,26 @@ Check in theme_loftspace's primary_variables.scss and theme.scss -->
     <field name="name">website.library_image_16</field>
     <field name="url">/theme_orchid/static/src/img/snippets/library_image_16.jpg</field>
 </record>
+<record id="s_quadrant_default_image_1" model="theme.ir.attachment">
+    <field name="key">website.s_quadrant_default_image_1</field>
+    <field name="name">website.s_quadrant_default_image_1</field>
+    <field name="url">/theme_orchid/static/src/img/content/content_img_03.jpg</field>
+</record>
+<record id="s_quadrant_default_image_2" model="theme.ir.attachment">
+    <field name="key">website.s_quadrant_default_image_2</field>
+    <field name="name">website.s_quadrant_default_image_2</field>
+    <field name="url">/theme_orchid/static/src/img/snippets/library_image_05.jpg</field>
+</record>
+<record id="s_quadrant_default_image_3" model="theme.ir.attachment">
+    <field name="key">website.s_quadrant_default_image_3</field>
+    <field name="name">website.s_quadrant_default_image_3</field>
+    <field name="url">/theme_orchid/static/src/img/snippets/s_carousel_2.jpg</field>
+</record>
+<record id="s_quadrant_default_image_4" model="theme.ir.attachment">
+    <field name="key">website.s_quadrant_default_image_4</field>
+    <field name="name">website.s_quadrant_default_image_4</field>
+    <field name="url">/theme_orchid/static/src/img/content/content_img_12.jpg</field>
+</record>
 <record id="s_accordion_image_default_image" model="theme.ir.attachment">
     <field name="key">website.s_accordion_image_default_image</field>
     <field name="name">website.s_accordion_image_default_image</field>

--- a/theme_orchid/views/snippets/s_quadrant.xml
+++ b/theme_orchid/views/snippets/s_quadrant.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+
+<template id="s_quadrant" inherit_id="website.s_quadrant">
+    <!-- Title -->
+    <xpath expr="//h2" position="replace" mode="inner">
+        Floral &amp; Gardens
+    </xpath>
+    <!-- Paragraph -->
+    <xpath expr="//p[hasclass('lead')]" position="replace" mode="inner">
+        Bring nature’s beauty into your life with our exquisite floral arrangements and garden designs. Our selections are perfect for any occasion and setting.<br/><br/> Discover the elegance of flowers and greenery.
+    </xpath>
+    <!-- Button -->
+    <xpath expr="//a[hasclass('btn')]/t" position="replace" mode="inner">
+        Browse Flowers
+    </xpath>
+</template>
+
+</odoo>

--- a/theme_paptic/views/customizations.xml
+++ b/theme_paptic/views/customizations.xml
@@ -504,6 +504,22 @@
     </xpath>
 </template>
 
+<!-- ======== QUADRANT ======== -->
+<template id="s_quadrant" inherit_id="website.s_quadrant">
+    <!-- Title -->
+    <xpath expr="//h2" position="replace" mode="inner">
+        IT Consultancy
+    </xpath>
+    <!-- Paragraph -->
+    <xpath expr="//p[hasclass('lead')]" position="replace" mode="inner">
+        Unlock your business potential with our IT consultancy services. We offer strategic advice and cutting-edge solutions to keep you ahead in the tech world.<br/><br/> Let us guide your digital transformation.
+    </xpath>
+    <!-- Button -->
+    <xpath expr="//a[hasclass('btn')]/t" position="replace" mode="inner">
+        Get Started
+    </xpath>
+</template>
+
 <!-- ==== Accordion Image ===== -->
 <template id="s_accordion_image" inherit_id="website.s_accordion_image" name="Paptic s_accordion_image">
     <xpath expr="//section" position="attributes">

--- a/theme_paptic/views/images.xml
+++ b/theme_paptic/views/images.xml
@@ -186,6 +186,28 @@
     <field name="url">/theme_paptic/static/src/img/pictures/s_product_list_6.jpg</field>
 </record>
 
+<!-- Quadrant -->
+<record id="s_quadrant_default_image_1" model="theme.ir.attachment">
+    <field name="key">website.s_quadrant_default_image_1</field>
+    <field name="name">website.s_quadrant_default_image_1</field>
+    <field name="url">/theme_paptic/static/src/img/pictures/s_carousel_1.jpg</field>
+</record>
+<record id="s_quadrant_default_image_2" model="theme.ir.attachment">
+    <field name="key">website.s_quadrant_default_image_2</field>
+    <field name="name">website.s_quadrant_default_image_2</field>
+    <field name="url">/theme_paptic/static/src/img/pictures/s_carousel_3.jpg</field>
+</record>
+<record id="s_quadrant_default_image_3" model="theme.ir.attachment">
+    <field name="key">website.s_quadrant_default_image_3</field>
+    <field name="name">website.s_quadrant_default_image_3</field>
+    <field name="url">/theme_paptic/static/src/img/pictures/s_product_catalog.jpg</field>
+</record>
+<record id="s_quadrant_default_image_4" model="theme.ir.attachment">
+    <field name="key">website.s_quadrant_default_image_4</field>
+    <field name="name">website.s_quadrant_default_image_4</field>
+    <field name="url">/theme_paptic/static/src/img/pictures/s_quotes_carousel_bg_slide3.jpg</field>
+</record>
+
 <!-- Popup -->
 <record id="s_popup_default_image" model="theme.ir.attachment">
     <field name="key">website.s_popup_default_image</field>

--- a/theme_real_estate/__manifest__.py
+++ b/theme_real_estate/__manifest__.py
@@ -30,6 +30,7 @@
         'views/snippets/s_image_gallery.xml',
         'views/snippets/s_striped_center_top.xml',
         'views/snippets/s_call_to_action.xml',
+        'views/snippets/s_quadrant.xml',
         'views/snippets/s_unveil.xml',
         'views/snippets/s_key_benefits.xml',
         'views/snippets/s_carousel.xml',

--- a/theme_real_estate/views/images.xml
+++ b/theme_real_estate/views/images.xml
@@ -211,6 +211,26 @@ Check in theme_monglia's primary_variables.scss, theme.scss and theme_common's m
     <field name="name">website.library_image_17</field>
     <field name="url">/theme_real_estate/static/src/img/snippets/s_newsletter.jpg</field>
 </record>
+<record id="s_quadrant_default_image_1" model="theme.ir.attachment">
+    <field name="key">website.s_quadrant_default_image_1</field>
+    <field name="name">website.s_quadrant_default_image_1</field>
+    <field name="url">/theme_real_estate/static/src/img/snippets/s_carousel_1.jpg</field>
+</record>
+<record id="s_quadrant_default_image_2" model="theme.ir.attachment">
+    <field name="key">website.s_quadrant_default_image_2</field>
+    <field name="name">website.s_quadrant_default_image_2</field>
+    <field name="url">/theme_real_estate/static/src/img/snippets/s_carousel_2.jpg</field>
+</record>
+<record id="s_quadrant_default_image_3" model="theme.ir.attachment">
+    <field name="key">website.s_quadrant_default_image_3</field>
+    <field name="name">website.s_quadrant_default_image_3</field>
+    <field name="url">/theme_real_estate/static/src/img/snippets/s_carousel_3.jpg</field>
+</record>
+<record id="s_quadrant_default_image_4" model="theme.ir.attachment">
+    <field name="key">website.s_quadrant_default_image_4</field>
+    <field name="name">website.s_quadrant_default_image_4</field>
+    <field name="url">/theme_real_estate/static/src/img/snippets/s_image_text.jpg</field>
+</record>
 <record id="s_accordion_image_default_image" model="theme.ir.attachment">
     <field name="key">website.s_accordion_image_default_image</field>
     <field name="name">website.s_accordion_image_default_image</field>

--- a/theme_real_estate/views/snippets/s_quadrant.xml
+++ b/theme_real_estate/views/snippets/s_quadrant.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+
+<template id="s_quadrant" inherit_id="website.s_quadrant">
+    <!-- Title -->
+    <xpath expr="//h2" position="replace" mode="inner">
+        Real Estate
+    </xpath>
+    <!-- Paragraph -->
+    <xpath expr="//p[hasclass('lead')]" position="replace" mode="inner">
+        Find your dream property with our real estate services. Whether you’re looking to buy, sell, or rent, we offer expert guidance and personalized solutions.<br/><br/> Your perfect home is just a click away.
+    </xpath>
+    <!-- Button -->
+    <xpath expr="//a[hasclass('btn')]/t" position="replace" mode="inner">
+        View Listings
+    </xpath>
+</template>
+
+</odoo>

--- a/theme_treehouse/__manifest__.py
+++ b/theme_treehouse/__manifest__.py
@@ -33,6 +33,7 @@
         'views/snippets/s_features_wall.xml',
         'views/snippets/s_three_columns.xml',
         'views/snippets/s_title.xml',
+        'views/snippets/s_quadrant.xml',
         'views/snippets/s_unveil.xml',
         'views/snippets/s_key_benefits.xml',
         'views/snippets/s_pricelist_boxed.xml',

--- a/theme_treehouse/views/images_library.xml
+++ b/theme_treehouse/views/images_library.xml
@@ -333,4 +333,26 @@
     <field name="url">/theme_treehouse/static/src/img/content/s_kickoff_default_image.jpg</field>
 </record>
 
+<!-- Quadrant -->
+<record id="s_quadrant_default_image_1" model="theme.ir.attachment">
+    <field name="key">website.s_quadrant_default_image_1</field>
+    <field name="name">website.s_quadrant_default_image_1</field>
+    <field name="url">/theme_treehouse/static/src/img/backgrounds/07.jpg</field>
+</record>
+<record id="s_quadrant_default_image_2" model="theme.ir.attachment">
+    <field name="key">website.s_quadrant_default_image_2</field>
+    <field name="name">website.s_quadrant_default_image_2</field>
+    <field name="url">/theme_treehouse/static/src/img/backgrounds/09.jpg</field>
+</record>
+<record id="s_quadrant_default_image_3" model="theme.ir.attachment">
+    <field name="key">website.s_quadrant_default_image_3</field>
+    <field name="name">website.s_quadrant_default_image_3</field>
+    <field name="url">/theme_treehouse/static/src/img/backgrounds/10.jpg</field>
+</record>
+<record id="s_quadrant_default_image_4" model="theme.ir.attachment">
+    <field name="key">website.s_quadrant_default_image_4</field>
+    <field name="name">website.s_quadrant_default_image_4</field>
+    <field name="url">/theme_treehouse/static/src/img/backgrounds/12.jpg</field>
+</record>
+
 </odoo>

--- a/theme_treehouse/views/snippets/s_quadrant.xml
+++ b/theme_treehouse/views/snippets/s_quadrant.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+
+<template id="s_quadrant" inherit_id="website.s_quadrant">
+    <!-- Title -->
+    <xpath expr="//h2" position="replace" mode="inner">
+        Sustainability
+    </xpath>
+    <!-- Paragraph -->
+    <xpath expr="//p[hasclass('lead')]" position="replace" mode="inner">
+        Join us in promoting sustainability and protecting the environment. Our initiatives focus on eco-friendly practices and sustainable development.<br/><br/> Be part of the change for a greener future.
+    </xpath>
+    <!-- Button -->
+    <xpath expr="//a[hasclass('btn')]/t" position="replace" mode="inner">
+        Get Involved
+    </xpath>
+</template>
+
+</odoo>

--- a/theme_vehicle/views/customizations.xml
+++ b/theme_vehicle/views/customizations.xml
@@ -479,6 +479,22 @@
     </xpath>
 </template>
 
+<!-- ======== QUADRANT ======== -->
+<template id="s_quadrant" inherit_id="website.s_quadrant">
+    <!-- Title -->
+    <xpath expr="//h2" position="replace" mode="inner">
+        Vehicle Services
+    </xpath>
+    <!-- Paragraph -->
+    <xpath expr="//p[hasclass('lead')]" position="replace" mode="inner">
+        Keep your vehicle in top condition with our expert repair and maintenance services. From cars to motorbikes, we’ve got you covered.<br/><br/> Drive with confidence and style.
+    </xpath>
+    <!-- Button -->
+    <xpath expr="//a[hasclass('btn')]/t" position="replace" mode="inner">
+        Book a Service
+    </xpath>
+</template>
+
 <!-- ======== KEY BENEFITS ======== -->
 <template id="s_key_benefits" inherit_id="website.s_key_benefits">
     <!-- Titles -->

--- a/theme_vehicle/views/images.xml
+++ b/theme_vehicle/views/images.xml
@@ -220,6 +220,26 @@ Check in theme_monglia's primary_variables.scss, theme.scss and theme_common's m
     <field name="name">website.library_image_17</field>
     <field name="url">/theme_vehicle/static/src/img/snippets/s_newsletter.jpg</field>
 </record>
+<record id="s_quadrant_default_image_1" model="theme.ir.attachment">
+    <field name="key">website.s_quadrant_default_image_1</field>
+    <field name="name">website.s_quadrant_default_image_1</field>
+    <field name="url">/theme_vehicle/static/src/img/content/content_img_03.jpg</field>
+</record>
+<record id="s_quadrant_default_image_2" model="theme.ir.attachment">
+    <field name="key">website.s_quadrant_default_image_2</field>
+    <field name="name">website.s_quadrant_default_image_2</field>
+    <field name="url">/theme_vehicle/static/src/img/content/content_img_12.jpg</field>
+</record>
+<record id="s_quadrant_default_image_3" model="theme.ir.attachment">
+    <field name="key">website.s_quadrant_default_image_3</field>
+    <field name="name">website.s_quadrant_default_image_3</field>
+    <field name="url">/theme_vehicle/static/src/img/content/content_img_02.jpg</field>
+</record>
+<record id="s_quadrant_default_image_4" model="theme.ir.attachment">
+    <field name="key">website.s_quadrant_default_image_4</field>
+    <field name="name">website.s_quadrant_default_image_4</field>
+    <field name="url">/theme_vehicle/static/src/img/content/content_img_10.jpg</field>
+</record>
 <record id="s_accordion_image_default_image" model="theme.ir.attachment">
     <field name="key">website.s_accordion_image_default_image</field>
     <field name="name">website.s_accordion_image_default_image</field>

--- a/theme_yes/__manifest__.py
+++ b/theme_yes/__manifest__.py
@@ -34,6 +34,7 @@
         'views/snippets/s_text_image.xml',
         'views/snippets/s_three_columns.xml',
         'views/snippets/s_title.xml',
+        'views/snippets/s_quadrant.xml',
         'views/snippets/s_unveil.xml',
         'views/snippets/s_key_benefits.xml',
         'views/snippets/s_pricelist_boxed.xml',

--- a/theme_yes/views/images.xml
+++ b/theme_yes/views/images.xml
@@ -298,6 +298,27 @@ Check in theme_kea's primary_variables.scss, theme.scss and theme_common's mixin
     <field name="name">website.s_newsletter_block</field>
     <field name="url">/theme_yes/static/src/img/snippets/s_newsletter.jpg</field>
 </record>
+<!-- Quadrant -->
+<record id="s_quadrant_default_image_1" model="theme.ir.attachment">
+    <field name="key">website.s_quadrant_default_image_1</field>
+    <field name="name">website.s_quadrant_default_image_1</field>
+    <field name="url">/theme_yes/static/src/img/content/content_img_07.jpg</field>
+</record>
+<record id="s_quadrant_default_image_2" model="theme.ir.attachment">
+    <field name="key">website.s_quadrant_default_image_2</field>
+    <field name="name">website.s_quadrant_default_image_2</field>
+    <field name="url">/theme_yes/static/src/img/snippets/library_image_08.jpg</field>
+</record>
+<record id="s_quadrant_default_image_3" model="theme.ir.attachment">
+    <field name="key">website.s_quadrant_default_image_3</field>
+    <field name="name">website.s_quadrant_default_image_3</field>
+    <field name="url">/theme_yes/static/src/img/snippets/library_image_10.jpg</field>
+</record>
+<record id="s_quadrant_default_image_4" model="theme.ir.attachment">
+    <field name="key">website.s_quadrant_default_image_4</field>
+    <field name="name">website.s_quadrant_default_image_4</field>
+    <field name="url">/theme_yes/static/src/img/snippets/s_banner.jpg</field>
+</record>
 <!-- // Accordion Image // -->
 <record id="s_accordion_image_default_image" model="theme.ir.attachment">
     <field name="key">website.s_accordion_image_default_image</field>

--- a/theme_yes/views/snippets/s_quadrant.xml
+++ b/theme_yes/views/snippets/s_quadrant.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+
+<template id="s_quadrant" inherit_id="website.s_quadrant">
+    <!-- Title -->
+    <xpath expr="//h2" position="replace" mode="inner">
+        Wedding Memories
+    </xpath>
+    <!-- Paragraph -->
+    <xpath expr="//p[hasclass('lead')]" position="replace" mode="inner">
+        Capture the magic of your special day with our professional wedding photography services. We help you create memories that last a lifetime.<br/><br/> Let us tell your love story.
+    </xpath>
+    <!-- Button -->
+    <xpath expr="//a[hasclass('btn')]/t" position="replace" mode="inner">
+        View Portfolio
+    </xpath>
+</template>
+
+</odoo>

--- a/theme_zap/__manifest__.py
+++ b/theme_zap/__manifest__.py
@@ -28,6 +28,7 @@
         'views/snippets/s_three_columns.xml',
         'views/snippets/s_image_gallery.xml',
         'views/snippets/s_freegrid.xml',
+        'views/snippets/s_quadrant.xml',
         'views/snippets/s_unveil.xml',
         'views/snippets/s_numbers_showcase.xml',
         'views/snippets/s_key_benefits.xml',

--- a/theme_zap/views/images_library.xml
+++ b/theme_zap/views/images_library.xml
@@ -293,6 +293,28 @@
     <field name="url">/theme_zap/static/src/img/backgrounds/04.jpg</field>
 </record>
 
+<!-- Quadrant -->
+<record id="s_quadrant_default_image_1" model="theme.ir.attachment">
+    <field name="key">website.s_quadrant_default_image_1</field>
+    <field name="name">website.s_quadrant_default_image_1</field>
+    <field name="url">/theme_zap/static/src/img/backgrounds/03.jpg</field>
+</record>
+<record id="s_quadrant_default_image_2" model="theme.ir.attachment">
+    <field name="key">website.s_quadrant_default_image_2</field>
+    <field name="name">website.s_quadrant_default_image_2</field>
+    <field name="url">/theme_zap/static/src/img/backgrounds/06.jpg</field>
+</record>
+<record id="s_quadrant_default_image_3" model="theme.ir.attachment">
+    <field name="key">website.s_quadrant_default_image_3</field>
+    <field name="name">website.s_quadrant_default_image_3</field>
+    <field name="url">/theme_zap/static/src/img/backgrounds/12.jpg</field>
+</record>
+<record id="s_quadrant_default_image_4" model="theme.ir.attachment">
+    <field name="key">website.s_quadrant_default_image_4</field>
+    <field name="name">website.s_quadrant_default_image_4</field>
+    <field name="url">/theme_zap/static/src/img/backgrounds/13.jpg</field>
+</record>
+
 <!-- Image Title -->
 <record id="s_image_title_default_image" model="theme.ir.attachment">
     <field name="key">website.s_image_title_default_image</field>

--- a/theme_zap/views/snippets/s_quadrant.xml
+++ b/theme_zap/views/snippets/s_quadrant.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+
+<template id="s_quadrant" inherit_id="website.s_quadrant">
+    <!-- Title -->
+    <xpath expr="//h2" position="replace" mode="inner">
+        Digital Marketing
+    </xpath>
+    <!-- Paragraph -->
+    <xpath expr="//p[hasclass('lead')]" position="replace" mode="inner">
+        Boost your brand’s online presence with our expert digital marketing services. From copywriting to media campaigns, we tailor strategies that drive results.<br/><br/> Elevate your brand with us.
+    </xpath>
+    <!-- Button -->
+    <xpath expr="//a[hasclass('btn')]/t" position="replace" mode="inner">
+        Start Campaign
+    </xpath>
+</template>
+
+</odoo>


### PR DESCRIPTION
*: anelusia, artists, avantgarde, aviato, beauty, bewise, bistro, bookstore, buzzy, clean, cobalt, enark, graphene, kea, kiddo, loftspace, monglia, nano, notes, odoo_experts, paptic, real_estate, treehouse, vehicle, yes, zap

This commit adapts the design of `s_quadrant` for multiple themes, based on the new Odoo 18 snippet redesign.

task-4105045
Part-of: task-4077427

requires: https://github.com/odoo/odoo/pull/177058