### PR TITLE
[FIX] *: finish adapting homepage tours to new Columns category

### DIFF
--- a/theme_clean/static/src/js/tour.js
+++ b/theme_clean/static/src/js/tour.js
@@ -37,7 +37,7 @@ const snippets = [
     {
         id: 's_three_columns',
         name: 'Columns',
-        groupName: "Content",
+        groupName: "Columns",
     },
     {
         id: 's_call_to_action',

--- a/theme_kiddo/static/src/js/tour.js
+++ b/theme_kiddo/static/src/js/tour.js
@@ -16,7 +16,7 @@ const snippets = [
     {
         id: 's_three_columns',
         name: 'Columns',
-        groupName: "Content",
+        groupName: "Columns",
     },
     {
         id: 's_product_list',

--- a/theme_loftspace/static/src/js/tour.js
+++ b/theme_loftspace/static/src/js/tour.js
@@ -11,7 +11,7 @@ const snippets = [
     {
         id: 's_three_columns',
         name: 'Columns',
-        groupName: "Content",
+        groupName: "Columns",
     },
     {
         id: 's_title',

--- a/theme_monglia/static/src/js/tour.js
+++ b/theme_monglia/static/src/js/tour.js
@@ -21,7 +21,7 @@ const snippets = [
     {
         id: 's_three_columns',
         name: 'Columns',
-        groupName: "Content",
+        groupName: "Columns",
     },
     {
         id: 's_images_wall',


### PR DESCRIPTION
*: theme_clean, theme_kiddo, theme_loftspace, theme_monglia

Commit [1] adapted the homepage tour to the new Columns category added in the "Add Snippet Dialog".

Unfortunately, it did not properly adapt every tour, and this was not caught by runbot because the test was disabled during that time.

This commit fixes the leftovers.

[1]: https://github.com/odoo/design-themes/commit/a63e21e41ac0dba102b4267a775fc1ea3221addd

related to task-4119460
runbot-75889