### PR TITLE
[IMP] theme_*: adapt `s_references_social`

### DIFF
--- a/theme_anelusia/__manifest__.py
+++ b/theme_anelusia/__manifest__.py
@@ -25,6 +25,7 @@
         'views/snippets/s_company_team_shapes.xml',
         'views/snippets/s_sidegrid.xml',
         'views/snippets/s_references.xml',
+        'views/snippets/s_references_social.xml',
         'views/snippets/s_call_to_action.xml',
         'views/snippets/s_comparisons.xml',
         'views/snippets/s_freegrid.xml',

--- a/theme_anelusia/views/snippets/s_references_social.xml
+++ b/theme_anelusia/views/snippets/s_references_social.xml
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+
+<template id="s_references_social" inherit_id="website.s_references_social">
+    <!-- Title -->
+    <xpath expr="//h2" position="replace" mode="inner">
+        <font style="background-image: linear-gradient(135deg, var(--o-color-1) 0%, var(--o-color-2) 100%);" class="text-gradient">Our top brands</font>
+    </xpath>
+    <!-- Subtitle -->
+    <xpath expr="//p[hasclass('lead')]" position="replace" mode="inner">
+        Every style for everybody.
+    </xpath>
+    <!-- Partners -->
+    <xpath expr="//div[hasclass('row')]/div[2]/p" position="replace" mode="inner">
+        Redefining elegance since 2009
+    </xpath>
+    <xpath expr="//div[hasclass('row')]/div[3]/p" position="replace" mode="inner">
+        Disrupting fashion since 2013
+    </xpath>
+    <xpath expr="//div[hasclass('row')]/div[4]/p" position="replace" mode="inner">
+        Shaping your style since 2015
+    </xpath>
+    <xpath expr="//div[hasclass('row')]/div[5]/p" position="replace" mode="inner">
+        Transforming trends since 2018
+    </xpath>
+</template>
+
+</odoo>

--- a/theme_buzzy/__manifest__.py
+++ b/theme_buzzy/__manifest__.py
@@ -36,6 +36,7 @@
         'views/snippets/s_product_list.xml',
         'views/snippets/s_tabs.xml',
         'views/snippets/s_references.xml',
+        'views/snippets/s_references_social.xml',
         'views/snippets/s_faq_collapse.xml',
         'views/snippets/s_timeline.xml',
         'views/snippets/s_process_steps.xml',

--- a/theme_buzzy/views/snippets/s_references_social.xml
+++ b/theme_buzzy/views/snippets/s_references_social.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+
+<template id="s_references_social" inherit_id="website.s_references_social">
+    <!-- Section -->
+    <xpath expr="//section" position="attributes">
+        <attribute name="class" add="o_cc2" remove="o_cc1" separator=" "/>
+    </xpath>
+</template>
+
+</odoo>

--- a/theme_kea/__manifest__.py
+++ b/theme_kea/__manifest__.py
@@ -20,6 +20,7 @@
         'views/snippets/s_media_list.xml',
         'views/snippets/s_freegrid.xml',
         'views/snippets/s_references.xml',
+        'views/snippets/s_references_social.xml',
         'views/snippets/s_motto.xml',
         'views/snippets/s_color_blocks_2.xml',
         'views/snippets/s_features_wall.xml',

--- a/theme_kea/views/snippets/s_references_social.xml
+++ b/theme_kea/views/snippets/s_references_social.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+
+<template id="s_references_social" inherit_id="website.s_references_social">
+    <!-- Section -->
+    <xpath expr="//section" position="attributes">
+        <attribute name="class" add="o_cc2" remove="o_cc1" separator=" "/>
+    </xpath>
+</template>
+
+</odoo>

--- a/theme_nano/__manifest__.py
+++ b/theme_nano/__manifest__.py
@@ -24,6 +24,7 @@
         'views/snippets/s_parallax.xml',
         'views/snippets/s_pricelist_boxed.xml',
         'views/snippets/s_references.xml',
+        'views/snippets/s_references_social.xml',
         'views/snippets/s_text_block.xml',
         'views/snippets/s_text_image.xml',
         'views/snippets/s_three_columns.xml',

--- a/theme_nano/views/snippets/s_references_social.xml
+++ b/theme_nano/views/snippets/s_references_social.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+
+<template id="s_references_social" inherit_id="website.s_references_social">
+    <!-- Section -->
+    <xpath expr="//div[hasclass('row')]/div[2]/h3" position="replace" mode="inner">
+        Barbershop
+    </xpath>
+    <xpath expr="//div[hasclass('row')]/div[3]/h3" position="replace" mode="inner">
+        Oceandor
+    </xpath>
+    <xpath expr="//div[hasclass('row')]/div[4]/h3" position="replace" mode="inner">
+        Mountain
+    </xpath>
+    <xpath expr="//div[hasclass('row')]/div[5]/h3" position="replace" mode="inner">
+        Hosoren
+    </xpath>
+</template>
+
+</odoo>

--- a/theme_odoo_experts/__manifest__.py
+++ b/theme_odoo_experts/__manifest__.py
@@ -20,6 +20,7 @@
         'views/snippets/s_text_image.xml',
         'views/snippets/s_company_team.xml',
         'views/snippets/s_references.xml',
+        'views/snippets/s_references_social.xml',
         'views/snippets/s_freegrid.xml',
         'views/snippets/s_cover.xml',
         'views/snippets/s_numbers.xml',

--- a/theme_odoo_experts/views/snippets/s_references_social.xml
+++ b/theme_odoo_experts/views/snippets/s_references_social.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+
+<template id="s_references_social" inherit_id="website.s_references_social">
+    <!-- Section -->
+    <xpath expr="//section" position="attributes">
+        <attribute name="class" add="pt0 pb56 o_cc2" remove="pt64 pb64 o_cc1" separator=" "/>
+    </xpath>
+    <!-- Remove title, subtitle -->
+    <xpath expr="//div[hasclass('row')]/div" position="replace"/>
+</template>
+
+</odoo>

--- a/theme_zap/__manifest__.py
+++ b/theme_zap/__manifest__.py
@@ -23,6 +23,7 @@
         'views/snippets/s_media_list.xml',
         'views/snippets/s_numbers.xml',
         'views/snippets/s_references.xml',
+        'views/snippets/s_references_social.xml',
         'views/snippets/s_image_text.xml',
         'views/snippets/s_key_images.xml',
         'views/snippets/s_three_columns.xml',

--- a/theme_zap/views/snippets/s_references_social.xml
+++ b/theme_zap/views/snippets/s_references_social.xml
@@ -1,0 +1,31 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+
+<template id="s_references_social" inherit_id="website.s_references_social">
+    <!-- Section -->
+    <xpath expr="//section" position="attributes">
+        <attribute name="class" add="o_cc2" remove="o_cc1" separator=" "/>
+    </xpath>
+    <!-- Column #01 -->
+    <xpath expr="//div[hasclass('row')]/div[2]" position="attributes">
+        <attribute name="class" add="o_cc o_cc1" separator=" "/>
+        <attribute name="style" add="box-shadow: rgba(0, 0, 0, 0.15) 0px 2px 4px 0px !important;" separator=" "/>
+    </xpath>
+    <!-- Column #02 -->
+    <xpath expr="//div[hasclass('row')]/div[3]" position="attributes">
+        <attribute name="class" add="o_cc o_cc1" separator=" "/>
+        <attribute name="style" add="box-shadow: rgba(0, 0, 0, 0.15) 0px 2px 4px 0px !important;" separator=" "/>
+    </xpath>
+    <!-- Column #03 -->
+    <xpath expr="//div[hasclass('row')]/div[4]" position="attributes">
+        <attribute name="class" add="o_cc o_cc1" separator=" "/>
+        <attribute name="style" add="box-shadow: rgba(0, 0, 0, 0.15) 0px 2px 4px 0px !important;" separator=" "/>
+    </xpath>
+    <!-- Column #04 -->
+    <xpath expr="//div[hasclass('row')]/div[5]" position="attributes">
+        <attribute name="class" add="o_cc o_cc1" separator=" "/>
+        <attribute name="style" add="box-shadow: rgba(0, 0, 0, 0.15) 0px 2px 4px 0px !important;" separator=" "/>
+    </xpath>
+</template>
+
+</odoo>


### PR DESCRIPTION
*: buzzy, kea, nano, odoo_experts, zap

Adapt the newly introduced `s_references_social` to match existing themes. 

task-4146797
Part-of: task-4077427

Community PR: https://github.com/odoo/odoo/pull/178379

| Visual change |
|:--------:|
| Default* v |
| ![image](https://github.com/user-attachments/assets/f65d3157-f0e6-436b-bec9-e0aa95e27c87) |
| Anelusia v |
| ![image](https://github.com/user-attachments/assets/a59680a5-2baf-4efa-a80a-de280316bdc7) | 
| Buzzy* v |
| ![image](https://github.com/user-attachments/assets/7ab3d154-eca8-4632-9e71-649c87c494cc) | 
| Kea* v |
| ![image](https://github.com/user-attachments/assets/9536e502-84d2-4104-aa11-8521f0bd3438) | 
| Nano* v |
| ![image](https://github.com/user-attachments/assets/337eba41-97ce-4bf0-807f-c921fed99608) | 
| Odoo Experts* v |
| ![image](https://github.com/user-attachments/assets/194ada9b-fb1c-4cc3-802a-75a187e463a6) |
| Zap* v |
| ![image](https://github.com/user-attachments/assets/680554f0-b618-4764-a98f-503c9996843c) | 

*All the themes inheriting the default wording are now displaying adapted demo data
