### PR TITLE
[IMP] test_themes: add test to detect accidental cross-theme references

### DIFF
--- a/test_themes/tests/__init__.py
+++ b/test_themes/tests/__init__.py
@@ -6,6 +6,7 @@
 
 from . import test_crawl
 from . import test_new_page_templates
+from . import test_theme_scope
 from . import test_theme_upgrade
 # This test should be last.
 from . import test_theme_standalone

--- a/test_themes/tests/test_theme_scope.py
+++ b/test_themes/tests/test_theme_scope.py
@@ -1,0 +1,34 @@
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+import logging
+
+from odoo.tests import tagged, TransactionCase
+
+_logger = logging.getLogger(__name__)
+
+@tagged('post_install', '-at_install')
+class TestThemeScope(TransactionCase):
+
+    def test_scope(self):
+        websites_themes = self.env['website'].get_test_themes_websites()
+        assets_count = 0
+        attachments_count = 0
+        fails = []
+        for website in websites_themes:
+            prefix = f'{website.theme_id.name}/'
+            slash_prefix = f'/{website.theme_id.name}/'
+            theme_module = self.env['ir.module.module'].search([
+                ('name', '=', website.theme_id.name),
+            ])
+            assets = theme_module._get_module_data('ir.asset')
+            for asset in assets:
+                if not asset.path.startswith(prefix) and not asset.path.startswith(slash_prefix):
+                    fails.append(f"Asset {asset.id} {asset.key} references outside of theme {website.theme_id.name}: {asset.path}")
+            assets_count += len(assets)
+            attachments = theme_module._get_module_data('ir.attachment')
+            for attachment in attachments:
+                if not attachment.url.startswith(slash_prefix):
+                    fails.append(f"Attachment {attachment.id} {attachment.key} references outside of theme {website.theme_id.name}: {attachment.url}")
+            attachments_count += len(attachments)
+        _logger.info(f"Verified {assets_count} assets and {attachments_count} attachments")
+        self.assertFalse(fails, "\n".join(fails))

--- a/theme_anelusia/views/images_library.xml
+++ b/theme_anelusia/views/images_library.xml
@@ -20,7 +20,7 @@
 <record id="s_text_cover_default_image" model="theme.ir.attachment">
     <field name="key">website.s_text_cover_default_image</field>
     <field name="name">website.s_text_cover_default_image</field>
-    <field name="url">website.s_banner_default_image</field>
+    <field name="url">/theme_anelusia/static/src/img/snippets/s_banner.jpg</field>
 </record>
 <record id="s_popup_default_image" model="theme.ir.attachment">
     <field name="key">website.s_popup_default_image</field>

--- a/theme_artists/views/images.xml
+++ b/theme_artists/views/images.xml
@@ -83,7 +83,7 @@ Check in theme_monglia's primary_variables.scss, theme.scss and theme_common's m
 <record id="s_three_columns_default_image_2" model="theme.ir.attachment">
     <field name="key">website.s_three_columns_default_image_2</field>
     <field name="name">website.s_three_columns_default_image_2</field>
-    <field name="url">/theme_loftspace/static/src/img/snippets/library_image_13.jpg</field>
+    <field name="url">/theme_artists/static/src/img/snippets/library_image_13.jpg</field>
 </record>
 <record id="library_image_11" model="theme.ir.attachment">
     <field name="key">website.library_image_11</field>


### PR DESCRIPTION
This commit adds a test to ensure that assets and images referenced from
a theme do actually belong to that theme.

task-4146886
