### PR TITLE
[IMP] theme_*: adapt theme with new `s_features_wall` snippet

### DIFF
--- a/theme_anelusia/__manifest__.py
+++ b/theme_anelusia/__manifest__.py
@@ -29,6 +29,7 @@
         'views/snippets/s_product_catalog.xml',
         'views/snippets/s_showcase.xml',
         'views/snippets/s_text_image.xml',
+        'views/snippets/s_features_wall.xml',
         'views/snippets/s_image_text.xml',
         'views/snippets/s_numbers.xml',
         'views/snippets/s_three_columns.xml',

--- a/theme_anelusia/views/snippets/s_features_wall.xml
+++ b/theme_anelusia/views/snippets/s_features_wall.xml
@@ -1,0 +1,36 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+
+<template id="s_features_wall" inherit_id="website.s_features_wall">
+    <!-- Section -->
+    <xpath expr="//section" position="attributes">
+        <attribute name="data-oe-shape-data">{"shape":"web_editor/Floats/09"}</attribute>
+    </xpath>
+    <!-- Shape -->
+    <xpath expr="//div[hasclass('o_we_shape')]" position="replace">
+        <div class="o_we_shape o_web_editor_Floats_09 o_we_animated"/>
+    </xpath>
+    <!-- Card 1 -->
+    <xpath expr="//div[hasclass('g-col-lg-3')]//h3" position="replace" mode="inner">
+        Custom Tailoring
+    </xpath>
+    <xpath expr="//div[hasclass('g-col-lg-3')]//p" position="replace" mode="inner">
+        Experience perfectly fitted clothing with our bespoke tailoring service, designed to match your unique style and body shape.
+    </xpath>
+    <!-- Card 2 -->
+    <xpath expr="//div[hasclass('g-col-lg-3')][4]//h3" position="replace" mode="inner">
+        Personal Styling
+    </xpath>
+    <xpath expr="//div[hasclass('g-col-lg-3')][4]//p" position="replace" mode="inner">
+        Elevate your wardrobe with personalized styling advice from our experts, helping you express your individuality effortlessly.
+    </xpath>
+    <!-- Card 3 -->
+    <xpath expr="//div[hasclass('g-col-lg-3')][6]//h3" position="replace" mode="inner">
+        Trend Forecasting
+    </xpath>
+    <xpath expr="//div[hasclass('g-col-lg-3')][6]//p" position="replace" mode="inner">
+        Stay ahead of fashion trends with our insightful forecasts, curated to keep your look fresh and contemporary all year round.
+    </xpath>
+</template>
+
+</odoo>

--- a/theme_artists/__manifest__.py
+++ b/theme_artists/__manifest__.py
@@ -27,6 +27,7 @@
         'views/snippets/s_picture.xml',
         'views/snippets/s_image_text.xml',
         'views/snippets/s_features_grid.xml',
+        'views/snippets/s_features_wall.xml',
         'views/snippets/s_product_catalog.xml',
         'views/snippets/s_quotes_carousel.xml',
         'views/snippets/s_comparisons.xml',

--- a/theme_artists/views/snippets/s_features_wall.xml
+++ b/theme_artists/views/snippets/s_features_wall.xml
@@ -1,0 +1,37 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+
+<template id="s_features_wall" inherit_id="website.s_features_wall">
+    <!-- Section -->
+    <xpath expr="//section" position="attributes">
+        <attribute name="class" add="o_cc o_cc4" separator=" "/>
+        <attribute name="data-oe-shape-data">{"shape":"web_editor/Floats/02"}</attribute>
+    </xpath>
+    <!-- Shape -->
+    <xpath expr="//div[hasclass('o_we_shape')]" position="replace">
+        <div class="o_we_shape o_web_editor_Floats_02 o_we_animated"/>
+    </xpath>
+    <!-- Card 1 -->
+    <xpath expr="//div[hasclass('g-col-lg-3')]//h3" position="replace" mode="inner">
+        Custom Art Commissions
+    </xpath>
+    <xpath expr="//div[hasclass('g-col-lg-3')]//p" position="replace" mode="inner">
+        Bring your vision to life with personalized artwork created by talented artists, tailored to your unique preferences.
+    </xpath>
+    <!-- Card 2 -->
+    <xpath expr="//div[hasclass('g-col-lg-3')][4]//h3" position="replace" mode="inner">
+        Art Restoration &amp; Repair
+    </xpath>
+    <xpath expr="//div[hasclass('g-col-lg-3')][4]//p" position="replace" mode="inner">
+        Restore your cherished art pieces to their former glory with expert cleaning, repair, and preservation services.
+    </xpath>
+    <!-- Card 3 -->
+    <xpath expr="//div[hasclass('g-col-lg-3')][6]//h3" position="replace" mode="inner">
+        Exclusive Art Prints
+    </xpath>
+    <xpath expr="//div[hasclass('g-col-lg-3')][6]//p" position="replace" mode="inner">
+        Discover limited-edition prints of stunning original artworks, perfect for enhancing your home or office space.
+    </xpath>
+</template>
+
+</odoo>

--- a/theme_aviato/__manifest__.py
+++ b/theme_aviato/__manifest__.py
@@ -22,6 +22,7 @@
         'views/snippets/s_popup.xml',
         'views/snippets/s_title.xml',
         'views/snippets/s_quotes_carousel.xml',
+        'views/snippets/s_features_wall.xml',
         'views/snippets/s_unveil.xml',
         'views/snippets/s_accordion_image.xml',
         'views/snippets/s_key_benefits.xml',

--- a/theme_aviato/views/snippets/s_features_wall.xml
+++ b/theme_aviato/views/snippets/s_features_wall.xml
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+
+<template id="s_features_wall" inherit_id="website.s_features_wall">
+    <!-- Card 1 -->
+    <xpath expr="//div[hasclass('g-col-lg-3')]//h3" position="replace" mode="inner">
+        Tailored Travel Packages
+    </xpath>
+    <xpath expr="//div[hasclass('g-col-lg-3')]//p" position="replace" mode="inner">
+        Experience personalized itineraries crafted to suit your interests, preferences, and budget for the perfect vacation.
+    </xpath>
+    <!-- Card 2 -->
+    <xpath expr="//div[hasclass('g-col-lg-3')][4]//h3" position="replace" mode="inner">
+        Group Tours &amp; Adventures
+    </xpath>
+    <xpath expr="//div[hasclass('g-col-lg-3')][4]//p" position="replace" mode="inner">
+        Join expertly guided group tours for exciting cultural, historical, and nature-filled experiences in top destinations worldwide.
+    </xpath>
+    <!-- Card 3 -->
+    <xpath expr="//div[hasclass('g-col-lg-3')][6]//h3" position="replace" mode="inner">
+        Flight &amp; Hotel Deals
+    </xpath>
+    <xpath expr="//div[hasclass('g-col-lg-3')][6]//p" position="replace" mode="inner">
+        Save big on exclusive flight and hotel offers, ensuring comfortable and affordable accommodations throughout your journey.
+    </xpath>
+</template>
+
+</odoo>

--- a/theme_beauty/__manifest__.py
+++ b/theme_beauty/__manifest__.py
@@ -31,6 +31,7 @@
         'views/snippets/s_product_catalog.xml',
         'views/snippets/s_unveil.xml',
         'views/snippets/s_numbers_showcase.xml',
+        'views/snippets/s_features_wall.xml',
         'views/snippets/s_accordion_image.xml',
         'views/snippets/s_key_benefits.xml',
         'views/snippets/s_carousel.xml',

--- a/theme_beauty/views/snippets/s_features_wall.xml
+++ b/theme_beauty/views/snippets/s_features_wall.xml
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+
+<template id="s_features_wall" inherit_id="website.s_features_wall">
+    <!-- Card 1 -->
+    <xpath expr="//div[hasclass('g-col-lg-3')]//h3" position="replace" mode="inner">
+        Natural Skincare Products
+    </xpath>
+    <xpath expr="//div[hasclass('g-col-lg-3')]//p" position="replace" mode="inner">
+        Revitalize your skin with our range of organic, chemical-free skincare products designed for all skin types.
+    </xpath>
+    <!-- Card 2 -->
+    <xpath expr="//div[hasclass('g-col-lg-3')][4]//h3" position="replace" mode="inner">
+        Premium Makeup Collection
+    </xpath>
+    <xpath expr="//div[hasclass('g-col-lg-3')][4]//p" position="replace" mode="inner">
+        Explore our luxurious makeup selection, offering vibrant colors and long-lasting formulas for a flawless look every day.
+    </xpath>
+    <!-- Card 3 -->
+    <xpath expr="//div[hasclass('g-col-lg-3')][6]//h3" position="replace" mode="inner">
+        Fragrances and Scents
+    </xpath>
+    <xpath expr="//div[hasclass('g-col-lg-3')][6]//p" position="replace" mode="inner">
+        Find your signature scent with our exclusive range of perfumes, crafted to leave a lasting impression all day long.
+    </xpath>
+</template>
+
+</odoo>

--- a/theme_bewise/views/customizations.xml
+++ b/theme_bewise/views/customizations.xml
@@ -325,6 +325,31 @@
     </xpath>
 </template>
 
+<!-- ======== FEATURES WALL ======== -->
+<template id="s_features_wall" inherit_id="website.s_features_wall">
+    <!-- Card 1 -->
+    <xpath expr="//div[hasclass('g-col-lg-3')]//h3" position="replace" mode="inner">
+        Innovative Academic Programs
+    </xpath>
+    <xpath expr="//div[hasclass('g-col-lg-3')]//p" position="replace" mode="inner">
+        Explore cutting-edge courses designed to prepare you for success in today’s evolving job market and academic fields.
+    </xpath>
+    <!-- Card 2 -->
+    <xpath expr="//div[hasclass('g-col-lg-3')][4]//h3" position="replace" mode="inner">
+        World-Class Faculty
+    </xpath>
+    <xpath expr="//div[hasclass('g-col-lg-3')][4]//p" position="replace" mode="inner">
+        Learn from distinguished professors and industry experts dedicated to providing exceptional education and mentorship.
+    </xpath>
+    <!-- Card 3 -->
+    <xpath expr="//div[hasclass('g-col-lg-3')][6]//h3" position="replace" mode="inner">
+        Global Student Experience
+    </xpath>
+    <xpath expr="//div[hasclass('g-col-lg-3')][6]//p" position="replace" mode="inner">
+        Immerse yourself in a diverse campus community with opportunities for international exchange, cultural enrichment, and personal growth.
+    </xpath>
+</template>
+
 <!-- ======== FEATURES ======== -->
 <template id="s_features" inherit_id="website.s_features" name="Be Wise s_features">
     <!-- Icons -->

--- a/theme_bistro/__manifest__.py
+++ b/theme_bistro/__manifest__.py
@@ -21,6 +21,7 @@
         'views/snippets/s_image_text.xml',
         'views/snippets/s_freegrid.xml',
         'views/snippets/s_media_list.xml',
+        'views/snippets/s_features_wall.xml',
         'views/snippets/s_numbers.xml',
         'views/snippets/s_picture.xml',
         'views/snippets/s_product_catalog.xml',

--- a/theme_bistro/views/snippets/s_features_wall.xml
+++ b/theme_bistro/views/snippets/s_features_wall.xml
@@ -1,0 +1,36 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+
+<template id="s_features_wall" inherit_id="website.s_features_wall">
+    <!-- Section -->
+    <xpath expr="//section" position="attributes">
+        <attribute name="data-oe-shape-data">{"shape":"web_editor/Blobs/06"}</attribute>
+    </xpath>
+    <!-- Shape -->
+    <xpath expr="//div[hasclass('o_we_shape')]" position="replace">
+        <div class="o_we_shape o_web_editor_Blobs_06 o_we_animated"/>
+    </xpath>
+    <!-- Card 1 -->
+    <xpath expr="//div[hasclass('g-col-lg-3')]//h3" position="replace" mode="inner">
+        Gourmet Dining Experience
+    </xpath>
+    <xpath expr="//div[hasclass('g-col-lg-3')]//p" position="replace" mode="inner">
+        Savor exquisite dishes crafted with fresh, high-quality ingredients in a sophisticated and welcoming atmosphere.
+    </xpath>
+    <!-- Card 2 -->
+    <xpath expr="//div[hasclass('g-col-lg-3')][4]//h3" position="replace" mode="inner">
+        Signature Cocktails and Wines
+    </xpath>
+    <xpath expr="//div[hasclass('g-col-lg-3')][4]//p" position="replace" mode="inner">
+        Enjoy a curated selection of unique cocktails and fine wines, expertly paired to complement your meal.
+    </xpath>
+    <!-- Card 3 -->
+    <xpath expr="//div[hasclass('g-col-lg-3')][6]//h3" position="replace" mode="inner">
+        Exceptional Service
+    </xpath>
+    <xpath expr="//div[hasclass('g-col-lg-3')][6]//p" position="replace" mode="inner">
+        Delight in attentive and personalized service that ensures a memorable dining experience from start to finish.
+    </xpath>
+</template>
+
+</odoo>

--- a/theme_bookstore/__manifest__.py
+++ b/theme_bookstore/__manifest__.py
@@ -22,6 +22,7 @@
         'views/snippets/s_image_text.xml',
         'views/snippets/s_showcase.xml',
         'views/snippets/s_freegrid.xml',
+        'views/snippets/s_features_wall.xml',
         'views/snippets/s_masonry_block.xml',
         'views/snippets/s_banner.xml',
         'views/snippets/s_numbers.xml',

--- a/theme_bookstore/views/snippets/s_features_wall.xml
+++ b/theme_bookstore/views/snippets/s_features_wall.xml
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+
+<template id="s_features_wall" inherit_id="website.s_features_wall">
+    <!-- Card 1 -->
+    <xpath expr="//div[hasclass('g-col-lg-3')]//h3" position="replace" mode="inner">
+        Curated Book Selections
+    </xpath>
+    <xpath expr="//div[hasclass('g-col-lg-3')]//p" position="replace" mode="inner">
+        Discover a handpicked collection of books across genres, featuring bestsellers, classics, and hidden gems for every reader.
+    </xpath>
+    <!-- Card 2 -->
+    <xpath expr="//div[hasclass('g-col-lg-3')][4]//h3" position="replace" mode="inner">
+        Cozy Reading Nooks
+    </xpath>
+    <xpath expr="//div[hasclass('g-col-lg-3')][4]//p" position="replace" mode="inner">
+        Enjoy a relaxing atmosphere with comfortable seating and quiet spaces perfect for browsing and reading your new favorites.
+    </xpath>
+    <!-- Card 3 -->
+    <xpath expr="//div[hasclass('g-col-lg-3')][6]//h3" position="replace" mode="inner">
+        Literary Events and Signings
+    </xpath>
+    <xpath expr="//div[hasclass('g-col-lg-3')][6]//p" position="replace" mode="inner">
+        Attend author events, book signings, and literary discussions that connect you with the vibrant world of books and writers.
+    </xpath>
+</template>
+
+</odoo>

--- a/theme_enark/__manifest__.py
+++ b/theme_enark/__manifest__.py
@@ -23,6 +23,7 @@
         'views/snippets/s_call_to_action.xml',
         'views/snippets/s_parallax.xml',
         'views/snippets/s_image_gallery.xml',
+        'views/snippets/s_features_wall.xml',
         'views/snippets/s_unveil.xml',
         'views/snippets/s_key_benefits.xml',
         'views/snippets/s_carousel.xml',

--- a/theme_enark/views/snippets/s_features_wall.xml
+++ b/theme_enark/views/snippets/s_features_wall.xml
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+
+<template id="s_features_wall" inherit_id="website.s_features_wall">
+    <!-- Card 1 -->
+    <xpath expr="//div[hasclass('g-col-lg-3')]//h3" position="replace" mode="inner">
+        Innovative Design Solutions
+    </xpath>
+    <xpath expr="//div[hasclass('g-col-lg-3')]//p" position="replace" mode="inner">
+        Transform your vision into reality with cutting-edge architectural designs tailored to your unique needs and aesthetic preferences.
+    </xpath>
+    <!-- Card 2 -->
+    <xpath expr="//div[hasclass('g-col-lg-3')][4]//h3" position="replace" mode="inner">
+        Sustainable Building Practices
+    </xpath>
+    <xpath expr="//div[hasclass('g-col-lg-3')][4]//p" position="replace" mode="inner">
+        Embrace eco-friendly architecture with sustainable design solutions that enhance efficiency and reduce environmental impact.
+    </xpath>
+    <!-- Card 3 -->
+    <xpath expr="//div[hasclass('g-col-lg-3')][6]//h3" position="replace" mode="inner">
+        Detailed Project Management
+    </xpath>
+    <xpath expr="//div[hasclass('g-col-lg-3')][6]//p" position="replace" mode="inner">
+        Experience seamless project execution with meticulous planning, budgeting, and oversight from concept to completion.
+    </xpath>
+</template>
+
+</odoo>

--- a/theme_kea/__manifest__.py
+++ b/theme_kea/__manifest__.py
@@ -20,6 +20,7 @@
         'views/snippets/s_freegrid.xml',
         'views/snippets/s_references.xml',
         'views/snippets/s_color_blocks_2.xml',
+        'views/snippets/s_features_wall.xml',
         'views/snippets/s_picture.xml',
         'views/snippets/s_title.xml',
         'views/snippets/s_numbers.xml',

--- a/theme_kea/views/snippets/s_features_wall.xml
+++ b/theme_kea/views/snippets/s_features_wall.xml
@@ -1,0 +1,37 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+
+<template id="s_features_wall" inherit_id="website.s_features_wall">
+    <!-- Section -->
+    <xpath expr="//section" position="attributes">
+        <attribute name="class" add="o_cc o_cc3" separator=" "/>
+        <attribute name="data-oe-shape-data">{"shape":"web_editor/Floats/02"}</attribute>
+    </xpath>
+    <!-- Shape -->
+    <xpath expr="//div[hasclass('o_we_shape')]" position="replace">
+        <div class="o_we_shape o_web_editor_Floats_02 o_we_animated"/>
+    </xpath>
+    <!-- Card 1 -->
+    <xpath expr="//div[hasclass('g-col-lg-3')]//h3" position="replace" mode="inner">
+        Immersive VR Experiences
+    </xpath>
+    <xpath expr="//div[hasclass('g-col-lg-3')]//p" position="replace" mode="inner">
+        Dive into captivating virtual worlds with our state-of-the-art VR technology, offering unparalleled immersion and interactive adventures.
+    </xpath>
+    <!-- Card 2 -->
+    <xpath expr="//div[hasclass('g-col-lg-3')][4]//h3" position="replace" mode="inner">
+        Custom VR Solutions
+    </xpath>
+    <xpath expr="//div[hasclass('g-col-lg-3')][4]//p" position="replace" mode="inner">
+        Tailor virtual reality applications to meet your specific needs, whether for gaming, training, or business applications.
+    </xpath>
+    <!-- Card 3 -->
+    <xpath expr="//div[hasclass('g-col-lg-3')][6]//h3" position="replace" mode="inner">
+        Cutting-Edge VR Equipment
+    </xpath>
+    <xpath expr="//div[hasclass('g-col-lg-3')][6]//p" position="replace" mode="inner">
+        Equip yourself with the latest in VR hardware and accessories, ensuring top performance and an exceptional user experience.
+    </xpath>
+</template>
+
+</odoo>

--- a/theme_kiddo/__manifest__.py
+++ b/theme_kiddo/__manifest__.py
@@ -21,6 +21,7 @@
         'views/snippets/s_company_team_shapes.xml',
         'views/snippets/s_cover.xml',
         'views/snippets/s_three_columns.xml',
+        'views/snippets/s_features_wall.xml',
         'views/snippets/s_quotes_carousel.xml',
         'views/snippets/s_text_image.xml',
         'views/snippets/s_product_catalog.xml',

--- a/theme_kiddo/views/snippets/s_features_wall.xml
+++ b/theme_kiddo/views/snippets/s_features_wall.xml
@@ -1,0 +1,36 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+
+<template id="s_features_wall" inherit_id="website.s_features_wall">
+    <!-- Section -->
+    <xpath expr="//section" position="attributes">
+        <attribute name="data-oe-shape-data">{"shape":"web_editor/Floats/05"}</attribute>
+    </xpath>
+    <!-- Shape -->
+    <xpath expr="//div[hasclass('o_we_shape')]" position="replace">
+        <div class="o_we_shape o_web_editor_Floats_05 o_we_animated"/>
+    </xpath>
+    <!-- Card 1 -->
+    <xpath expr="//div[hasclass('g-col-lg-3')]//h3" position="replace" mode="inner">
+        Engaging Learning Activities
+    </xpath>
+    <xpath expr="//div[hasclass('g-col-lg-3')]//p" position="replace" mode="inner">
+        Foster early development with interactive and educational activities designed to stimulate curiosity and creativity in young children.
+    </xpath>
+    <!-- Card 2 -->
+    <xpath expr="//div[hasclass('g-col-lg-3')][4]//h3" position="replace" mode="inner">
+        Safe &amp; Nurturing Environment
+    </xpath>
+    <xpath expr="//div[hasclass('g-col-lg-3')][4]//p" position="replace" mode="inner">
+        Ensure your child’s well-being in a secure, caring setting with experienced staff dedicated to providing personalized attention and support.
+    </xpath>
+    <!-- Card 3 -->
+    <xpath expr="//div[hasclass('g-col-lg-3')][6]//h3" position="replace" mode="inner">
+        Flexible Scheduling Options
+    </xpath>
+    <xpath expr="//div[hasclass('g-col-lg-3')][6]//p" position="replace" mode="inner">
+        Enjoy convenient and adaptable care schedules to fit your family’s needs, from full-day to part-time and drop-in services.
+    </xpath>
+</template>
+
+</odoo>

--- a/theme_loftspace/__manifest__.py
+++ b/theme_loftspace/__manifest__.py
@@ -26,6 +26,7 @@
         'views/snippets/s_color_blocks_2.xml',
         'views/snippets/s_company_team_shapes.xml',
         'views/snippets/s_media_list.xml',
+        'views/snippets/s_features_wall.xml',
         'views/snippets/s_features_grid.xml',
         'views/snippets/s_comparisons.xml',
         'views/snippets/s_product_catalog.xml',

--- a/theme_loftspace/views/snippets/s_features_wall.xml
+++ b/theme_loftspace/views/snippets/s_features_wall.xml
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+
+<template id="s_features_wall" inherit_id="website.s_features_wall">
+    <!-- Card 1 -->
+    <xpath expr="//div[hasclass('g-col-lg-3')]//h3" position="replace" mode="inner">
+        Innovative Design Solutions
+    </xpath>
+    <xpath expr="//div[hasclass('g-col-lg-3')]//p" position="replace" mode="inner">
+        Transform your vision into reality with cutting-edge architectural designs tailored to your unique needs and aesthetic preferences.
+    </xpath>
+    <!-- Card 2 -->
+    <xpath expr="//div[hasclass('g-col-lg-3')][4]//h3" position="replace" mode="inner">
+        Sustainable Building Practices
+    </xpath>
+    <xpath expr="//div[hasclass('g-col-lg-3')][4]//p" position="replace" mode="inner">
+        Embrace eco-friendly architecture with sustainable design solutions that enhance efficiency and reduce environmental impact.
+    </xpath>
+    <!-- Card 3 -->
+    <xpath expr="//div[hasclass('g-col-lg-3')][6]//h3" position="replace" mode="inner">
+        Detailed Project Management
+    </xpath>
+    <xpath expr="//div[hasclass('g-col-lg-3')][6]//p" position="replace" mode="inner">
+        Experience seamless project execution with meticulous planning, budgeting, and oversight from concept to completion.
+    </xpath>
+</template>
+
+</odoo>

--- a/theme_monglia/views/customizations.xml
+++ b/theme_monglia/views/customizations.xml
@@ -285,6 +285,31 @@
     </xpath>
 </template>
 
+<!-- ======== FEATURES WALL======== -->
+<template id="s_features_wall" inherit_id="website.s_features_wall">
+    <!-- Card 1 -->
+    <xpath expr="//div[hasclass('g-col-lg-3')]//h3" position="replace" mode="inner">
+        Customized Event Planning
+    </xpath>
+    <xpath expr="//div[hasclass('g-col-lg-3')]//p" position="replace" mode="inner">
+        Create unforgettable events with personalized planning services tailored to your specific needs and preferences.
+    </xpath>
+    <!-- Card 2 -->
+    <xpath expr="//div[hasclass('g-col-lg-3')][4]//h3" position="replace" mode="inner">
+        Themed Party Design
+    </xpath>
+    <xpath expr="//div[hasclass('g-col-lg-3')][4]//p" position="replace" mode="inner">
+        Transform any venue with unique and creative themes that make your party stand out and impress your guests.
+    </xpath>
+    <!-- Card 3 -->
+    <xpath expr="//div[hasclass('g-col-lg-3')][6]//h3" position="replace" mode="inner">
+        Complete Event Management
+    </xpath>
+    <xpath expr="//div[hasclass('g-col-lg-3')][6]//p" position="replace" mode="inner">
+        Enjoy a stress-free experience with end-to-end event management, from logistics to execution and everything in between.
+    </xpath>
+</template>
+
 <!-- ======== UNVEIL ======== -->
 <template id="s_unveil" inherit_id="website.s_unveil">
     <!-- Section -->

--- a/theme_notes/__manifest__.py
+++ b/theme_notes/__manifest__.py
@@ -28,6 +28,7 @@
         'views/snippets/s_company_team_shapes.xml',
         'views/snippets/s_image_gallery.xml',
         'views/snippets/s_call_to_action.xml',
+        'views/snippets/s_features_wall.xml',
         'views/snippets/s_features_grid.xml',
         'views/snippets/s_product_list.xml',
         'views/snippets/s_parallax.xml',

--- a/theme_notes/views/snippets/s_features_wall.xml
+++ b/theme_notes/views/snippets/s_features_wall.xml
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+
+<template id="s_features_wall" inherit_id="website.s_features_wall">
+    <!-- Card 1 -->
+    <xpath expr="//div[hasclass('g-col-lg-3')]//h3" position="replace" mode="inner">
+        Live Concert Experiences
+    </xpath>
+    <xpath expr="//div[hasclass('g-col-lg-3')]//p" position="replace" mode="inner">
+        Enjoy unforgettable live performances from top artists in an immersive and electrifying atmosphere.
+    </xpath>
+    <!-- Card 2 -->
+    <xpath expr="//div[hasclass('g-col-lg-3')][4]//h3" position="replace" mode="inner">
+        Exclusive VIP Access
+    </xpath>
+    <xpath expr="//div[hasclass('g-col-lg-3')][4]//p" position="replace" mode="inner">
+        Get closer to the action with VIP tickets offering premium seating, backstage passes, and special amenities.
+    </xpath>
+    <!-- Card 3 -->
+    <xpath expr="//div[hasclass('g-col-lg-3')][6]//h3" position="replace" mode="inner">
+        Unique Music Festivals
+    </xpath>
+    <xpath expr="//div[hasclass('g-col-lg-3')][6]//p" position="replace" mode="inner">
+        Immerse yourself in diverse music genres and vibrant cultural experiences at our curated music festivals.
+    </xpath>
+</template>
+
+</odoo>

--- a/theme_orchid/__manifest__.py
+++ b/theme_orchid/__manifest__.py
@@ -17,6 +17,7 @@
         'views/snippets/s_image_text.xml',
         'views/snippets/s_three_columns.xml',
         'views/snippets/s_quotes_carousel.xml',
+        'views/snippets/s_features_wall.xml',
         'views/snippets/s_call_to_action.xml',
         'views/snippets/s_freegrid.xml',
         'views/snippets/s_company_team_shapes.xml',

--- a/theme_orchid/views/images.xml
+++ b/theme_orchid/views/images.xml
@@ -210,6 +210,11 @@ Check in theme_loftspace's primary_variables.scss and theme.scss -->
     <field name="name">website.library_image_05</field>
     <field name="url">/theme_orchid/static/src/img/snippets/library_image_05.jpg</field>
 </record>
+<record id="library_image_13" model="theme.ir.attachment">
+    <field name="key">website.library_image_13</field>
+    <field name="name">website.library_image_13</field>
+    <field name="url">/theme_orchid/static/src/img/snippets/library_image_13.jpg</field>
+</record>
 <record id="library_image_14" model="theme.ir.attachment">
     <field name="key">website.library_image_14</field>
     <field name="name">website.library_image_14</field>

--- a/theme_orchid/views/snippets/s_features_wall.xml
+++ b/theme_orchid/views/snippets/s_features_wall.xml
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+
+<template id="s_features_wall" inherit_id="website.s_features_wall">
+    <!-- Card 1 -->
+    <xpath expr="//div[hasclass('g-col-lg-3')]//h3" position="replace" mode="inner">
+        Stunning Floral Arrangements
+    </xpath>
+    <xpath expr="//div[hasclass('g-col-lg-3')]//p" position="replace" mode="inner">
+        Enhance any occasion with beautiful, custom-designed floral arrangements crafted to match your style and preferences.
+    </xpath>
+    <!-- Card 2 -->
+    <xpath expr="//div[hasclass('g-col-lg-3')][4]//h3" position="replace" mode="inner">
+        Fresh Seasonal Flowers
+    </xpath>
+    <xpath expr="//div[hasclass('g-col-lg-3')][4]//p" position="replace" mode="inner">
+        Enjoy the best of each season with our selection of fresh, high-quality flowers sourced for peak freshness and beauty.
+    </xpath>
+    <!-- Card 3 -->
+    <xpath expr="//div[hasclass('g-col-lg-3')][6]//h3" position="replace" mode="inner">
+        Personalized Flower Delivery
+    </xpath>
+    <xpath expr="//div[hasclass('g-col-lg-3')][6]//p" position="replace" mode="inner">
+        Send a heartfelt message with our reliable and timely flower delivery service, tailored to your special occasions.
+    </xpath>
+</template>
+
+</odoo>

--- a/theme_paptic/views/customizations.xml
+++ b/theme_paptic/views/customizations.xml
@@ -392,6 +392,18 @@
     </xpath>
 </template>
 
+<!-- ======== Features Wall ======== -->
+<template id="s_features_wall" inherit_id="website.s_features_wall">
+    <!-- Card 1 Image -->
+    <xpath expr="//img" position="attributes">
+        <attribute name="src">/web/image/website.s_three_columns_default_image_1</attribute>
+    </xpath>
+    <!-- Card 2 Image-->
+    <xpath expr="(//img)[2]" position="attributes">
+        <attribute name="src">/web/image/website.s_three_columns_default_image_3</attribute>
+    </xpath>
+</template>
+
 <!-- ==== Media List ===== -->
 <template id="s_media_list" inherit_id="website.s_media_list" name="Paptic s_media_list">
     <xpath expr="//section" position="attributes">

--- a/theme_real_estate/__manifest__.py
+++ b/theme_real_estate/__manifest__.py
@@ -20,6 +20,7 @@
         'views/snippets/s_quotes_carousel.xml',
         'views/snippets/s_freegrid.xml',
         'views/snippets/s_text_block.xml',
+        'views/snippets/s_features_wall.xml',
         'views/snippets/s_masonry_block.xml',
         'views/snippets/s_numbers.xml',
         'views/snippets/s_title.xml',

--- a/theme_real_estate/views/snippets/s_features_wall.xml
+++ b/theme_real_estate/views/snippets/s_features_wall.xml
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+
+<template id="s_features_wall" inherit_id="website.s_features_wall">
+    <!-- Card 1 -->
+    <xpath expr="//div[hasclass('g-col-lg-3')]//h3" position="replace" mode="inner">
+        Dream Home Search
+    </xpath>
+    <xpath expr="//div[hasclass('g-col-lg-3')]//p" position="replace" mode="inner">
+        Find your perfect home with our personalized search services, tailored to match your lifestyle and preferences.
+    </xpath>
+    <!-- Card 2 -->
+    <xpath expr="//div[hasclass('g-col-lg-3')][4]//h3" position="replace" mode="inner">
+        Expert Property Valuation
+    </xpath>
+    <xpath expr="//div[hasclass('g-col-lg-3')][4]//p" position="replace" mode="inner">
+        Get accurate and comprehensive property valuations from our experienced team to help you make informed decisions.
+    </xpath>
+    <!-- Card 3 -->
+    <xpath expr="//div[hasclass('g-col-lg-3')][6]//h3" position="replace" mode="inner">
+        Seamless Buying &amp; Selling
+    </xpath>
+    <xpath expr="//div[hasclass('g-col-lg-3')][6]//p" position="replace" mode="inner">
+        Experience a smooth real estate transaction with our expert guidance and support throughout the buying and selling process.
+    </xpath>
+</template>
+
+</odoo>

--- a/theme_treehouse/__manifest__.py
+++ b/theme_treehouse/__manifest__.py
@@ -28,6 +28,7 @@
         'views/snippets/s_tabs.xml',
         'views/snippets/s_text_block.xml',
         'views/snippets/s_text_image.xml',
+        'views/snippets/s_features_wall.xml',
         'views/snippets/s_three_columns.xml',
         'views/snippets/s_title.xml',
         'views/snippets/s_unveil.xml',

--- a/theme_treehouse/views/snippets/s_features_wall.xml
+++ b/theme_treehouse/views/snippets/s_features_wall.xml
@@ -1,0 +1,34 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+
+<template id="s_features_wall" inherit_id="website.s_features_wall">
+    <!-- Card 1 -->
+    <xpath expr="//img" position="attributes">
+        <attribute name="src">/web/image/website.s_three_columns_default_image_1</attribute>
+    </xpath>
+    <xpath expr="//div[hasclass('g-col-lg-3')]//h3" position="replace" mode="inner">
+        Environmental Conservation Efforts
+    </xpath>
+    <xpath expr="//div[hasclass('g-col-lg-3')]//p" position="replace" mode="inner">
+        Join our initiatives to protect natural habitats and preserve biodiversity through hands-on conservation projects.
+    </xpath>
+    <!-- Card 2 -->
+    <xpath expr="//div[hasclass('g-col-lg-3')][4]//h3" position="replace" mode="inner">
+        Eco-Friendly Community Programs
+    </xpath>
+    <xpath expr="//div[hasclass('g-col-lg-3')][4]//p" position="replace" mode="inner">
+        Participate in local programs focused on sustainable living, recycling, and reducing environmental footprints.
+    </xpath>
+    <!-- Card 3 -->
+    <xpath expr="(//img)[3]" position="attributes">
+        <attribute name="src">/web/image/website.s_three_columns_default_image_3</attribute>
+    </xpath>
+    <xpath expr="//div[hasclass('g-col-lg-3')][6]//h3" position="replace" mode="inner">
+        Green Advocacy &amp; Education
+    </xpath>
+    <xpath expr="//div[hasclass('g-col-lg-3')][6]//p" position="replace" mode="inner">
+        Support our efforts to educate the public and advocate for policies that promote environmental sustainability and green practices.
+    </xpath>
+</template>
+
+</odoo>

--- a/theme_vehicle/views/customizations.xml
+++ b/theme_vehicle/views/customizations.xml
@@ -74,6 +74,31 @@
     </xpath>
 </template>
 
+<!-- ======== FEATURES WALL ======== -->
+<template id="s_features_wall" inherit_id="website.s_features_wall">
+    <!-- Card 1 -->
+    <xpath expr="//div[hasclass('g-col-lg-3')]//h3" position="replace" mode="inner">
+        Wide Vehicle Selection
+    </xpath>
+    <xpath expr="//div[hasclass('g-col-lg-3')]//p" position="replace" mode="inner">
+        Explore our extensive inventory of new and pre-owned cars to find the perfect vehicle that fits your needs and budget.
+    </xpath>
+    <!-- Card 2 -->
+    <xpath expr="//div[hasclass('g-col-lg-3')][4]//h3" position="replace" mode="inner">
+        Flexible Financing Options
+    </xpath>
+    <xpath expr="//div[hasclass('g-col-lg-3')][4]//p" position="replace" mode="inner">
+        Benefit from competitive financing plans and leasing options designed to make your car purchase as affordable as possible.
+    </xpath>
+    <!-- Card 3 -->
+    <xpath expr="//div[hasclass('g-col-lg-3')][6]//h3" position="replace" mode="inner">
+        Expert Vehicle Service
+    </xpath>
+    <xpath expr="//div[hasclass('g-col-lg-3')][6]//p" position="replace" mode="inner">
+        Keep your car in top condition with our comprehensive service and maintenance options, handled by skilled technicians.
+    </xpath>
+</template>
+
 <!-- ======== NUMBERS ======== -->
 <template id="s_numbers" inherit_id="website.s_numbers">
     <!-- Section -->

--- a/theme_yes/__manifest__.py
+++ b/theme_yes/__manifest__.py
@@ -25,6 +25,7 @@
         'views/snippets/s_picture.xml',
         'views/snippets/s_popup.xml',
         'views/snippets/s_freegrid.xml',
+        'views/snippets/s_features_wall.xml',
         'views/snippets/s_quotes_carousel.xml',
         'views/snippets/s_text_image.xml',
         'views/snippets/s_three_columns.xml',

--- a/theme_yes/views/snippets/s_features_wall.xml
+++ b/theme_yes/views/snippets/s_features_wall.xml
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+
+<template id="s_features_wall" inherit_id="website.s_features_wall">
+    <!-- Card 1 -->
+    <xpath expr="//div[hasclass('g-col-lg-3')]//h3" position="replace" mode="inner">
+        Personalized Wedding Design
+    </xpath>
+    <xpath expr="//div[hasclass('g-col-lg-3')]//p" position="replace" mode="inner">
+        Create your dream wedding with customized design services that reflect your unique style and preferences.
+    </xpath>
+    <!-- Card 2 -->
+    <xpath expr="//div[hasclass('g-col-lg-3')][4]//h3" position="replace" mode="inner">
+        Full-Service Coordination
+    </xpath>
+    <xpath expr="//div[hasclass('g-col-lg-3')][4]//p" position="replace" mode="inner">
+        Enjoy a stress-free planning process with our comprehensive coordination services, managing every detail from start to finish.
+    </xpath>
+    <!-- Card 3 -->
+    <xpath expr="//div[hasclass('g-col-lg-3')][6]//h3" position="replace" mode="inner">
+        Vendor &amp; Venue Selection
+    </xpath>
+    <xpath expr="//div[hasclass('g-col-lg-3')][6]//p" position="replace" mode="inner">
+        Access our network of trusted vendors and venues to find the perfect partners for your wedding needs.
+    </xpath>
+</template>
+
+</odoo>


### PR DESCRIPTION
*: anelusia, artists, aviato, beauty, bewise, bistro, bookstore, enark,
kea, kiddo, loftspace, monglia, notes, orchid, paptic, real_estate, treehouse,
vehicle, yes

This commit adapts the design of new `s_features_wall` snippet for multiple themes

Part of task-4077427
task-4105231

requires: https://github.com/odoo/odoo/pull/177546