### PR TITLE
[IMP] theme_anelusia, *: adapt `container` divs  for `s_quotes_carousel`

### DIFF
--- a/theme_anelusia/views/snippets/s_quotes_carousel.xml
+++ b/theme_anelusia/views/snippets/s_quotes_carousel.xml
@@ -2,16 +2,19 @@
 <odoo>
 
 <template id="s_quotes_carousel" inherit_id="website.s_quotes_carousel">
+    <xpath expr="//div[hasclass('s_quotes_carousel')]" position="attributes">
+        <attribute name="class" remove="carousel-dark" separator=" "/>
+    </xpath>
     <!-- Slide #1 - Filter -->
-    <xpath expr="//div[hasclass('container')]" position="before">
+    <xpath expr="//blockquote" position="before">
         <div class="o_we_bg_filter bg-black-25"/>
     </xpath>
     <!-- Slide #2 - Filter -->
-    <xpath expr="(//div[hasclass('container')])[2]" position="before">
+    <xpath expr="(//blockquote)[2]" position="before">
         <div class="o_we_bg_filter bg-black-25"/>
     </xpath>
     <!-- Slide #3 - Filter -->
-    <xpath expr="(//div[hasclass('container')])[3]" position="before">
+    <xpath expr="(//blockquote)[3]" position="before">
         <div class="o_we_bg_filter bg-black-25"/>
     </xpath>
 </template>

--- a/theme_aviato/views/snippets/s_quotes_carousel.xml
+++ b/theme_aviato/views/snippets/s_quotes_carousel.xml
@@ -2,6 +2,9 @@
 <odoo>
 
 <template id="s_quotes_carousel" inherit_id="website.s_quotes_carousel">
+    <xpath expr="//div[hasclass('s_quotes_carousel')]" position="attributes">
+        <attribute name="class" remove="carousel-dark" separator=" "/>
+    </xpath>
     <!-- Quote 1 -->
     <xpath expr="//blockquote" position="attributes">
         <attribute name="class" add="w-75" remove="w-50" separator=" "/>

--- a/theme_monglia/views/customizations.xml
+++ b/theme_monglia/views/customizations.xml
@@ -212,6 +212,9 @@
 
 <!-- ======== QUOTES ======== -->
  <template id="s_quotes_carousel" inherit_id="website.s_quotes_carousel" name="Monglia s_quotes_carousel">
+    <xpath expr="//div[hasclass('s_quotes_carousel')]" position="attributes">
+        <attribute name="class" remove="carousel-dark" separator=" "/>
+    </xpath>
     <!-- Assign slide3 as 'active' and move it in first position -->
     <xpath expr="//div[hasclass('carousel-inner')]/div" position="attributes">
         <attribute name="class" remove="active" separator=" "/>

--- a/theme_odoo_experts/views/snippets/s_quotes_carousel.xml
+++ b/theme_odoo_experts/views/snippets/s_quotes_carousel.xml
@@ -2,16 +2,19 @@
 <odoo>
 
 <template id="s_quotes_carousel" inherit_id="website.s_quotes_carousel">
+    <xpath expr="//div[hasclass('s_quotes_carousel')]" position="attributes">
+        <attribute name="class" remove="carousel-dark" separator=" "/>
+    </xpath>
     <!-- Carousel item #1 - filter -->
-    <xpath expr="//div[hasclass('container')]" position="before">
+    <xpath expr="//blockquote" position="before">
         <div class="o_we_bg_filter bg-black-50"/>
     </xpath>
     <!-- Carousel item #2 - filter -->
-    <xpath expr="(//div[hasclass('container')])[2]" position="before">
+    <xpath expr="(//blockquote)[2]" position="before">
         <div class="o_we_bg_filter bg-black-50"/>
     </xpath>
     <!-- Carousel item #3 - filter -->
-    <xpath expr="(//div[hasclass('container')])[3]" position="before">
+    <xpath expr="(//blockquote)[3]" position="before">
         <div class="o_we_bg_filter bg-black-50"/>
     </xpath>
 </template>

--- a/theme_real_estate/views/snippets/s_quotes_carousel.xml
+++ b/theme_real_estate/views/snippets/s_quotes_carousel.xml
@@ -2,6 +2,9 @@
 <odoo>
 
 <template id="s_quotes_carousel" inherit_id="website.s_quotes_carousel">
+    <xpath expr="//div[hasclass('s_quotes_carousel')]" position="attributes">
+        <attribute name="class" remove="carousel-dark" separator=" "/>
+    </xpath>
     <!-- Quote 1 -->
     <xpath expr="(//p[hasclass('s_blockquote_quote')])[1]" position="replace" mode="inner">
         Amazing team! smiling, always nice to talk with, they always have the best advices for you, adapted to your needs!

--- a/theme_yes/views/snippets/s_quotes_carousel.xml
+++ b/theme_yes/views/snippets/s_quotes_carousel.xml
@@ -9,7 +9,7 @@
     <xpath expr="//div[hasclass('carousel-item')]" position="attributes">
         <attribute name="style" add="background-image: url('/web/image/website.s_quotes_carousel_demo_image_0'); background-position: 50% 25%;" separator="; "/>
     </xpath>
-    <xpath expr="//div[hasclass('container')]" position="before">
+    <xpath expr="//blockquote" position="before">
         <div class="o_we_bg_filter" style="background-color: rgba(25, 41, 37, 0.55) !important;"/>
     </xpath>
     <xpath expr="(//p[hasclass('s_blockquote_quote')])[1]" position="replace" mode="inner">
@@ -25,7 +25,7 @@
     <xpath expr="(//*[hasclass('carousel-item')])[2]" position="attributes">
         <attribute name="style" add="background-position: 50% 25%;" remove="background-position: 50% 50%;" separator="; "/>
     </xpath>
-    <xpath expr="(//div[hasclass('container')])[2]" position="before">
+    <xpath expr="(//blockquote)[2]" position="before">
         <div class="o_we_bg_filter" style="background-color: rgba(25, 41, 37, 0.55) !important;"/>
     </xpath>
     <xpath expr="(//div[hasclass('s_blockquote_author')])[2]//strong" position="replace" mode="inner">
@@ -38,7 +38,7 @@
     <xpath expr="(//*[hasclass('carousel-item')])[3]" position="attributes">
         <attribute name="style" add="background-position: 50% 20%;" remove="background-position: 50% 50%;" separator="; "/>
     </xpath>
-    <xpath expr="(//div[hasclass('container')])[3]" position="before">
+    <xpath expr="(//blockquote)[3]" position="before">
         <div class="o_we_bg_filter" style="background-color: rgba(25, 41, 37, 0.55) !important;"/>
     </xpath>
     <xpath expr="(//p[hasclass('s_blockquote_quote')])[3]" position="replace" mode="inner">


### PR DESCRIPTION
*: theme_aviato, theme_monglia, theme_odoo_experts, theme_real_estate, theme_yes

Since the removal of `container` divs in the `s_quotes_carousel` snippet, this commit adapts the theme customizations.

This commit also fixes contrast issues related to the "Invert colors" option.

task-4167538
Part of task-3619705

Requires:
- https://github.com/odoo/odoo/pull/179389