### PR TITLE
[IMP] theme_test_custo: adapt portal.user_dropdown classes

### DIFF
--- a/theme_test_custo/views/header.xml
+++ b/theme_test_custo/views/header.xml
@@ -34,7 +34,7 @@
                     <t t-call="portal.user_dropdown">
                         <t t-set="_user_name" t-value="true"/>
                         <t t-set="_item_class" t-valuef="nav-item dropdown ml-auto"/>
-                        <t t-set="_link_class" t-valuef="nav-link text-900"/>
+                        <t t-set="_link_class" t-valuef="btn nav-link text-900"/>
                     </t>
                 </t>
             </div>


### PR DESCRIPTION
Since `btn` has been removed by default from `portal.user_dropdown` classes, this commit adapts the template call to maintain the correct behavior.

task-4019055

Requires:
- https://github.com/odoo/odoo/pull/178150