### PR TITLE
[IMP] theme_*: adapt themes with new `s_freegrid` snippet

### DIFF
--- a/theme_anelusia/__manifest__.py
+++ b/theme_anelusia/__manifest__.py
@@ -23,6 +23,7 @@
         'views/snippets/s_references.xml',
         'views/snippets/s_call_to_action.xml',
         'views/snippets/s_comparisons.xml',
+        'views/snippets/s_freegrid.xml',
         'views/snippets/s_product_list.xml',
         'views/snippets/s_product_catalog.xml',
         'views/snippets/s_showcase.xml',

--- a/theme_anelusia/views/snippets/s_freegrid.xml
+++ b/theme_anelusia/views/snippets/s_freegrid.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+
+<template id="s_freegrid" inherit_id="website.s_freegrid">
+    <!-- Title -->
+    <xpath expr="//h2" position="replace" mode="inner">
+        Discover the Latest Fashion and Fitness Trends
+    </xpath>
+    <!-- Paragraph -->
+    <xpath expr="//p[hasclass('lead')]" position="replace" mode="inner">
+        Explore our collection of fashion and sportswear designed to keep you ahead of the trends. From innovative materials to cutting-edge designs, we offer products that combine style and performance.
+    </xpath>
+    <!-- Button -->
+    <xpath expr="//a" position="replace" mode="inner">
+        Explore Now
+    </xpath>
+</template>
+
+</odoo>

--- a/theme_artists/__manifest__.py
+++ b/theme_artists/__manifest__.py
@@ -30,6 +30,7 @@
         'views/snippets/s_product_catalog.xml',
         'views/snippets/s_quotes_carousel.xml',
         'views/snippets/s_comparisons.xml',
+        'views/snippets/s_freegrid.xml',
         'views/snippets/s_company_team.xml',
         'views/snippets/s_product_list.xml',
         'views/snippets/s_color_blocks_2.xml',

--- a/theme_artists/views/snippets/s_freegrid.xml
+++ b/theme_artists/views/snippets/s_freegrid.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+
+<template id="s_freegrid" inherit_id="website.s_freegrid">
+    <!-- Title -->
+    <xpath expr="//h2" position="replace" mode="inner">
+        Where Creativity Meets Innovation in Art
+    </xpath>
+    <!-- Paragraph -->
+    <xpath expr="//p[hasclass('lead')]" position="replace" mode="inner">
+        Explore our carefully curated selection of artworks that push the boundaries of creativity and innovation. Our galleries showcase the finest pieces that inspire and captivate.
+    </xpath>
+    <!-- Button -->
+    <xpath expr="//a" position="replace" mode="inner">
+        Visit the Gallery
+    </xpath>
+</template>
+
+</odoo>

--- a/theme_avantgarde/views/customizations.xml
+++ b/theme_avantgarde/views/customizations.xml
@@ -274,6 +274,22 @@
     </xpath>
 </template>
 
+<!-- ======== FREE GRID ======== -->
+<template id="s_freegrid" inherit_id="website.s_freegrid">
+    <!-- Title -->
+    <xpath expr="//h2" position="replace" mode="inner">
+        Innovative Design and Art That Inspire Change
+    </xpath>
+    <!-- Paragraph -->
+    <xpath expr="//p[hasclass('lead')]" position="replace" mode="inner">
+        Dive into the world of design and fine art with our collection of forward-thinking pieces. Discover how creativity drives change in the art world through our exclusive exhibitions and publications.
+    </xpath>
+    <!-- Button -->
+    <xpath expr="//a" position="replace" mode="inner">
+        Discover More
+    </xpath>
+</template>
+
 <!-- ======== KEY BENEFITS ======== -->
 <template id="s_key_benefits" inherit_id="website.s_key_benefits">
     <!-- Titles -->

--- a/theme_aviato/__manifest__.py
+++ b/theme_aviato/__manifest__.py
@@ -15,6 +15,7 @@
         'views/snippets/s_cover.xml',
         'views/snippets/s_features.xml',
         'views/snippets/s_image_text.xml',
+        'views/snippets/s_freegrid.xml',
         'views/snippets/s_text_image.xml',
         'views/snippets/s_three_columns.xml',
         'views/snippets/s_picture.xml',

--- a/theme_aviato/views/snippets/s_freegrid.xml
+++ b/theme_aviato/views/snippets/s_freegrid.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+
+<template id="s_freegrid" inherit_id="website.s_freegrid">
+    <!-- Title -->
+    <xpath expr="//h2" position="replace" mode="inner">
+        Experience the World with Our Unique Travel Plans
+    </xpath>
+    <!-- Paragraph -->
+    <xpath expr="//p[hasclass('lead')]" position="replace" mode="inner">
+        Discover the beauty of the world through our curated travel experiences. From adventurous excursions to relaxing tours, we tailor your journeys to meet your wildest travel dreams.
+    </xpath>
+    <!-- Button -->
+    <xpath expr="//a" position="replace" mode="inner">
+        Start Your Journey
+    </xpath>
+</template>
+
+</odoo>

--- a/theme_beauty/__manifest__.py
+++ b/theme_beauty/__manifest__.py
@@ -16,6 +16,7 @@
         'views/snippets/s_text_image.xml',
         'views/snippets/s_title.xml',
         'views/snippets/s_company_team.xml',
+        'views/snippets/s_freegrid.xml',
         'views/snippets/s_call_to_action.xml',
         'views/snippets/s_product_list.xml',
         'views/snippets/s_banner.xml',

--- a/theme_beauty/views/snippets/s_freegrid.xml
+++ b/theme_beauty/views/snippets/s_freegrid.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+
+<template id="s_freegrid" inherit_id="website.s_freegrid">
+    <!-- Title -->
+    <xpath expr="//h2" position="replace" mode="inner">
+        Enhance Your Natural Beauty with Our Products
+    </xpath>
+    <!-- Paragraph -->
+    <xpath expr="//p[hasclass('lead')]" position="replace" mode="inner">
+        Discover our range of beauty products designed to bring out the best in you. From skincare to cosmetics, we offer everything you need to look and feel your best.
+    </xpath>
+    <!-- Button -->
+    <xpath expr="//a" position="replace" mode="inner">
+        Shop Beauty
+    </xpath>
+</template>
+
+</odoo>

--- a/theme_bewise/views/customizations.xml
+++ b/theme_bewise/views/customizations.xml
@@ -458,6 +458,22 @@
     </xpath>
 </template>
 
+<!-- ======== FREE GRID ======== -->
+<template id="s_freegrid" inherit_id="website.s_freegrid">
+    <!-- Title -->
+    <xpath expr="//h2" position="replace" mode="inner">
+        Shaping the Future of Education and Learning
+    </xpath>
+    <!-- Paragraph -->
+    <xpath expr="//p[hasclass('lead')]" position="replace" mode="inner">
+        Our educational programs are designed to empower students with the knowledge and skills they need for the future. Explore our innovative approach to learning and personal development.
+    </xpath>
+    <!-- Button -->
+    <xpath expr="//a" position="replace" mode="inner">
+        Learn More
+    </xpath>
+</template>
+
 <!-- ======== KEY BENEFITS ======== -->
 <template id="s_key_benefits" inherit_id="website.s_key_benefits">
     <!-- Titles -->

--- a/theme_bistro/__manifest__.py
+++ b/theme_bistro/__manifest__.py
@@ -19,6 +19,7 @@
         'views/snippets/s_cover.xml',
         'views/snippets/s_features.xml',
         'views/snippets/s_image_text.xml',
+        'views/snippets/s_freegrid.xml',
         'views/snippets/s_media_list.xml',
         'views/snippets/s_numbers.xml',
         'views/snippets/s_picture.xml',

--- a/theme_bistro/views/snippets/s_freegrid.xml
+++ b/theme_bistro/views/snippets/s_freegrid.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+
+<template id="s_freegrid" inherit_id="website.s_freegrid">
+    <!-- Title -->
+    <xpath expr="//h2" position="replace" mode="inner">
+        Indulge in Culinary Excellence at Our Bistros
+    </xpath>
+    <!-- Paragraph -->
+    <xpath expr="//p[hasclass('lead')]" position="replace" mode="inner">
+        Savor the finest cuisine at our bistros and cafes, where each dish is crafted with passion and precision. Whether it’s a casual meal or a special occasion, we have something for everyone.
+    </xpath>
+    <!-- Button -->
+    <xpath expr="//a" position="replace" mode="inner">
+        Reserve a Table
+    </xpath>
+</template>
+
+</odoo>

--- a/theme_bookstore/__manifest__.py
+++ b/theme_bookstore/__manifest__.py
@@ -21,6 +21,7 @@
         'views/snippets/s_cover.xml',
         'views/snippets/s_image_text.xml',
         'views/snippets/s_showcase.xml',
+        'views/snippets/s_freegrid.xml',
         'views/snippets/s_masonry_block.xml',
         'views/snippets/s_banner.xml',
         'views/snippets/s_numbers.xml',

--- a/theme_bookstore/views/snippets/s_freegrid.xml
+++ b/theme_bookstore/views/snippets/s_freegrid.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+
+<template id="s_freegrid" inherit_id="website.s_freegrid">
+    <!-- Title -->
+    <xpath expr="//h2" position="replace" mode="inner">
+        Explore a World of Knowledge and Creativity
+    </xpath>
+    <!-- Paragraph -->
+    <xpath expr="//p[hasclass('lead')]" position="replace" mode="inner">
+        Dive into our extensive collection of books, music, and media. Whether you’re a lover of literature or a music enthusiast, our library offers something for every curious mind.
+    </xpath>
+    <!-- Button -->
+    <xpath expr="//a" position="replace" mode="inner">
+        Browse the Collection
+    </xpath>
+</template>
+
+</odoo>

--- a/theme_buzzy/__manifest__.py
+++ b/theme_buzzy/__manifest__.py
@@ -22,6 +22,7 @@
         'views/snippets/s_three_columns.xml',
         'views/snippets/s_color_blocks_2.xml',
         'views/snippets/s_features.xml',
+        'views/snippets/s_freegrid.xml',
         'views/snippets/s_image_gallery.xml',
         'views/snippets/s_media_list.xml',
         'views/snippets/s_showcase.xml',

--- a/theme_buzzy/views/snippets/s_freegrid.xml
+++ b/theme_buzzy/views/snippets/s_freegrid.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+
+<template id="s_freegrid" inherit_id="website.s_freegrid">
+    <!-- Title -->
+    <xpath expr="//h2" position="replace" mode="inner">
+        Driving Innovation in Corporate Services
+    </xpath>
+    <!-- Paragraph -->
+    <xpath expr="//p[hasclass('lead')]" position="replace" mode="inner">
+        Our corporate services are designed to enhance your business operations through innovative technology and creative design. Explore how we can help your business reach new heights.
+    </xpath>
+    <!-- Button -->
+    <xpath expr="//a" position="replace" mode="inner">
+        Discover Services
+    </xpath>
+</template>
+
+</odoo>

--- a/theme_clean/__manifest__.py
+++ b/theme_clean/__manifest__.py
@@ -20,6 +20,7 @@
         'views/snippets/s_title.xml',
         'views/snippets/s_features.xml',
         'views/snippets/s_numbers.xml',
+        'views/snippets/s_freegrid.xml',
         'views/snippets/s_image_text.xml',
         'views/snippets/s_color_blocks_2.xml',
         'views/snippets/s_comparisons.xml',

--- a/theme_clean/views/snippets/s_freegrid.xml
+++ b/theme_clean/views/snippets/s_freegrid.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+
+<template id="s_freegrid" inherit_id="website.s_freegrid">
+    <!-- Title -->
+    <xpath expr="//h2" position="replace" mode="inner">
+        Legal Expertise for the Modern Business World
+    </xpath>
+    <!-- Paragraph -->
+    <xpath expr="//p[hasclass('lead')]" position="replace" mode="inner">
+        Stay ahead in the business world with our expert legal services. We offer comprehensive solutions that protect your interests and support your business growth in today’s competitive environment.
+    </xpath>
+    <!-- Button -->
+    <xpath expr="//a" position="replace" mode="inner">
+        Learn More
+    </xpath>
+</template>
+
+</odoo>

--- a/theme_cobalt/views/customizations.xml
+++ b/theme_cobalt/views/customizations.xml
@@ -274,6 +274,22 @@
     </xpath>
 </template>
 
+<!-- ======== FREE GRID ======== -->
+<template id="s_freegrid" inherit_id="website.s_freegrid">
+    <!-- Title -->
+    <xpath expr="//h2" position="replace" mode="inner">
+        Pioneering IT Development and Design Solutions
+    </xpath>
+    <!-- Paragraph -->
+    <xpath expr="//p[hasclass('lead')]" position="replace" mode="inner">
+        Harness the power of technology with our cutting-edge IT development and design services. We create solutions that drive innovation and deliver exceptional results for your business.
+    </xpath>
+    <!-- Button -->
+    <xpath expr="//a" position="replace" mode="inner">
+        Explore Services
+    </xpath>
+</template>
+
 <!-- ======== KEY BENEFITS ======== -->
 <template id="s_key_benefits" inherit_id="website.s_key_benefits">
     <!-- Titles -->

--- a/theme_enark/__manifest__.py
+++ b/theme_enark/__manifest__.py
@@ -18,6 +18,7 @@
         'views/snippets/s_text_image.xml',
         'views/snippets/s_picture.xml',
         'views/snippets/s_pricelist_boxed.xml',
+        'views/snippets/s_freegrid.xml',
         'views/snippets/s_media_list.xml',
         'views/snippets/s_call_to_action.xml',
         'views/snippets/s_parallax.xml',

--- a/theme_enark/views/snippets/s_freegrid.xml
+++ b/theme_enark/views/snippets/s_freegrid.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+
+<template id="s_freegrid" inherit_id="website.s_freegrid">
+    <!-- Title -->
+    <xpath expr="//h2" position="replace" mode="inner">
+        Architectural Excellence for Corporate Success
+    </xpath>
+    <!-- Paragraph -->
+    <xpath expr="//p[hasclass('lead')]" position="replace" mode="inner">
+        Our architectural solutions combine design excellence with business acumen, creating spaces that inspire and support your corporate goals. Transform your workspace with our expertise.
+    </xpath>
+    <!-- Button -->
+    <xpath expr="//a" position="replace" mode="inner">
+        Start a Project
+    </xpath>
+</template>
+
+</odoo>

--- a/theme_graphene/views/customizations.xml
+++ b/theme_graphene/views/customizations.xml
@@ -275,6 +275,22 @@
     </xpath>
 </template>
 
+<!-- ======== FREE GRID ======== -->
+<template id="s_freegrid" inherit_id="website.s_freegrid">
+    <!-- Title -->
+    <xpath expr="//h2" position="replace" mode="inner">
+        Robotics and Technology
+    </xpath>
+    <!-- Paragraph -->
+    <xpath expr="//p[hasclass('lead')]" position="replace" mode="inner">
+        Embrace the future with our advanced robotics and technology services. We provide innovative solutions that enhance productivity and drive business success in the digital age.
+    </xpath>
+    <!-- Button -->
+    <xpath expr="//a" position="replace" mode="inner">
+        Discover Robotics
+    </xpath>
+</template>
+
 <!-- ======== UNVEIL ======== -->
 <template id="s_unveil" inherit_id="website.s_unveil">
     <!-- Section -->

--- a/theme_kea/__manifest__.py
+++ b/theme_kea/__manifest__.py
@@ -17,6 +17,7 @@
         'views/snippets/s_text_image.xml',
         'views/snippets/s_three_columns.xml',
         'views/snippets/s_media_list.xml',
+        'views/snippets/s_freegrid.xml',
         'views/snippets/s_references.xml',
         'views/snippets/s_color_blocks_2.xml',
         'views/snippets/s_picture.xml',

--- a/theme_kea/views/snippets/s_freegrid.xml
+++ b/theme_kea/views/snippets/s_freegrid.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+
+<template id="s_freegrid" inherit_id="website.s_freegrid">
+    <!-- Title -->
+    <xpath expr="//h2" position="replace" mode="inner">
+        Step into the Future with Virtual Reality
+    </xpath>
+    <!-- Paragraph -->
+    <xpath expr="//p[hasclass('lead')]" position="replace" mode="inner">
+        Explore new dimensions with our virtual reality solutions, designed to transform the way you experience and interact with technology. Dive into the future with immersive VR experiences.
+    </xpath>
+    <!-- Button -->
+    <xpath expr="//a" position="replace" mode="inner">
+        Experience VR
+    </xpath>
+</template>
+
+</odoo>

--- a/theme_kiddo/__manifest__.py
+++ b/theme_kiddo/__manifest__.py
@@ -17,6 +17,7 @@
         'views/snippets/s_picture.xml',
         'views/snippets/s_product_list.xml',
         'views/snippets/s_call_to_action.xml',
+        'views/snippets/s_freegrid.xml',
         'views/snippets/s_cover.xml',
         'views/snippets/s_three_columns.xml',
         'views/snippets/s_quotes_carousel.xml',

--- a/theme_kiddo/views/snippets/s_freegrid.xml
+++ b/theme_kiddo/views/snippets/s_freegrid.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+
+<template id="s_freegrid" inherit_id="website.s_freegrid">
+    <!-- Title -->
+    <xpath expr="//h2" position="replace" mode="inner">
+        Toys and Games That Spark Creativity
+    </xpath>
+    <!-- Paragraph -->
+    <xpath expr="//p[hasclass('lead')]" position="replace" mode="inner">
+        Inspire imagination and creativity with our range of toys and games for kids of all ages. Our products are designed to engage young minds, offering endless hours of fun and learning.
+    </xpath>
+    <!-- Button -->
+    <xpath expr="//a" position="replace" mode="inner">
+        Shop Toys
+    </xpath>
+</template>
+
+</odoo>

--- a/theme_loftspace/__manifest__.py
+++ b/theme_loftspace/__manifest__.py
@@ -18,6 +18,7 @@
         'views/snippets/s_three_columns.xml',
         'views/snippets/s_call_to_action.xml',
         'views/snippets/s_image_gallery.xml',
+        'views/snippets/s_freegrid.xml',
         'views/snippets/s_banner.xml',
         'views/snippets/s_image_text.xml',
         'views/snippets/s_numbers.xml',

--- a/theme_loftspace/views/snippets/s_freegrid.xml
+++ b/theme_loftspace/views/snippets/s_freegrid.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+
+<template id="s_freegrid" inherit_id="website.s_freegrid">
+    <!-- Title -->
+    <xpath expr="//h2" position="replace" mode="inner">
+        Redefine Your Space with Elegant Furniture
+    </xpath>
+    <!-- Paragraph -->
+    <xpath expr="//p[hasclass('lead')]" position="replace" mode="inner">
+        Transform your home with our sophisticated furniture and interior designs. We offer a curated selection of pieces that blend style, comfort, and functionality to enhance your living spaces.
+    </xpath>
+    <!-- Button -->
+    <xpath expr="//a" position="replace" mode="inner">
+        Browse Furniture
+    </xpath>
+</template>
+
+</odoo>

--- a/theme_monglia/views/customizations.xml
+++ b/theme_monglia/views/customizations.xml
@@ -257,6 +257,22 @@
     </xpath>
 </template>
 
+<!-- ======== FREE GRID ======== -->
+<template id="s_freegrid" inherit_id="website.s_freegrid">
+    <!-- Title -->
+    <xpath expr="//h2" position="replace" mode="inner">
+        Elevate Your Events with Unforgettable Experiences
+    </xpath>
+    <!-- Paragraph -->
+    <xpath expr="//p[hasclass('lead')]" position="replace" mode="inner">
+        From intimate gatherings to grand celebrations, our event services are designed to create memorable experiences. Enjoy the finest food, drinks, and entertainment at our restaurants and venues.
+    </xpath>
+    <!-- Button -->
+    <xpath expr="//a" position="replace" mode="inner">
+        Plan Your Event
+    </xpath>
+</template>
+
 <!-- ======== UNVEIL ======== -->
 <template id="s_unveil" inherit_id="website.s_unveil">
     <!-- Section -->

--- a/theme_nano/__manifest__.py
+++ b/theme_nano/__manifest__.py
@@ -17,6 +17,7 @@
         'views/snippets/s_cover.xml',
         'views/snippets/s_features.xml',
         'views/snippets/s_image_text.xml',
+        'views/snippets/s_freegrid.xml',
         'views/snippets/s_images_wall.xml',
         'views/snippets/s_parallax.xml',
         'views/snippets/s_pricelist_boxed.xml',

--- a/theme_nano/views/snippets/s_freegrid.xml
+++ b/theme_nano/views/snippets/s_freegrid.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+
+<template id="s_freegrid" inherit_id="website.s_freegrid">
+    <!-- Title -->
+    <xpath expr="//h2" position="replace" mode="inner">
+        Creative Solutions for Modern Agencies
+    </xpath>
+    <!-- Paragraph -->
+    <xpath expr="//p[hasclass('lead')]" position="replace" mode="inner">
+        Partner with us for innovative design and IT services that bring your creative visions to life in the digital world. We blend creativity and technology to deliver exceptional results.
+    </xpath>
+    <!-- Button -->
+    <xpath expr="//a" position="replace" mode="inner">
+        Work With Us
+    </xpath>
+</template>
+
+</odoo>

--- a/theme_notes/__manifest__.py
+++ b/theme_notes/__manifest__.py
@@ -18,6 +18,7 @@
         'views/snippets/s_company_team.xml',
         'views/snippets/s_masonry_block.xml',
         'views/snippets/s_product_catalog.xml',
+        'views/snippets/s_freegrid.xml',
         'views/snippets/s_banner.xml',
         'views/snippets/s_cover.xml',
         'views/snippets/s_text_image.xml',

--- a/theme_notes/views/snippets/s_freegrid.xml
+++ b/theme_notes/views/snippets/s_freegrid.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+
+<template id="s_freegrid" inherit_id="website.s_freegrid">
+    <!-- Title -->
+    <xpath expr="//h2" position="replace" mode="inner">
+        Immerse Yourself in the World of Music
+    </xpath>
+    <!-- Paragraph -->
+    <xpath expr="//p[hasclass('lead')]" position="replace" mode="inner">
+        Explore the vibrant world of music with our curated events and collections. Whether you’re attending a live concert or browsing our records, we bring the best of sound and artistry to you.
+    </xpath>
+    <!-- Button -->
+    <xpath expr="//a" position="replace" mode="inner">
+        Discover Music
+    </xpath>
+</template>
+
+</odoo>

--- a/theme_odoo_experts/__manifest__.py
+++ b/theme_odoo_experts/__manifest__.py
@@ -19,6 +19,7 @@
         'views/snippets/s_text_image.xml',
         'views/snippets/s_company_team.xml',
         'views/snippets/s_references.xml',
+        'views/snippets/s_freegrid.xml',
         'views/snippets/s_cover.xml',
         'views/snippets/s_numbers.xml',
         'views/snippets/s_three_columns.xml',

--- a/theme_odoo_experts/views/snippets/s_freegrid.xml
+++ b/theme_odoo_experts/views/snippets/s_freegrid.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+
+<template id="s_freegrid" inherit_id="website.s_freegrid">
+    <!-- Title -->
+    <xpath expr="//h2" position="replace" mode="inner">
+        Strategic Advice for Business and IT Success
+    </xpath>
+    <!-- Paragraph -->
+    <xpath expr="//p[hasclass('lead')]" position="replace" mode="inner">
+        Achieve your business goals with our expert advisory services in corporate strategy and IT solutions. We offer tailored advice that helps you navigate the complexities of the modern business landscape.
+    </xpath>
+    <!-- Button -->
+    <xpath expr="//a" position="replace" mode="inner">
+        Get Expert Advice
+    </xpath>
+</template>
+
+</odoo>

--- a/theme_orchid/__manifest__.py
+++ b/theme_orchid/__manifest__.py
@@ -18,6 +18,7 @@
         'views/snippets/s_three_columns.xml',
         'views/snippets/s_quotes_carousel.xml',
         'views/snippets/s_call_to_action.xml',
+        'views/snippets/s_freegrid.xml',
         'views/snippets/s_numbers.xml',
         'views/snippets/s_pricelist_boxed.xml',
         'views/snippets/s_media_list.xml',

--- a/theme_orchid/views/snippets/s_freegrid.xml
+++ b/theme_orchid/views/snippets/s_freegrid.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+
+<template id="s_freegrid" inherit_id="website.s_freegrid">
+    <!-- Title -->
+    <xpath expr="//h2" position="replace" mode="inner">
+        Bringing the Beauty of Nature to Your Space
+    </xpath>
+    <!-- Paragraph -->
+    <xpath expr="//p[hasclass('lead')]" position="replace" mode="inner">
+        Enhance your surroundings with our exquisite floral arrangements and garden designs. We offer a variety of options that bring the serenity and beauty of nature into your home or workspace.
+    </xpath>
+    <!-- Button -->
+    <xpath expr="//a" position="replace" mode="inner">
+        Explore Our Gardens
+    </xpath>
+</template>
+
+</odoo>

--- a/theme_paptic/views/customizations.xml
+++ b/theme_paptic/views/customizations.xml
@@ -428,6 +428,22 @@
     </xpath>
 </template>
 
+<!-- ======== FREE GRID ======== -->
+<template id="s_freegrid" inherit_id="website.s_freegrid">
+    <!-- Title -->
+    <xpath expr="//h2" position="replace" mode="inner">
+        Expert Consultancy in Tech and Design
+    </xpath>
+    <!-- Paragraph -->
+    <xpath expr="//p[hasclass('lead')]" position="replace" mode="inner">
+        Optimize your business with our consultancy services in technology and design. We provide strategic advice and innovative solutions to help you stay ahead in the digital age.
+    </xpath>
+    <!-- Button -->
+    <xpath expr="//a" position="replace" mode="inner">
+        Unlock Your Potential
+    </xpath>
+</template>
+
 <!-- ======== UNVEIL ======== -->
 <template id="s_unveil" inherit_id="website.s_unveil">
     <!-- Section -->

--- a/theme_real_estate/__manifest__.py
+++ b/theme_real_estate/__manifest__.py
@@ -18,6 +18,7 @@
         'views/snippets/s_text_image.xml',
         'views/snippets/s_three_columns.xml',
         'views/snippets/s_quotes_carousel.xml',
+        'views/snippets/s_freegrid.xml',
         'views/snippets/s_text_block.xml',
         'views/snippets/s_masonry_block.xml',
         'views/snippets/s_numbers.xml',

--- a/theme_real_estate/views/snippets/s_freegrid.xml
+++ b/theme_real_estate/views/snippets/s_freegrid.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+
+<template id="s_freegrid" inherit_id="website.s_freegrid">
+    <!-- Title -->
+    <xpath expr="//h2" position="replace" mode="inner">
+        Real Estate Solutions Tailored for You
+    </xpath>
+    <!-- Paragraph -->
+    <xpath expr="//p[hasclass('lead')]" position="replace" mode="inner">
+        Find your perfect home or investment property with our comprehensive real estate services. We guide you through every step, from buying and selling to property management.
+    </xpath>
+    <!-- Button -->
+    <xpath expr="//a" position="replace" mode="inner">
+        View Listings
+    </xpath>
+</template>
+
+</odoo>

--- a/theme_treehouse/__manifest__.py
+++ b/theme_treehouse/__manifest__.py
@@ -23,6 +23,7 @@
         'views/snippets/s_image_text.xml',
         'views/snippets/s_media_list.xml',
         'views/snippets/s_picture.xml',
+        'views/snippets/s_freegrid.xml',
         'views/snippets/s_quotes_carousel.xml',
         'views/snippets/s_tabs.xml',
         'views/snippets/s_text_block.xml',

--- a/theme_treehouse/views/snippets/s_freegrid.xml
+++ b/theme_treehouse/views/snippets/s_freegrid.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+
+<template id="s_freegrid" inherit_id="website.s_freegrid">
+    <!-- Title -->
+    <xpath expr="//h2" position="replace" mode="inner">
+        Sustainability for a Better Tomorrow
+    </xpath>
+    <!-- Paragraph -->
+    <xpath expr="//p[hasclass('lead')]" position="replace" mode="inner">
+        Join us in our mission to protect the environment and promote sustainable development. We focus on creating a greener future through innovative ecological solutions.
+    </xpath>
+    <!-- Button -->
+    <xpath expr="//a" position="replace" mode="inner">
+        Be Part of the Change
+    </xpath>
+</template>
+
+</odoo>

--- a/theme_vehicle/views/customizations.xml
+++ b/theme_vehicle/views/customizations.xml
@@ -370,6 +370,22 @@
     </xpath>
 </template>
 
+<!-- ======== FREE GRID ======== -->
+<template id="s_freegrid" inherit_id="website.s_freegrid">
+    <!-- Title -->
+    <xpath expr="//h2" position="replace" mode="inner">
+        Reliable Vehicle Services and Maintenance
+    </xpath>
+    <!-- Paragraph -->
+    <xpath expr="//p[hasclass('lead')]" position="replace" mode="inner">
+        Keep your vehicle in top condition with our comprehensive repair and maintenance services. From cars to motorbikes, we offer expert solutions to ensure safe and smooth rides.
+    </xpath>
+    <!-- Button -->
+    <xpath expr="//a" position="replace" mode="inner">
+        Book a Service
+    </xpath>
+</template>
+
 <!-- ======== UNVEIL ======== -->
 <template id="s_unveil" inherit_id="website.s_unveil">
     <!-- Section -->

--- a/theme_yes/__manifest__.py
+++ b/theme_yes/__manifest__.py
@@ -24,6 +24,7 @@
         'views/snippets/s_media_list.xml',
         'views/snippets/s_picture.xml',
         'views/snippets/s_popup.xml',
+        'views/snippets/s_freegrid.xml',
         'views/snippets/s_quotes_carousel.xml',
         'views/snippets/s_text_image.xml',
         'views/snippets/s_three_columns.xml',

--- a/theme_yes/views/snippets/s_freegrid.xml
+++ b/theme_yes/views/snippets/s_freegrid.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+
+<template id="s_freegrid" inherit_id="website.s_freegrid">
+    <!-- Title -->
+    <xpath expr="//h2" position="replace" mode="inner">
+        Capture Your Love Story in Beautiful Photos
+    </xpath>
+    <!-- Paragraph -->
+    <xpath expr="//p[hasclass('lead')]" position="replace" mode="inner">
+        Let us help you capture the magic of your special day. Our professional photography services ensure that your wedding memories are preserved beautifully for a lifetime.
+    </xpath>
+    <!-- Button -->
+    <xpath expr="//a" position="replace" mode="inner">
+        View Portfolio
+    </xpath>
+</template>
+
+</odoo>

--- a/theme_zap/__manifest__.py
+++ b/theme_zap/__manifest__.py
@@ -24,6 +24,7 @@
         'views/snippets/s_image_text.xml',
         'views/snippets/s_three_columns.xml',
         'views/snippets/s_image_gallery.xml',
+        'views/snippets/s_freegrid.xml',
         'views/snippets/s_unveil.xml',
         'views/snippets/s_numbers_showcase.xml',
         'views/snippets/s_key_benefits.xml',

--- a/theme_zap/views/snippets/s_freegrid.xml
+++ b/theme_zap/views/snippets/s_freegrid.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+
+<template id="s_freegrid" inherit_id="website.s_freegrid">
+    <!-- Title -->
+    <xpath expr="//h2" position="replace" mode="inner">
+        Elevate Your Brand with Digital Marketing
+    </xpath>
+    <!-- Paragraph -->
+    <xpath expr="//p[hasclass('lead')]" position="replace" mode="inner">
+        Boost your brand’s visibility and engagement with our expert digital marketing services. From copywriting to media strategies, we tailor solutions to meet your unique needs.
+    </xpath>
+    <!-- Button -->
+    <xpath expr="//a" position="replace" mode="inner">
+        Start Your Campaign
+    </xpath>
+</template>
+
+</odoo>


### PR DESCRIPTION
anelusia, artists, avantgarde, aviato, beauty, bewise, bistro, bookstore , buzzy, clean, cobalt, enark, graphene, kea, kiddo, loftspace, monglia, nano, notes, odoo_experts, orchid, paptic, real_estate, treehouse, vehicle, yes, zap

This commit adapts the design of `s_freegrid` for multiple themes, based on the new Odoo 18 snippet redesign.

requires: https://github.com/odoo/odoo/pull/177573

task-4104931
Part-of: task-4077427