### PR TITLE
[IMP] theme_*: adapt s_big_number across themes

### DIFF
--- a/theme_anelusia/__manifest__.py
+++ b/theme_anelusia/__manifest__.py
@@ -45,6 +45,7 @@
         'views/snippets/s_pricelist_boxed.xml',
         'views/snippets/s_striped_center_top.xml',
         'views/snippets/s_key_images.xml',
+        'views/snippets/s_big_number.xml',
         'views/new_page_template.xml',
     ],
     'images': [

--- a/theme_anelusia/views/snippets/s_big_number.xml
+++ b/theme_anelusia/views/snippets/s_big_number.xml
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+
+<template id="s_big_number" inherit_id="website.s_big_number">
+    <!-- Section -->
+    <xpath expr="//section" position="attributes">
+        <attribute name="data-oe-shape-data">{"shape":"web_editor/Blobs/06"}</attribute>
+    </xpath>
+
+    <!-- Shape -->
+    <xpath expr="//div[hasclass('o_we_shape')]" position="replace">
+        <div class="o_we_shape o_web_editor_Blobs_06"/>
+    </xpath>
+
+    <!-- Text -->
+    <xpath expr="//h2/div" position="replace" mode="inner">
+        <font class="text-gradient" style="background-image: linear-gradient(0deg, rgb(29, 32, 48) 25%, rgb(222, 222, 222) 80%);">
+            100+
+        </font>
+    </xpath>
+    <xpath expr="//h2/following-sibling::div" position="replace" mode="inner">
+        happy customers
+    </xpath>
+</template>
+
+</odoo>

--- a/theme_artists/__manifest__.py
+++ b/theme_artists/__manifest__.py
@@ -49,6 +49,7 @@
         'views/snippets/s_pricelist_boxed.xml',
         'views/snippets/s_striped_center_top.xml',
         'views/snippets/s_key_images.xml',
+        'views/snippets/s_big_number.xml',
         'views/new_page_template.xml',
     ],
     'images': [

--- a/theme_artists/views/snippets/s_big_number.xml
+++ b/theme_artists/views/snippets/s_big_number.xml
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+
+<template id="s_big_number" inherit_id="website.s_big_number">
+    <!-- Section -->
+    <xpath expr="//section" position="attributes">
+        <attribute name="data-oe-shape-data">{"shape":"web_editor/Airy/14"}</attribute>
+    </xpath>
+
+    <!-- Shape -->
+    <xpath expr="//div[hasclass('o_we_shape')]" position="replace">
+        <div class="o_we_shape o_web_editor_Airy_14"/>
+    </xpath>
+
+    <!-- Text -->
+    <xpath expr="//h2/div" position="attributes">
+        <attribute name="style" add="font-size: 7.75rem;" remove="font-size: 10.75rem;" separator=";"/>
+    </xpath>
+    <xpath expr="//h2/div" position="replace" mode="inner">
+        <font class="text-gradient" style="background-image: linear-gradient(0deg, rgb(165, 78, 223) 8%, rgb(222, 222, 222) 80%);">
+            250+
+        </font>
+    </xpath>
+    <xpath expr="//h2/following-sibling::div" position="replace" mode="inner">
+        songs released
+    </xpath>
+</template>
+
+</odoo>

--- a/theme_avantgarde/views/customizations.xml
+++ b/theme_avantgarde/views/customizations.xml
@@ -474,4 +474,29 @@
     </xpath>
 </template>
 
+<!-- ======== BIG NUMBER ======== -->
+<template id="s_big_number" inherit_id="website.s_big_number">
+    <!-- Section -->
+    <xpath expr="//section" position="attributes">
+        <attribute name="data-oe-shape-data">{"shape":"web_editor/Blocks/03"}</attribute>
+        <attribute name="class" add="o_cc1" remove="o_cc5" separator=" "/>
+    </xpath>
+
+    <!-- Shape -->
+    <xpath expr="//div[hasclass('o_we_shape')]" position="replace">
+        <div class="o_we_shape o_web_editor_Blocks_03"/>
+    </xpath>
+
+    <!-- Text -->
+    <xpath expr="//h2/div" position="replace" mode="inner">
+        <font class="text-gradient" style="background-image: linear-gradient(0deg, rgb(56, 60, 214) 0%, rgb(255, 255, 255) 65%);">
+            50+
+        </font>
+    </xpath>
+    <xpath expr="//h2/following-sibling::div" position="replace" mode="inner">
+        projects shipped
+    </xpath>
+</template>
+
 </odoo>
+

--- a/theme_aviato/__manifest__.py
+++ b/theme_aviato/__manifest__.py
@@ -36,6 +36,7 @@
         'views/snippets/s_carousel.xml',
         'views/snippets/s_image_hexagonal.xml',
         'views/snippets/s_key_images.xml',
+        'views/snippets/s_big_number.xml',
         'views/new_page_template.xml',
     ],
     'images': [

--- a/theme_aviato/views/snippets/s_big_number.xml
+++ b/theme_aviato/views/snippets/s_big_number.xml
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+
+<template id="s_big_number" inherit_id="website.s_big_number">
+    <!-- Section -->
+    <xpath expr="//section" position="attributes">
+        <attribute name="data-oe-shape-data">{"shape":"web_editor/Origins/14"}</attribute>
+        <attribute name="class" add="o_cc4" remove="o_cc5" separator=" "/>
+    </xpath>
+
+    <!-- Shape -->
+    <xpath expr="//div[hasclass('o_we_shape')]" position="replace">
+        <div class="o_we_shape o_web_editor_Origins_14_001" style="background-image: url('/web_editor/shape/web_editor/Origins/14.svg?c3=o-color-4&amp;c4=o-color-4&amp;');"/>
+    </xpath>
+
+    <!-- Text -->
+    <xpath expr="//h2/div" position="attributes">
+        <attribute name="style" add="font-size: 7.75rem;" remove="font-size: 10.75rem;" separator=";"/>
+    </xpath>
+    <xpath expr="//h2/div" position="replace" mode="inner">
+        <font class="text-gradient" style="background-image: linear-gradient(0deg, rgb(244, 168, 26) 0%, rgb(222, 222, 222) 58%);">100+</font>
+    </xpath>
+    <xpath expr="//h2/following-sibling::div" position="replace" mode="inner">
+        destinations available
+    </xpath>
+</template>
+
+</odoo>

--- a/theme_beauty/__manifest__.py
+++ b/theme_beauty/__manifest__.py
@@ -44,6 +44,7 @@
         'views/snippets/s_striped_center_top.xml',
         'views/snippets/s_key_images.xml',
         'views/snippets/s_intro_pill.xml',
+        'views/snippets/s_big_number.xml',
         'views/new_page_template.xml',
     ],
     'images': [

--- a/theme_beauty/views/snippets/s_big_number.xml
+++ b/theme_beauty/views/snippets/s_big_number.xml
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+
+<template id="s_big_number" inherit_id="website.s_big_number">
+    <!-- Section -->
+    <xpath expr="//section" position="attributes">
+        <attribute name="data-oe-shape-data">{"shape":"web_editor/Blobs/12"}</attribute>
+        <attribute name="class" add="o_cc1" remove="o_cc5" separator=" "/>
+    </xpath>
+
+    <!-- Shape -->
+    <xpath expr="//div[hasclass('o_we_shape')]" position="replace">
+        <div class="o_we_shape o_web_editor_Blobs_12"/>
+    </xpath>
+
+    <!-- Text -->
+    <xpath expr="//h2/div" position="attributes">
+        <attribute name="style" add="font-size: 7.75rem;" remove="font-size: 10.75rem;" separator=";"/>
+    </xpath>
+    <xpath expr="//h2/div" position="replace" mode="inner">
+        <font style="color: rgb(165, 35, 91);">200+</font>
+    </xpath>
+    <xpath expr="//h2/following-sibling::div" position="replace" mode="inner">
+        happy customers
+    </xpath>
+</template>
+
+</odoo>

--- a/theme_bewise/views/customizations.xml
+++ b/theme_bewise/views/customizations.xml
@@ -740,4 +740,25 @@
     </xpath>
 </template>
 
+<!-- ======== BIG NUMBER ======== -->
+<template id="s_big_number" inherit_id="website.s_big_number">
+    <!-- Section -->
+    <xpath expr="//section" position="attributes">
+        <attribute name="data-oe-shape-data">{"shape":"web_editor/Bold/06_001"}</attribute>
+    </xpath>
+
+    <!-- Shape -->
+    <xpath expr="//div[hasclass('o_we_shape')]" position="replace">
+        <div class="o_we_shape o_web_editor_Bold_06_001 bg-o-color-4" style="background-image: url('/web_editor/shape/web_editor/Bold/06_001.svg?c3=o-color-1&amp;');"/>
+    </xpath>
+
+    <!-- Text -->
+    <xpath expr="//h2/div" position="replace" mode="inner">
+        <font class="text-gradient" style="background-image: linear-gradient(0deg, rgb(29, 32, 48) 0%, rgb(222, 222, 222) 56%);">60+</font>
+    </xpath>
+    <xpath expr="//h2/following-sibling::div" position="replace" mode="inner">
+        academic programs available
+    </xpath>
+</template>
+
 </odoo>

--- a/theme_bistro/__manifest__.py
+++ b/theme_bistro/__manifest__.py
@@ -41,6 +41,7 @@
         'views/snippets/s_striped_top.xml',
         'views/snippets/s_quadrant.xml',
         'views/snippets/s_intro_pill.xml',
+        'views/snippets/s_big_number.xml',
         'views/new_page_template.xml',
 
     ],

--- a/theme_bistro/views/snippets/s_big_number.xml
+++ b/theme_bistro/views/snippets/s_big_number.xml
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+
+<template id="s_big_number" inherit_id="website.s_big_number">
+    <!-- Section -->
+    <xpath expr="//section" position="attributes">
+        <attribute name="data-oe-shape-data">{"shape":"web_editor/Blobs/02"}</attribute>
+    </xpath>
+
+    <!-- Shape -->
+    <xpath expr="//div[hasclass('o_we_shape')]" position="replace">
+        <div class="o_we_shape o_web_editor_Blobs_02"/>
+    </xpath>
+
+    <!-- Text -->
+    <xpath expr="//h2/div" position="replace" mode="inner">
+        350+
+    </xpath>
+    <xpath expr="//h2/div" position="attributes">
+        <attribute name="style" remove="font-size: 10.75rem;" add="font-size: 7.75rem;" separator=";"/>
+        350+
+    </xpath>
+    <xpath expr="//h2/following-sibling::div" position="replace" mode="inner">
+        happy guests served
+    </xpath>
+</template>
+
+</odoo>

--- a/theme_bookstore/__manifest__.py
+++ b/theme_bookstore/__manifest__.py
@@ -46,6 +46,7 @@
         'views/snippets/s_image_hexagonal.xml',
         'views/snippets/s_striped_center_top.xml',
         'views/snippets/s_intro_pill.xml',
+        'views/snippets/s_big_number.xml',
         'views/new_page_template.xml',
     ],
     'images': [

--- a/theme_bookstore/views/snippets/s_big_number.xml
+++ b/theme_bookstore/views/snippets/s_big_number.xml
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+
+<template id="s_big_number" inherit_id="website.s_big_number">
+    <!-- Section -->
+    <xpath expr="//section" position="attributes">
+        <attribute name="data-oe-shape-data">{"shape":"web_editor/Blobs/06"}</attribute>
+    </xpath>
+
+    <!-- Shape -->
+    <xpath expr="//div[hasclass('o_we_shape')]" position="replace">
+        <div class="o_we_shape o_web_editor_Blobs_06"/>
+    </xpath>
+
+    <!-- Text -->
+    <xpath expr="//h2/div" position="replace" mode="inner">
+        90%
+    </xpath>
+</template>
+
+</odoo>

--- a/theme_buzzy/__manifest__.py
+++ b/theme_buzzy/__manifest__.py
@@ -52,6 +52,7 @@
         'views/snippets/s_striped_center_top.xml',
         'views/snippets/s_image_title.xml',
         'views/snippets/s_key_images.xml',
+        'views/snippets/s_big_number.xml',
         'views/new_page_template.xml',
     ],
     'images': [

--- a/theme_buzzy/views/snippets/s_big_number.xml
+++ b/theme_buzzy/views/snippets/s_big_number.xml
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+
+<template id="s_big_number" inherit_id="website.s_big_number">
+    <!-- Section -->
+    <xpath expr="//section" position="attributes">
+        <attribute name="data-oe-shape-data">{"shape":"web_editor/Blocks/01_001"}</attribute>
+        <attribute name="class" add="o_cc4" remove="o_cc5" separator=" "/>
+    </xpath>
+
+    <!-- Shape -->
+    <xpath expr="//div[hasclass('o_we_shape')]" position="replace">
+        <div class="o_we_shape o_web_editor_Blocks_01_001"/>
+    </xpath>
+
+    <!-- Text -->
+    <xpath expr="//h2/div" position="replace" mode="inner">
+        90%
+    </xpath>
+    <xpath expr="//h2/following-sibling::div" position="attributes">
+        <attribute name="style" add="font-size: 7.75rem;" remove="font-size: 10.75rem;" separator=";"/>
+    </xpath>
+</template>
+
+</odoo>

--- a/theme_clean/__manifest__.py
+++ b/theme_clean/__manifest__.py
@@ -32,6 +32,7 @@
         'views/snippets/s_key_benefits.xml',
         'views/snippets/s_pricelist_boxed.xml',
         'views/snippets/s_striped_center_top.xml',
+        'views/snippets/s_big_number.xml',
         'views/new_page_template.xml',
     ],
     'images': [

--- a/theme_clean/views/snippets/s_big_number.xml
+++ b/theme_clean/views/snippets/s_big_number.xml
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+
+<template id="s_big_number" inherit_id="website.s_big_number">
+    <!-- Section -->
+    <xpath expr="//section" position="attributes">
+        <attribute name="data-oe-shape-data">{"shape":"web_editor/Blocks/01_001"}</attribute>
+        <attribute name="class" add="o_cc4" remove="o_cc5" separator=" "/>
+    </xpath>
+
+    <!-- Shape -->
+    <xpath expr="//div[hasclass('o_we_shape')]" position="replace">
+        <div class="o_we_shape o_web_editor_Blocks_01_001"/>
+    </xpath>
+
+    <!-- Text -->
+    <xpath expr="//h2/div" position="replace" mode="inner">
+        90%
+    </xpath>
+    <xpath expr="//h2/following-sibling::div" position="attributes">
+        <attribute name="style" add="font-size: 7.75rem;" remove="font-size: 10.75rem;" separator=";"/>
+    </xpath>
+</template>
+
+</odoo>

--- a/theme_cobalt/views/customizations.xml
+++ b/theme_cobalt/views/customizations.xml
@@ -478,4 +478,26 @@
     </xpath>
 </template>
 
+<!-- ======== BIG NUMBER ======== -->
+<template id="s_big_number" inherit_id="website.s_big_number">
+    <!-- Section -->
+    <xpath expr="//section" position="attributes">
+        <attribute name="data-oe-shape-data">{"shape":"web_editor/Blocks/01_001"}</attribute>
+        <attribute name="class" add="o_cc4" remove="o_cc5" separator=" "/>
+    </xpath>
+
+    <!-- Shape -->
+    <xpath expr="//div[hasclass('o_we_shape')]" position="replace">
+        <div class="o_we_shape o_web_editor_Blocks_01_001"/>
+    </xpath>
+
+    <!-- Text -->
+    <xpath expr="//h2/div" position="replace" mode="inner">
+        90%
+    </xpath>
+    <xpath expr="//h2/following-sibling::div" position="attributes">
+        <attribute name="style" add="font-size: 7.75rem;" remove="font-size: 10.75rem;" separator=";"/>
+    </xpath>
+</template>
+
 </odoo>

--- a/theme_enark/__manifest__.py
+++ b/theme_enark/__manifest__.py
@@ -35,6 +35,7 @@
         'views/snippets/s_carousel.xml',
         'views/snippets/s_striped_center_top.xml',
         'views/snippets/s_intro_pill.xml',
+        'views/snippets/s_big_number.xml',
         'views/new_page_template.xml',
     ],
     'images': [

--- a/theme_enark/views/snippets/s_big_number.xml
+++ b/theme_enark/views/snippets/s_big_number.xml
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+
+<template id="s_big_number" inherit_id="website.s_big_number">
+    <!-- Section -->
+    <xpath expr="//section" position="attributes">
+        <attribute name="data-oe-shape-data">{"shape":"web_editor/Bold/03"}</attribute>
+        <attribute name="class" add="o_cc1" remove="o_cc5" separator=" "/>
+    </xpath>
+
+    <!-- Shape -->
+    <xpath expr="//div[hasclass('o_we_shape')]" position="replace">
+        <div class="o_we_shape o_web_editor_Bold_03" style="background-image: url('/web_editor/shape/web_editor/Bold/03.svg?c1=o-color-3&amp;c3=o-color-3&amp;c5=o-color-3&amp;');"/>
+    </xpath>
+
+    <!-- Text -->
+    <xpath expr="//h2/div" position="replace" mode="inner">
+        80+
+    </xpath>
+    <xpath expr="//h2/following-sibling::div" position="replace" mode="inner">
+        projects shipped
+    </xpath>
+</template>
+
+</odoo>

--- a/theme_graphene/views/customizations.xml
+++ b/theme_graphene/views/customizations.xml
@@ -489,4 +489,26 @@
     </xpath>
 </template>
 
+<!-- ======== BIG NUMBER ======== -->
+<template id="s_big_number" inherit_id="website.s_big_number">
+    <!-- Section -->
+    <xpath expr="//section" position="attributes">
+        <attribute name="data-oe-shape-data">{"shape":"web_editor/Blocks/01_001"}</attribute>
+        <attribute name="class" add="o_cc3" remove="o_cc5" separator=" "/>
+    </xpath>
+
+    <!-- Shape -->
+    <xpath expr="//div[hasclass('o_we_shape')]" position="replace">
+        <div class="o_we_shape o_web_editor_Blocks_01_001"/>
+    </xpath>
+
+    <!-- Text -->
+    <xpath expr="//h2/div" position="replace" mode="inner">
+        90%
+    </xpath>
+    <xpath expr="//h2/following-sibling::div" position="attributes">
+        <attribute name="style" add="font-size: 7.75rem;" remove="font-size: 10.75rem;" separator=";"/>
+    </xpath>
+</template>
+
 </odoo>

--- a/theme_kea/__manifest__.py
+++ b/theme_kea/__manifest__.py
@@ -39,6 +39,7 @@
         'views/snippets/s_image_title.xml',
         'views/snippets/s_key_images.xml',
         'views/snippets/s_quadrant.xml',
+        'views/snippets/s_big_number.xml',
         'views/new_page_template.xml',
     ],
     'images': [

--- a/theme_kea/views/snippets/s_big_number.xml
+++ b/theme_kea/views/snippets/s_big_number.xml
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+
+<template id="s_big_number" inherit_id="website.s_big_number">
+    <!-- Section -->
+    <xpath expr="//section" position="attributes">
+        <attribute name="data-oe-shape-data">{"shape":"web_editor/Blobs/02"}</attribute>
+        <attribute name="class" add="o_cc1" remove="o_cc5" separator=" "/>
+    </xpath>
+
+    <!-- Shape -->
+    <xpath expr="//div[hasclass('o_we_shape')]" position="replace">
+        <div class="o_we_shape o_web_editor_Blobs_02"/>
+    </xpath>
+
+    <!-- Text -->
+    <xpath expr="//h2/div" position="replace" mode="inner">
+        80+
+    </xpath>
+    <xpath expr="//h2/following-sibling::div" position="replace" mode="inner">
+        satisfied clients
+    </xpath>
+</template>
+
+</odoo>

--- a/theme_kiddo/__manifest__.py
+++ b/theme_kiddo/__manifest__.py
@@ -41,6 +41,7 @@
         'views/snippets/s_image_title.xml',
         'views/snippets/s_key_images.xml',
         'views/snippets/s_intro_pill.xml',
+        'views/snippets/s_big_number.xml',
         'views/new_page_template.xml',
     ],
     'images': [

--- a/theme_kiddo/views/snippets/s_big_number.xml
+++ b/theme_kiddo/views/snippets/s_big_number.xml
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+
+<template id="s_big_number" inherit_id="website.s_big_number">
+    <!-- Section -->
+    <xpath expr="//section" position="attributes">
+        <attribute name="data-oe-shape-data">{"shape":"web_editor/Blobs/02"}</attribute>
+        <attribute name="class" add="o_cc1" remove="o_cc5" separator=" "/>
+    </xpath>
+
+    <!-- Shape -->
+    <xpath expr="//div[hasclass('o_we_shape')]" position="replace">
+        <div class="o_we_shape o_web_editor_Blobs_02"/>
+    </xpath>
+
+    <!-- Text -->
+    <xpath expr="//h2/div" position="replace" mode="inner">
+        80+
+    </xpath>
+    <xpath expr="//h2/following-sibling::div" position="replace" mode="inner">
+        families trusted us
+    </xpath>
+</template>
+
+</odoo>

--- a/theme_loftspace/__manifest__.py
+++ b/theme_loftspace/__manifest__.py
@@ -39,6 +39,7 @@
         'views/snippets/s_striped_center_top.xml',
         'views/snippets/s_key_images.xml',
         'views/snippets/s_quadrant.xml',
+        'views/snippets/s_big_number.xml',
         'views/new_page_template.xml',
     ],
     'images': [

--- a/theme_loftspace/views/snippets/s_big_number.xml
+++ b/theme_loftspace/views/snippets/s_big_number.xml
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+
+<template id="s_big_number" inherit_id="website.s_big_number">
+    <!-- Section -->
+    <xpath expr="//section" position="attributes">
+        <attribute name="data-oe-shape-data">{"shape":"web_editor/Blobs/12"}</attribute>
+        <attribute name="class" add="o_cc1" remove="o_cc5" separator=" "/>
+    </xpath>
+
+    <!-- Shape -->
+    <xpath expr="//div[hasclass('o_we_shape')]" position="replace">
+        <div class="o_we_shape o_web_editor_Blobs_12"/>
+    </xpath>
+
+    <!-- Text -->
+    <xpath expr="//h2/div" position="attributes">
+        <attribute name="style" add="font-size: 7.75rem;" remove="font-size: 10.75rem;" separator=";"/>
+    </xpath>
+    <xpath expr="//h2/div" position="replace" mode="inner">
+        250+
+    </xpath>
+    <xpath expr="//h2/following-sibling::div" position="replace" mode="inner">
+        satisfied clients
+    </xpath>
+</template>
+
+</odoo>

--- a/theme_monglia/views/customizations.xml
+++ b/theme_monglia/views/customizations.xml
@@ -567,4 +567,31 @@
     </xpath>
 </template>
 
+<!-- ======== BIG NUMBER ======== -->
+<template id="s_big_number" inherit_id="website.s_big_number">
+    <!-- Section -->
+    <xpath expr="//section" position="attributes">
+        <attribute name="data-oe-shape-data">{"shape":"web_editor/Origins/18"}</attribute>
+    </xpath>
+
+    <!-- Shape -->
+    <xpath expr="//div[hasclass('o_we_shape')]" position="replace">
+        <div class="o_we_shape o_web_editor_Origins_18 o_we_animated"/>
+    </xpath>
+
+    <!-- Text -->
+    <xpath expr="//h2/div" position="attributes">
+        <attribute name="style" add="font-size: 7.75rem;" remove="font-size: 10.75rem;" separator=";"/>
+    </xpath>
+    <xpath expr="//h2/div" position="replace" mode="inner">
+        <font class="text-gradient" style="background-image: linear-gradient(0deg, rgb(237, 7, 104) 0%, rgb(222, 222, 222) 59%);">
+            250+
+        </font>
+    </xpath>
+    <xpath expr="//h2/following-sibling::div" position="replace" mode="inner">
+        events organized
+    </xpath>
+</template>
+
+
 </odoo>

--- a/theme_nano/__manifest__.py
+++ b/theme_nano/__manifest__.py
@@ -32,6 +32,7 @@
         'views/snippets/s_numbers_showcase.xml',
         'views/snippets/s_key_benefits.xml',
         'views/snippets/s_striped_center_top.xml',
+        'views/snippets/s_big_number.xml',
         'views/new_page_template.xml',
     ],
     'images': [

--- a/theme_nano/views/snippets/s_big_number.xml
+++ b/theme_nano/views/snippets/s_big_number.xml
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+
+<template id="s_big_number" inherit_id="website.s_big_number">
+    <!-- Section -->
+    <xpath expr="//section" position="attributes">
+        <attribute name="data-oe-shape-data">{"shape":"web_editor/Bold/06_001"}</attribute>
+        <attribute name="class" add="o_cc4" remove="o_cc5" separator=" "/>
+    </xpath>
+
+    <!-- Shape -->
+    <xpath expr="//div[hasclass('o_we_shape')]" position="replace">
+        <div class="o_we_shape o_web_editor_Bold_06_001"/>
+    </xpath>
+
+    <!-- Text -->
+    <xpath expr="//h2/div" position="attributes">
+        <attribute name="style" add="font-size: 7.75rem;" remove="font-size: 10.75rem;" separator=";"/>
+    </xpath>
+    <xpath expr="//h2/div" position="replace" mode="inner">
+        250+
+    </xpath>
+    <xpath expr="//h2/following-sibling::div" position="replace" mode="inner">
+        satisfied clients
+    </xpath>
+</template>
+
+</odoo>

--- a/theme_notes/__manifest__.py
+++ b/theme_notes/__manifest__.py
@@ -45,6 +45,7 @@
         'views/snippets/s_key_images.xml',
         'views/snippets/s_quadrant.xml',
         'views/snippets/s_intro_pill.xml',
+        'views/snippets/s_big_number.xml',
         'views/new_page_template.xml',
     ],
     'images': [

--- a/theme_notes/views/snippets/s_big_number.xml
+++ b/theme_notes/views/snippets/s_big_number.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+
+<template id="s_big_number" inherit_id="website.s_big_number">
+    <!-- Section -->
+    <xpath expr="//section" position="attributes">
+        <attribute name="data-oe-shape-data">{"shape":"web_editor/Blobs/04"}</attribute>
+    </xpath>
+
+    <!-- Shape -->
+    <xpath expr="//div[hasclass('o_we_shape')]" position="replace">
+        <div class="o_we_shape o_web_editor_Blobs_04"/>
+    </xpath>
+
+    <!-- Text -->
+    <xpath expr="//h2/div" position="attributes">
+        <attribute name="style" add="font-size: 7.75rem;" remove="font-size: 10.75rem;" separator=";"/>
+    </xpath>
+    <xpath expr="//h2/div" position="replace" mode="inner">
+        20M
+    </xpath>
+    <xpath expr="//h2/following-sibling::div" position="replace" mode="inner">
+        Monthly listeners on streaming platforms
+    </xpath>
+</template>
+
+</odoo>

--- a/theme_odoo_experts/__manifest__.py
+++ b/theme_odoo_experts/__manifest__.py
@@ -41,6 +41,7 @@
         'views/snippets/s_image_title.xml',
         'views/snippets/s_key_images.xml',
         'views/snippets/s_quadrant.xml',
+        'views/snippets/s_big_number.xml',
         'views/new_page_template.xml',
     ],
     'images': [

--- a/theme_odoo_experts/views/snippets/s_big_number.xml
+++ b/theme_odoo_experts/views/snippets/s_big_number.xml
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+
+<template id="s_big_number" inherit_id="website.s_big_number">
+    <!-- Section -->
+    <xpath expr="//section" position="attributes">
+        <attribute name="data-oe-shape-data">{"shape":"web_editor/Origins/18"}</attribute>
+    </xpath>
+
+    <!-- Shape -->
+    <xpath expr="//div[hasclass('o_we_shape')]" position="replace">
+        <div class="o_we_shape o_web_editor_Origins_18 o_we_animated"/>
+    </xpath>
+
+    <!-- Text -->
+    <xpath expr="//h2/div" position="attributes">
+        <attribute name="style" add="font-size: 7.75rem;" remove="font-size: 10.75rem;" separator=";"/>
+    </xpath>
+    <xpath expr="//h2/div" position="replace" mode="inner">
+        90%
+    </xpath>
+</template>
+
+</odoo>

--- a/theme_orchid/__manifest__.py
+++ b/theme_orchid/__manifest__.py
@@ -37,6 +37,7 @@
         'views/snippets/s_striped_center_top.xml',
         'views/snippets/s_key_images.xml',
         'views/snippets/s_intro_pill.xml',
+        'views/snippets/s_big_number.xml',
         'views/new_page_template.xml',
     ],
     'images': [

--- a/theme_orchid/views/snippets/s_big_number.xml
+++ b/theme_orchid/views/snippets/s_big_number.xml
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+
+<template id="s_big_number" inherit_id="website.s_big_number">
+    <!-- Section -->
+    <xpath expr="//section" position="attributes">
+        <attribute name="data-oe-shape-data">{"shape":"web_editor/Blobs/08"}</attribute>
+    </xpath>
+
+    <!-- Shape -->
+    <xpath expr="//div[hasclass('o_we_shape')]" position="replace">
+        <div class="o_we_shape o_web_editor_Blobs_08"/>
+    </xpath>
+
+    <!-- Text -->
+    <xpath expr="//h2/div" position="replace" mode="inner">
+        50+
+    </xpath>
+    <xpath expr="//h2/following-sibling::div" position="replace" mode="inner">
+        varieties of flowers to choose from
+    </xpath>
+</template>
+
+</odoo>

--- a/theme_paptic/views/customizations.xml
+++ b/theme_paptic/views/customizations.xml
@@ -691,4 +691,29 @@
     </xpath>
 </template>
 
+<!-- ==== Big Number ===== -->
+<template id="s_big_number" inherit_id="website.s_big_number">
+    <!-- Section -->
+    <xpath expr="//section" position="attributes">
+        <attribute name="data-oe-shape-data">{"shape":"web_editor/Wavy/03"}</attribute>
+        <attribute name="class" add="o_cc4" remove="o_cc5" separator=" "/>
+    </xpath>
+
+    <!-- Shape -->
+    <xpath expr="//div[hasclass('o_we_shape')]" position="replace">
+        <div class="o_we_shape o_web_editor_Wavy_03"/>
+    </xpath>
+
+    <!-- Text -->
+    <xpath expr="//h2/div" position="attributes">
+        <attribute name="style" add="font-size: 9.375rem;" remove="font-size: 10.75rem;" separator=";"/>
+    </xpath>
+    <xpath expr="//h2/div" position="replace" mode="inner">
+        85%
+    </xpath>
+    <xpath expr="//h2/following-sibling::div" position="replace" mode="inner">
+        customers satisfaction
+    </xpath>
+</template>
+
 </odoo>

--- a/theme_real_estate/__manifest__.py
+++ b/theme_real_estate/__manifest__.py
@@ -37,6 +37,7 @@
         'views/snippets/s_pricelist_boxed.xml',
         'views/snippets/s_key_images.xml',
         'views/snippets/s_intro_pill.xml',
+        'views/snippets/s_big_number.xml',
         'views/new_page_template.xml',
     ],
     'images': [

--- a/theme_real_estate/views/snippets/s_big_number.xml
+++ b/theme_real_estate/views/snippets/s_big_number.xml
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+
+<template id="s_big_number" inherit_id="website.s_big_number">
+    <!-- Section -->
+    <xpath expr="//section" position="attributes">
+        <attribute name="data-oe-shape-data">{"shape":"web_editor/Wavy/03"}</attribute>
+        <attribute name="class" add="o_cc4" remove="o_cc5" separator=" "/>
+    </xpath>
+
+    <!-- Shape -->
+    <xpath expr="//div[hasclass('o_we_shape')]" position="replace">
+        <div class="o_we_shape o_web_editor_Wavy_03"/>
+    </xpath>
+
+    <!-- Text -->
+    <xpath expr="//h2/div" position="attributes">
+        <attribute name="style" add="font-size: 9.375rem;" remove="font-size: 10.75rem;" separator=";"/>
+    </xpath>
+    <xpath expr="//h2/div" position="replace" mode="inner">
+        85%
+    </xpath>
+    <xpath expr="//h2/following-sibling::div" position="replace" mode="inner">
+        customers satisfaction
+    </xpath>
+</template>
+
+</odoo>

--- a/theme_treehouse/__manifest__.py
+++ b/theme_treehouse/__manifest__.py
@@ -39,6 +39,7 @@
         'views/snippets/s_pricelist_boxed.xml',
         'views/snippets/s_striped_center_top.xml',
         'views/snippets/s_intro_pill.xml',
+        'views/snippets/s_big_number.xml',
         'views/new_page_template.xml',
     ],
     'images': [

--- a/theme_treehouse/views/snippets/s_big_number.xml
+++ b/theme_treehouse/views/snippets/s_big_number.xml
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+
+<template id="s_big_number" inherit_id="website.s_big_number">
+    <!-- Section -->
+    <xpath expr="//section" position="attributes">
+        <attribute name="data-oe-shape-data">{"shape":"web_editor/Origins/18"}</attribute>
+        <attribute name="class" add="o_cc3" remove="o_cc5" separator=" "/>
+    </xpath>
+
+    <!-- Shape -->
+    <xpath expr="//div[hasclass('o_we_shape')]" position="replace">
+        <div class="o_we_shape o_web_editor_Origins_18 o_we_animated"/>
+    </xpath>
+
+    <!-- Text -->
+    <xpath expr="//h2/div" position="attributes">
+        <attribute name="style" add="font-size: 7.75rem;" remove="font-size: 10.75rem;" separator=";"/>
+    </xpath>
+    <xpath expr="//h2/div" position="replace" mode="inner">
+        1,250
+    </xpath>
+    <xpath expr="//h2/following-sibling::div" position="replace" mode="inner">
+        trees planted since last year
+    </xpath>
+</template>
+
+</odoo>

--- a/theme_vehicle/views/customizations.xml
+++ b/theme_vehicle/views/customizations.xml
@@ -663,4 +663,26 @@
     </xpath>
 </template>
 
+<!-- ======== BIG NUMBER ======== -->
+<template id="s_big_number" inherit_id="website.s_big_number">
+    <!-- Section -->
+    <xpath expr="//section" position="attributes">
+        <attribute name="data-oe-shape-data">{"shape":"web_editor/Bold/08"}</attribute>
+    </xpath>
+
+    <!-- Shape -->
+    <xpath expr="//div[hasclass('o_we_shape')]" position="replace">
+        <div class="o_we_shape o_web_editor_Bold_08"/>
+    </xpath>
+
+    <!-- Text -->
+    <xpath expr="//h2/div" position="replace" mode="inner">
+        <font class="text-gradient" style="background-image: linear-gradient(0deg, rgb(29, 32, 48) 0%, rgb(222, 222, 222) 49%);">
+            87%
+        </font>
+    </xpath>
+    <xpath expr="//h2/following-sibling::div" position="replace" mode="inner">
+        customer satisfaction
+    </xpath>
+</template>
 </odoo>

--- a/theme_yes/__manifest__.py
+++ b/theme_yes/__manifest__.py
@@ -43,6 +43,7 @@
         'views/snippets/s_key_images.xml',
         'views/snippets/s_kickoff.xml',
         'views/snippets/s_intro_pill.xml',
+        'views/snippets/s_big_number.xml',
         'views/new_page_template.xml',
     ],
     'images': [

--- a/theme_yes/views/snippets/s_big_number.xml
+++ b/theme_yes/views/snippets/s_big_number.xml
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+
+<template id="s_big_number" inherit_id="website.s_big_number">
+    <!-- Section -->
+    <xpath expr="//section" position="attributes">
+        <attribute name="data-oe-shape-data">{"shape":"web_editor/Blobs/02"}</attribute>
+        <attribute name="class" add="o_cc2" remove="o_cc5" separator=" "/>
+    </xpath>
+
+    <!-- Shape -->
+    <xpath expr="//div[hasclass('o_we_shape')]" position="replace">
+        <div class="o_we_shape o_web_editor_Blobs_02"/>
+    </xpath>
+
+    <!-- Text -->
+    <xpath expr="//h2/div" position="attributes">
+        <attribute name="style" add="font-size: 6.25rem;" remove="font-size: 10.75rem;" separator=";"/>
+    </xpath>
+    <xpath expr="//h2/div" position="replace" mode="inner">
+        1,500+
+    </xpath>
+    <xpath expr="//h2/following-sibling::div" position="replace" mode="inner">
+        personalized invitations created
+    </xpath>
+</template>
+
+</odoo>

--- a/theme_zap/__manifest__.py
+++ b/theme_zap/__manifest__.py
@@ -35,6 +35,7 @@
         'views/snippets/s_pricelist_boxed.xml',
         'views/snippets/s_striped_center_top.xml',
         'views/snippets/s_image_title.xml',
+        'views/snippets/s_big_number.xml',
         'views/new_page_template.xml',
     ],
     'images': [

--- a/theme_zap/views/snippets/s_big_number.xml
+++ b/theme_zap/views/snippets/s_big_number.xml
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+
+<template id="s_big_number" inherit_id="website.s_big_number">
+    <!-- Section -->
+    <xpath expr="//section" position="attributes">
+        <attribute name="data-oe-shape-data">{"shape":"web_editor/Airy/14"}</attribute>
+    </xpath>
+
+    <!-- Shape -->
+    <xpath expr="//div[hasclass('o_we_shape')]" position="replace">
+        <div class="o_we_shape o_web_editor_Airy_14"/>
+    </xpath>
+
+    <!-- Text -->
+    <xpath expr="//h2/div" position="attributes">
+        <attribute name="style" add="font-size: 9.375rem;" remove="font-size: 10.75rem;" separator=";"/>
+    </xpath>
+    <xpath expr="//h2/div" position="replace" mode="inner">
+        90%
+    </xpath>
+</template>
+
+</odoo>


### PR DESCRIPTION
- requires https://github.com/odoo/odoo/pull/175920
-------------------

*: anelusia, artists, avantgarde, aviato, beauty, bewise, bistro,
bookstore, buzzy, clean, cobalt, enark, graphene, kea, kiddo, loftspace,
monglia, nano, notes, odoo_experts, orchid, real_estate, treehouse,
vehicle, yes, zap

This PR adapts the occurrences of the `s_big_number` snippet across
design themes.

task-4094391
Part of task-4077427