### PR TITLE
[IMP] theme_*: adapt themes with new `s_company_team_grid` snippet

### DIFF
--- a/theme_anelusia/__manifest__.py
+++ b/theme_anelusia/__manifest__.py
@@ -28,6 +28,7 @@
         'views/snippets/s_color_blocks_2.xml',
         'views/snippets/s_company_team_shapes.xml',
         'views/snippets/s_sidegrid.xml',
+        'views/snippets/s_company_team_grid.xml',
         'views/snippets/s_references.xml',
         'views/snippets/s_references_social.xml',
         'views/snippets/s_references_grid.xml',

--- a/theme_anelusia/views/snippets/s_company_team_grid.xml
+++ b/theme_anelusia/views/snippets/s_company_team_grid.xml
@@ -1,0 +1,77 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+
+<template id="s_company_team_grid" inherit_id="website.s_company_team_grid">
+    <!-- Section -->
+    <xpath expr="//section" position="attributes">
+        <attribute name="class" add="o_cc5" remove="o_cc1" separator=" "/>
+    </xpath>
+    <!-- Team #01 -->
+    <xpath expr="(//div[hasclass('card')])[1]" position="attributes">
+        <attribute name="class" add="o_cc5" remove="o_cc2" separator=" "/>
+    </xpath>
+    <xpath expr="//img" position="attributes">
+        <attribute name="src">/web_editor/image_shape/website.s_company_team_image_1/web_editor/composition/composition_square_4.svg?c2=o-color-2&amp;c5=o-color-3</attribute>
+        <attribute name="data-shape">web_editor/composition/composition_square_4</attribute>
+        <attribute name="data-original-mimetype">image/jpeg</attribute>
+        <attribute name="data-file-name">uiface_1.svg</attribute>
+        <attribute name="data-shape-colors">;o-color-2;;;o-color-3</attribute>
+    </xpath>
+    <!-- Team #02 -->
+    <xpath expr="(//div[hasclass('card')])[2]" position="attributes">
+        <attribute name="class" add="o_cc5" remove="o_cc2" separator=" "/>
+    </xpath>
+    <xpath expr="(//img)[2]" position="attributes">
+        <attribute name="src">/web_editor/image_shape/website.s_company_team_image_2/web_editor/solid/solid_square_2.svg?c1=o-color-1</attribute>
+        <attribute name="data-shape">web_editor/solid/solid_square_2</attribute>
+        <attribute name="data-original-mimetype">image/jpeg</attribute>
+        <attribute name="data-file-name">uiface_2.svg</attribute>
+        <attribute name="data-shape-colors">o-color-1;;;;</attribute>
+    </xpath>
+    <!-- Team #03 -->
+    <xpath expr="(//div[hasclass('card')])[3]" position="attributes">
+        <attribute name="class" add="o_cc5" remove="o_cc2" separator=" "/>
+    </xpath>
+    <xpath expr="(//img)[3]" position="attributes">
+        <attribute name="src">/web_editor/image_shape/website.s_company_team_image_3/web_editor/composition/composition_square_2.svg?c2=o-color-3&amp;c5=o-color-2</attribute>
+        <attribute name="data-shape">web_editor/composition/composition_square_2</attribute>
+        <attribute name="data-original-mimetype">image/jpeg</attribute>
+        <attribute name="data-file-name">uiface_3.svg</attribute>
+        <attribute name="data-shape-colors">;o-color-3;;;o-color-2</attribute>
+    </xpath>
+    <!-- Team #04 -->
+    <xpath expr="(//div[hasclass('card')])[4]" position="attributes">
+        <attribute name="class" add="o_cc5" remove="o_cc2" separator=" "/>
+    </xpath>
+    <xpath expr="(//img)[4]" position="attributes">
+        <attribute name="src">/web_editor/image_shape/website.s_company_team_image_4/web_editor/composition/composition_square_1.svg?c1=o-color-3&amp;c2=o-color-1</attribute>
+        <attribute name="data-shape">web_editor/composition/composition_square_1</attribute>
+        <attribute name="data-original-mimetype">image/jpeg</attribute>
+        <attribute name="data-file-name">uiface_4.svg</attribute>
+        <attribute name="data-shape-colors">o-color-3;o-color-1;;;</attribute>
+    </xpath>
+    <!-- Team #05 -->
+    <xpath expr="(//div[hasclass('card')])[5]" position="attributes">
+        <attribute name="class" add="o_cc5" remove="o_cc2" separator=" "/>
+    </xpath>
+    <xpath expr="(//img)[5]" position="attributes">
+        <attribute name="src">/web_editor/image_shape/website.s_company_team_image_5/web_editor/solid/solid_square_1.svg?c2=o-color-2</attribute>
+        <attribute name="data-shape">web_editor/solid/solid_square_1</attribute>
+        <attribute name="data-original-mimetype">image/jpeg</attribute>
+        <attribute name="data-file-name">uiface_5.svg</attribute>
+        <attribute name="data-shape-colors">;o-color-2;;;</attribute>
+    </xpath>
+    <!-- Team #06 -->
+    <xpath expr="(//div[hasclass('card')])[6]" position="attributes">
+        <attribute name="class" add="o_cc5" remove="o_cc2" separator=" "/>
+    </xpath>
+    <xpath expr="(//img)[6]" position="attributes">
+        <attribute name="src">/web_editor/image_shape/website.s_company_team_image_6/web_editor/composition/composition_square_3.svg?c1=o-color-1&amp;c5=o-color-3</attribute>
+        <attribute name="data-shape">web_editor/composition/composition_square_3</attribute>
+        <attribute name="data-original-mimetype">image/jpeg</attribute>
+        <attribute name="data-file-name">uiface_6.svg</attribute>
+        <attribute name="data-shape-colors">o-color-1;;;;o-color-3</attribute>
+    </xpath>
+</template>
+
+</odoo>

--- a/theme_artists/__manifest__.py
+++ b/theme_artists/__manifest__.py
@@ -65,6 +65,7 @@
         'views/snippets/s_company_team_spotlight.xml',
         'views/snippets/s_product_list.xml',
         'views/snippets/s_color_blocks_2.xml',
+        'views/snippets/s_company_team_grid.xml',
         'views/snippets/s_company_team_shapes.xml',
         'views/snippets/s_numbers_showcase.xml',
         'views/snippets/s_mockup_image.xml',

--- a/theme_artists/views/snippets/s_company_team_grid.xml
+++ b/theme_artists/views/snippets/s_company_team_grid.xml
@@ -1,0 +1,35 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+
+<template id="s_company_team_grid" inherit_id="website.s_company_team_grid">
+    <!-- Section -->
+    <xpath expr="//section" position="attributes">
+        <attribute name="class" add="o_cc5" remove="o_cc1" separator=" "/>
+    </xpath>
+    <!-- Team #01 -->
+    <xpath expr="(//div[hasclass('card')])[1]" position="attributes">
+        <attribute name="class" add="o_cc1" remove="o_cc2" separator=" "/>
+    </xpath>
+    <!-- Team #02 -->
+    <xpath expr="(//div[hasclass('card')])[2]" position="attributes">
+        <attribute name="class" add="o_cc1" remove="o_cc2" separator=" "/>
+    </xpath>
+    <!-- Team #03 -->
+    <xpath expr="(//div[hasclass('card')])[3]" position="attributes">
+        <attribute name="class" add="o_cc1" remove="o_cc2" separator=" "/>
+    </xpath>
+    <!-- Team #04 -->
+    <xpath expr="(//div[hasclass('card')])[4]" position="attributes">
+        <attribute name="class" add="o_cc1" remove="o_cc2" separator=" "/>
+    </xpath>
+    <!-- Team #05 -->
+    <xpath expr="(//div[hasclass('card')])[5]" position="attributes">
+        <attribute name="class" add="o_cc1" remove="o_cc2" separator=" "/>
+    </xpath>
+    <!-- Team #06 -->
+    <xpath expr="(//div[hasclass('card')])[6]" position="attributes">
+        <attribute name="class" add="o_cc1" remove="o_cc2" separator=" "/>
+    </xpath>
+</template>
+
+</odoo>

--- a/theme_avantgarde/views/customizations.xml
+++ b/theme_avantgarde/views/customizations.xml
@@ -809,4 +809,78 @@
     </xpath>
 </template>
 
+<!-- ======== COMPANY TEAM GRID ======== -->
+<template id="s_company_team_grid" inherit_id="website.s_company_team_grid">
+    <!-- Team #01 -->
+    <xpath expr="//div[hasclass('card')]" position="attributes">
+        <attribute name="class" add="o_cc1" remove="o_cc2" separator=" "/>
+    </xpath>
+    <xpath expr="//img" position="attributes">
+        <attribute name="src">/web_editor/image_shape/website.s_company_team_image_1/web_editor/geometric_round/geo_round_gem.svg</attribute>
+        <attribute name="data-shape">web_editor/geometric_round/geo_round_gem</attribute>
+        <attribute name="data-original-mimetype">image/jpeg</attribute>
+        <attribute name="data-file-name">uiface_1.svg</attribute>
+        <attribute name="data-shape-colors">;;;;</attribute>
+    </xpath>
+    <!-- Team #02 -->
+    <xpath expr="(//div[hasclass('card')])[2]" position="attributes">
+        <attribute name="class" add="o_cc1" remove="o_cc2" separator=" "/>
+    </xpath>
+    <xpath expr="(//img)[2]" position="attributes">
+        <attribute name="src">/web_editor/image_shape/website.s_company_team_image_2/web_editor/geometric_round/geo_round_gem.svg</attribute>
+        <attribute name="data-shape">web_editor/geometric_round/geo_round_gem</attribute>
+        <attribute name="data-shape-rotate">90</attribute>
+        <attribute name="data-original-mimetype">image/jpeg</attribute>
+        <attribute name="data-file-name">uiface_1.svg</attribute>
+        <attribute name="data-shape-colors">;;;;</attribute>
+    </xpath>
+    <!-- Team #03 -->
+    <xpath expr="(//div[hasclass('card')])[3]" position="attributes">
+        <attribute name="class" add="o_cc1" remove="o_cc2" separator=" "/>
+    </xpath>
+    <xpath expr="(//img)[3]" position="attributes">
+        <attribute name="src">/web_editor/image_shape/website.s_company_team_image_3/web_editor/geometric_round/geo_round_gem.svg</attribute>
+        <attribute name="data-shape">web_editor/geometric_round/geo_round_gem</attribute>
+        <attribute name="data-shape-flip">x</attribute>
+        <attribute name="data-original-mimetype">image/jpeg</attribute>
+        <attribute name="data-file-name">uiface_1.svg</attribute>
+        <attribute name="data-shape-colors">;;;;</attribute>
+    </xpath>
+    <!-- Team #04 -->
+    <xpath expr="(//div[hasclass('card')])[4]" position="attributes">
+        <attribute name="class" add="o_cc1" remove="o_cc2" separator=" "/>
+    </xpath>
+    <xpath expr="(//img)[4]" position="attributes">
+        <attribute name="src">/web_editor/image_shape/website.s_company_team_image_4/web_editor/geometric_round/geo_round_gem.svg</attribute>
+        <attribute name="data-shape">web_editor/geometric_round/geo_round_gem</attribute>
+        <attribute name="data-shape-flip">y</attribute>
+        <attribute name="data-original-mimetype">image/jpeg</attribute>
+        <attribute name="data-file-name">uiface_1.svg</attribute>
+        <attribute name="data-shape-colors">;;;;</attribute>
+    </xpath>
+    <!-- Team #05 -->
+    <xpath expr="(//div[hasclass('card')])[5]" position="attributes">
+        <attribute name="class" add="o_cc1" remove="o_cc2" separator=" "/>
+    </xpath>
+    <xpath expr="(//img)[5]" position="attributes">
+        <attribute name="src">/web_editor/image_shape/website.s_company_team_image_5/web_editor/geometric_round/geo_round_gem.svg</attribute>
+        <attribute name="data-shape">web_editor/geometric_round/geo_round_gem</attribute>
+        <attribute name="data-original-mimetype">image/jpeg</attribute>
+        <attribute name="data-file-name">uiface_1.svg</attribute>
+        <attribute name="data-shape-colors">;;;;</attribute>
+    </xpath>
+    <!-- Team #06 -->
+    <xpath expr="(//div[hasclass('card')])[6]" position="attributes">
+        <attribute name="class" add="o_cc1" remove="o_cc2" separator=" "/>
+    </xpath>
+    <xpath expr="(//img)[6]" position="attributes">
+        <attribute name="src">/web_editor/image_shape/website.s_company_team_image_6/web_editor/geometric_round/geo_round_gem.svg</attribute>
+        <attribute name="data-shape">web_editor/geometric_round/geo_round_gem</attribute>
+        <attribute name="data-shape-flip">xy</attribute>
+        <attribute name="data-original-mimetype">image/jpeg</attribute>
+        <attribute name="data-file-name">uiface_1.svg</attribute>
+        <attribute name="data-shape-colors">;;;;</attribute>
+    </xpath>
+</template>
+
 </odoo>

--- a/theme_beauty/__manifest__.py
+++ b/theme_beauty/__manifest__.py
@@ -36,6 +36,7 @@
         'views/snippets/s_color_blocks_2.xml',
         'views/snippets/s_company_team_shapes.xml',
         'views/snippets/s_company_team_detail.xml',
+        'views/snippets/s_company_team_grid.xml',
         'views/snippets/s_media_list.xml',
         'views/snippets/s_comparisons.xml',
         'views/snippets/s_comparisons_horizontal.xml',

--- a/theme_beauty/views/snippets/s_company_team_grid.xml
+++ b/theme_beauty/views/snippets/s_company_team_grid.xml
@@ -1,0 +1,35 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+
+<template id="s_company_team_grid" inherit_id="website.s_company_team_grid">
+    <!-- Section -->
+    <xpath expr="//section" position="attributes">
+        <attribute name="class" add="o_cc5" remove="o_cc1" separator=" "/>
+    </xpath>
+    <!-- Team #01 -->
+    <xpath expr="(//div[hasclass('card')])[1]" position="attributes">
+        <attribute name="class" add="o_cc4" remove="o_cc2" separator=" "/>
+    </xpath>
+    <!-- Team #02 -->
+    <xpath expr="(//div[hasclass('card')])[2]" position="attributes">
+        <attribute name="class" add="o_cc4" remove="o_cc2" separator=" "/>
+    </xpath>
+    <!-- Team #03 -->
+    <xpath expr="(//div[hasclass('card')])[3]" position="attributes">
+        <attribute name="class" add="o_cc4" remove="o_cc2" separator=" "/>
+    </xpath>
+    <!-- Team #04 -->
+    <xpath expr="(//div[hasclass('card')])[4]" position="attributes">
+        <attribute name="class" add="o_cc4" remove="o_cc2" separator=" "/>
+    </xpath>
+    <!-- Team #05 -->
+    <xpath expr="(//div[hasclass('card')])[5]" position="attributes">
+        <attribute name="class" add="o_cc4" remove="o_cc2" separator=" "/>
+    </xpath>
+    <!-- Team #06 -->
+    <xpath expr="(//div[hasclass('card')])[6]" position="attributes">
+        <attribute name="class" add="o_cc4" remove="o_cc2" separator=" "/>
+    </xpath>
+</template>
+
+</odoo>

--- a/theme_bewise/views/customizations.xml
+++ b/theme_bewise/views/customizations.xml
@@ -629,6 +629,13 @@
     </xpath>
 </template>
 
+<template id="s_company_team_grid" inherit_id="website.s_company_team_grid">
+    <!-- Section -->
+    <xpath expr="//section" position="attributes">
+        <attribute name="class" add="o_cc5" remove="o_cc1" separator=" "/>
+    </xpath>
+</template>
+
 <!-- ======== FREE GRID ======== -->
 <template id="s_freegrid" inherit_id="website.s_freegrid">
     <!-- Title -->

--- a/theme_bistro/__manifest__.py
+++ b/theme_bistro/__manifest__.py
@@ -55,6 +55,7 @@
         'views/snippets/s_images_constellation.xml',
         'views/snippets/s_text_cover.xml',
         'views/snippets/s_empowerment.xml',
+        'views/snippets/s_company_team_grid.xml',
         'views/new_page_template.xml',
 
     ],

--- a/theme_bistro/views/snippets/s_company_team_grid.xml
+++ b/theme_bistro/views/snippets/s_company_team_grid.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+
+<template id="s_company_team_grid" inherit_id="website.s_company_team_grid">
+    <!-- Section -->
+    <xpath expr="//section" position="attributes">
+        <attribute name="class" add="o_cc5" remove="o_cc1" separator=" "/>
+    </xpath>
+    <!-- Team #01 -->
+    <xpath expr="//div[hasclass('card')]" position="attributes">
+        <attribute name="class" add="o_cc4" remove="o_cc2" separator=" "/>
+    </xpath>
+    <!-- Team #02 -->
+    <xpath expr="(//div[hasclass('card')])[2]" position="attributes">
+        <attribute name="class" add="o_cc2" remove="o_cc2" separator=" "/>
+    </xpath>
+    <!-- Team #03 -->
+    <xpath expr="(//div[hasclass('card')])[3]" position="attributes">
+        <attribute name="class" add="o_cc4" remove="o_cc2" separator=" "/>
+    </xpath>
+    <!-- Team #05 -->
+    <xpath expr="(//div[hasclass('card')])[5]" position="attributes">
+        <attribute name="class" add="o_cc4" remove="o_cc2" separator=" "/>
+    </xpath>
+</template>
+
+</odoo>

--- a/theme_bookstore/__manifest__.py
+++ b/theme_bookstore/__manifest__.py
@@ -50,6 +50,7 @@
         'views/snippets/s_carousel_intro.xml',
         'views/snippets/s_pricelist_boxed.xml',
         'views/snippets/s_image_hexagonal.xml',
+        'views/snippets/s_company_team_grid.xml',
         'views/snippets/s_striped_center_top.xml',
         'views/snippets/s_intro_pill.xml',
         'views/snippets/s_big_number.xml',

--- a/theme_bookstore/views/snippets/s_company_team_grid.xml
+++ b/theme_bookstore/views/snippets/s_company_team_grid.xml
@@ -1,0 +1,35 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+
+<template id="s_company_team_grid" inherit_id="website.s_company_team_grid">
+    <!-- Section -->
+    <xpath expr="//section" position="attributes">
+        <attribute name="class" add="o_cc2" remove="o_cc1" separator=" "/>
+    </xpath>
+    <!-- Team #01 -->
+    <xpath expr="//div[hasclass('card')]" position="attributes">
+        <attribute name="class" add="o_cc1" remove="o_cc2" separator=" "/>
+    </xpath>
+    <!-- Team #02 -->
+    <xpath expr="(//div[hasclass('card')])[2]" position="attributes">
+        <attribute name="class" add="o_cc1" remove="o_cc2" separator=" "/>
+    </xpath>
+    <!-- Team #03 -->
+    <xpath expr="(//div[hasclass('card')])[3]" position="attributes">
+        <attribute name="class" add="o_cc1" remove="o_cc2" separator=" "/>
+    </xpath>
+    <!-- Team #04 -->
+    <xpath expr="(//div[hasclass('card')])[4]" position="attributes">
+        <attribute name="class" add="o_cc1" remove="o_cc2" separator=" "/>
+    </xpath>
+    <!-- Team #05 -->
+    <xpath expr="(//div[hasclass('card')])[5]" position="attributes">
+        <attribute name="class" add="o_cc1" remove="o_cc2" separator=" "/>
+    </xpath>
+    <!-- Team #06 -->
+    <xpath expr="(//div[hasclass('card')])[6]" position="attributes">
+        <attribute name="class" add="o_cc1" remove="o_cc2" separator=" "/>
+    </xpath>
+</template>
+
+</odoo>

--- a/theme_clean/__manifest__.py
+++ b/theme_clean/__manifest__.py
@@ -23,6 +23,7 @@
         'views/snippets/s_three_columns.xml',
         'views/snippets/s_call_to_action.xml',
         'views/snippets/s_company_team.xml',
+        'views/snippets/s_company_team_grid.xml',
         'views/snippets/s_title.xml',
         'views/snippets/s_features.xml',
         'views/snippets/s_numbers.xml',

--- a/theme_clean/views/snippets/s_company_team_grid.xml
+++ b/theme_clean/views/snippets/s_company_team_grid.xml
@@ -1,0 +1,35 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+
+<template id="s_company_team_grid" inherit_id="website.s_company_team_grid">
+    <!-- Section -->
+    <xpath expr="//section" position="attributes">
+        <attribute name="class" add="o_cc2" remove="o_cc1" separator=" "/>
+    </xpath>
+    <!-- Team #01 -->
+    <xpath expr="//div[hasclass('card')]" position="attributes">
+        <attribute name="class" add="o_cc3" remove="o_cc2" separator=" "/>
+    </xpath>
+    <!-- Team #02 -->
+    <xpath expr="(//div[hasclass('card')])[2]" position="attributes">
+        <attribute name="class" add="o_cc3" remove="o_cc2" separator=" "/>
+    </xpath>
+    <!-- Team #03 -->
+    <xpath expr="(//div[hasclass('card')])[3]" position="attributes">
+        <attribute name="class" add="o_cc3" remove="o_cc2" separator=" "/>
+    </xpath>
+    <!-- Team #04 -->
+    <xpath expr="(//div[hasclass('card')])[4]" position="attributes">
+        <attribute name="class" add="o_cc3" remove="o_cc2" separator=" "/>
+    </xpath>
+    <!-- Team #05 -->
+    <xpath expr="(//div[hasclass('card')])[5]" position="attributes">
+        <attribute name="class" add="o_cc3" remove="o_cc2" separator=" "/>
+    </xpath>
+    <!-- Team #06 -->
+    <xpath expr="(//div[hasclass('card')])[6]" position="attributes">
+        <attribute name="class" add="o_cc3" remove="o_cc2" separator=" "/>
+    </xpath>
+</template>
+
+</odoo>

--- a/theme_cobalt/views/customizations.xml
+++ b/theme_cobalt/views/customizations.xml
@@ -706,4 +706,12 @@
     </xpath>
 </template>
 
+<!-- ======== COMPANY TREAM GRID ======== -->
+<template id="s_company_team_grid" inherit_id="website.s_company_team_grid">
+    <!-- Section -->
+    <xpath expr="//section" position="attributes">
+        <attribute name="class" add="o_cc3" remove="o_cc1" separator=" "/>
+    </xpath>
+</template>
+
 </odoo>

--- a/theme_kea/__manifest__.py
+++ b/theme_kea/__manifest__.py
@@ -27,6 +27,7 @@
         'views/snippets/s_references_social.xml',
         'views/snippets/s_references_grid.xml',
         'views/snippets/s_motto.xml',
+        'views/snippets/s_company_team_grid.xml',
         'views/snippets/s_color_blocks_2.xml',
         'views/snippets/s_features_wall.xml',
         'views/snippets/s_picture.xml',

--- a/theme_kea/views/snippets/s_company_team_grid.xml
+++ b/theme_kea/views/snippets/s_company_team_grid.xml
@@ -1,0 +1,73 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+
+<template id="s_company_team_grid" inherit_id="website.s_company_team_grid">
+    <!-- Team #01 -->
+    <xpath expr="//div[hasclass('card')]" position="attributes">
+        <attribute name="class" add="o_cc1" remove="o_cc2" separator=" "/>
+    </xpath>
+    <xpath expr="//img" position="attributes">
+        <attribute name="src">/web_editor/image_shape/website.s_company_team_image_1/web_editor/composition/composition_line_1.svg?c1=o-color-1</attribute>
+        <attribute name="data-shape">web_editor/composition/composition_line_1</attribute>
+        <attribute name="data-original-mimetype">image/jpeg</attribute>
+        <attribute name="data-file-name">uiface_1.svg</attribute>
+        <attribute name="data-shape-colors">o-color-1;;;;</attribute>
+    </xpath>
+    <!-- Team #02 -->
+    <xpath expr="(//div[hasclass('card')])[2]" position="attributes">
+        <attribute name="class" add="o_cc1" remove="o_cc2" separator=" "/>
+    </xpath>
+    <xpath expr="(//img)[2]" position="attributes">
+        <attribute name="src">/web_editor/image_shape/website.s_company_team_image_2/web_editor/composition/composition_mixed_1.svg?c1=o-color-1&amp;c2=o-color-2&amp;c5=o-color-5</attribute>
+        <attribute name="data-shape">web_editor/composition/composition_mixed_1</attribute>
+        <attribute name="data-original-mimetype">image/jpeg</attribute>
+        <attribute name="data-file-name">uiface_1.svg</attribute>
+        <attribute name="data-shape-colors">o-color-1;o-color-2;;;o-color-5</attribute>
+    </xpath>
+    <!-- Team #03 -->
+    <xpath expr="(//div[hasclass('card')])[3]" position="attributes">
+        <attribute name="class" add="o_cc1" remove="o_cc2" separator=" "/>
+    </xpath>
+    <xpath expr="(//img)[3]" position="attributes">
+        <attribute name="src">/web_editor/image_shape/website.s_company_team_image_3/web_editor/composition/composition_planet_1.svg?c1=o-color-1&amp;c2=o-color-2&amp;c5=o-color-5</attribute>
+        <attribute name="data-shape">web_editor/composition/composition_planet_1</attribute>
+        <attribute name="data-original-mimetype">image/jpeg</attribute>
+        <attribute name="data-file-name">uiface_1.svg</attribute>
+        <attribute name="data-shape-colors">o-color-1;o-color-2;;;o-color-5</attribute>
+    </xpath>
+    <!-- Team #04 -->
+    <xpath expr="(//div[hasclass('card')])[4]" position="attributes">
+        <attribute name="class" add="o_cc1" remove="o_cc2" separator=" "/>
+    </xpath>
+    <xpath expr="(//img)[4]" position="attributes">
+        <attribute name="src">/web_editor/image_shape/website.s_company_team_image_4/web_editor/composition/composition_planet_2.svg?c1=o-color-1&amp;c2=o-color-2&amp;c5=o-color-5</attribute>
+        <attribute name="data-shape">web_editor/composition/composition_planet_2</attribute>
+        <attribute name="data-original-mimetype">image/jpeg</attribute>
+        <attribute name="data-file-name">uiface_1.svg</attribute>
+        <attribute name="data-shape-colors">o-color-1;o-color-2;;;o-color-5</attribute>
+    </xpath>
+    <!-- Team #05 -->
+    <xpath expr="(//div[hasclass('card')])[5]" position="attributes">
+        <attribute name="class" add="o_cc1" remove="o_cc2" separator=" "/>
+    </xpath>
+    <xpath expr="(//img)[5]" position="attributes">
+        <attribute name="src">/web_editor/image_shape/website.s_company_team_image_5/web_editor/pattern/pattern_point.svg?c1=o-color-1</attribute>
+        <attribute name="data-shape">web_editor/pattern/pattern_point</attribute>
+        <attribute name="data-original-mimetype">image/jpeg</attribute>
+        <attribute name="data-file-name">uiface_1.svg</attribute>
+        <attribute name="data-shape-colors">o-color-1;;;;</attribute>
+    </xpath>
+    <!-- Team #06 -->
+    <xpath expr="(//div[hasclass('card')])[6]" position="attributes">
+        <attribute name="class" add="o_cc1" remove="o_cc2" separator=" "/>
+    </xpath>
+    <xpath expr="(//img)[6]" position="attributes">
+        <attribute name="src">/web_editor/image_shape/website.s_company_team_image_6/web_editor/composition/composition_mixed_2.svg?c1=o-color-1&amp;c2=o-color-2&amp;c5=o-color-5</attribute>
+        <attribute name="data-shape">web_editor/composition/composition_mixed_2</attribute>
+        <attribute name="data-original-mimetype">image/jpeg</attribute>
+        <attribute name="data-file-name">uiface_1.svg</attribute>
+        <attribute name="data-shape-colors">o-color-1;o-color-2;;;o-color-5</attribute>
+    </xpath>
+</template>
+
+</odoo>

--- a/theme_kiddo/__manifest__.py
+++ b/theme_kiddo/__manifest__.py
@@ -55,6 +55,7 @@
         'views/snippets/s_images_constellation.xml',
         'views/snippets/s_text_cover.xml',
         'views/snippets/s_empowerment.xml',
+        'views/snippets/s_company_team_grid.xml',
         'views/new_page_template.xml',
     ],
     'images': [

--- a/theme_kiddo/views/snippets/s_company_team_grid.xml
+++ b/theme_kiddo/views/snippets/s_company_team_grid.xml
@@ -1,0 +1,73 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+
+<template id="s_company_team_grid" inherit_id="website.s_company_team_grid">
+    <!-- Team #01 -->
+    <xpath expr="//div[hasclass('card')]" position="attributes">
+        <attribute name="class" add="o_cc1" remove="o_cc2" separator=" "/>
+    </xpath>
+    <xpath expr="//img" position="attributes">
+        <attribute name="src">/web_editor/image_shape/website.s_company_team_image_1/web_editor/solid/solid_blob_3.svg?c5=o-color-1</attribute>
+        <attribute name="data-shape">web_editor/composition/solid_blob_3</attribute>
+        <attribute name="data-original-mimetype">image/jpeg</attribute>
+        <attribute name="data-file-name">uiface_1.svg</attribute>
+        <attribute name="data-shape-colors">;;;;o-color-1</attribute>
+    </xpath>
+    <!-- Team #02 -->
+    <xpath expr="(//div[hasclass('card')])[2]" position="attributes">
+        <attribute name="class" add="o_cc1" remove="o_cc2" separator=" "/>
+    </xpath>
+    <xpath expr="(//img)[2]" position="attributes">
+        <attribute name="src">/web_editor/image_shape/website.s_company_team_image_2/web_editor/composition/composition_organic_line.svg?c1=o-color-5</attribute>
+        <attribute name="data-shape">web_editor/composition/composition_organic_line</attribute>
+        <attribute name="data-original-mimetype">image/jpeg</attribute>
+        <attribute name="data-file-name">uiface_1.svg</attribute>
+        <attribute name="data-shape-colors">o-color-5;;;;</attribute>
+    </xpath>
+    <!-- Team #03 -->
+    <xpath expr="(//div[hasclass('card')])[3]" position="attributes">
+        <attribute name="class" add="o_cc1" remove="o_cc2" separator=" "/>
+    </xpath>
+    <xpath expr="(//img)[3]" position="attributes">
+        <attribute name="src">/web_editor/image_shape/website.s_company_team_image_3/web_editor/solid/solid_blob_1.svg?c2=o-color-2</attribute>
+        <attribute name="data-shape">web_editor/solid/solid_blob_1</attribute>
+        <attribute name="data-original-mimetype">image/jpeg</attribute>
+        <attribute name="data-file-name">uiface_1.svg</attribute>
+        <attribute name="data-shape-colors">;o-color-2;;;</attribute>
+    </xpath>
+    <!-- Team #04 -->
+    <xpath expr="(//div[hasclass('card')])[4]" position="attributes">
+        <attribute name="class" add="o_cc1" remove="o_cc2" separator=" "/>
+    </xpath>
+    <xpath expr="(//img)[4]" position="attributes">
+        <attribute name="src">/web_editor/image_shape/website.s_company_team_image_4/web_editor/solid/solid_blob_4.svg?c5=o-color-2</attribute>
+        <attribute name="data-shape">web_editor/solid/solid_blob_4</attribute>
+        <attribute name="data-original-mimetype">image/jpeg</attribute>
+        <attribute name="data-file-name">uiface_1.svg</attribute>
+        <attribute name="data-shape-colors">;;;;o-color-2</attribute>
+    </xpath>
+    <!-- Team #05 -->
+    <xpath expr="(//div[hasclass('card')])[5]" position="attributes">
+        <attribute name="class" add="o_cc1" remove="o_cc2" separator=" "/>
+    </xpath>
+    <xpath expr="(//img)[5]" position="attributes">
+        <attribute name="src">/web_editor/image_shape/website.s_company_team_image_5/web_editor/composition/composition_oval_line.svg?c2=o-color-1</attribute>
+        <attribute name="data-shape">web_editor/composition/composition_oval_line</attribute>
+        <attribute name="data-original-mimetype">image/jpeg</attribute>
+        <attribute name="data-file-name">uiface_1.svg</attribute>
+        <attribute name="data-shape-colors">;o-color-1;;;</attribute>
+    </xpath>
+    <!-- Team #06 -->
+    <xpath expr="(//div[hasclass('card')])[6]" position="attributes">
+        <attribute name="class" add="o_cc1" remove="o_cc2" separator=" "/>
+    </xpath>
+    <xpath expr="(//img)[6]" position="attributes">
+        <attribute name="src">/web_editor/image_shape/website.s_company_team_image_6/web_editor/solid/solid_blob_3.svg?c5=o-color-5</attribute>
+        <attribute name="data-shape">web_editor/solid/solid_blob_3</attribute>
+        <attribute name="data-original-mimetype">image/jpeg</attribute>
+        <attribute name="data-file-name">uiface_1.svg</attribute>
+        <attribute name="data-shape-colors">;;;;o-color-5</attribute>
+    </xpath>
+</template>
+
+</odoo>

--- a/theme_monglia/views/customizations.xml
+++ b/theme_monglia/views/customizations.xml
@@ -614,6 +614,30 @@
     </xpath>
 </template>
 
+<!-- ======== COMPANY TEAM GRID ======== -->
+<template id="s_company_team_grid" inherit_id="website.s_company_team_grid">
+    <!-- Section -->
+    <xpath expr="//section" position="attributes">
+        <attribute name="class" add="o_cc5" remove="o_cc1" separator=" "/>
+    </xpath>
+    <!-- Team #01 -->
+    <xpath expr="(//div[hasclass('card')])[1]" position="attributes">
+        <attribute name="class" add="o_cc3" remove="o_cc2" separator=" "/>
+    </xpath>
+    <!-- Team #03 -->
+    <xpath expr="(//div[hasclass('card')])[3]" position="attributes">
+        <attribute name="class" add="o_cc4" remove="o_cc2" separator=" "/>
+    </xpath>
+    <!-- Team #04 -->
+    <xpath expr="(//div[hasclass('card')])[4]" position="attributes">
+        <attribute name="class" add="o_cc4" remove="o_cc2" separator=" "/>
+    </xpath>
+    <!-- Team #05 -->
+    <xpath expr="(//div[hasclass('card')])[5]" position="attributes">
+        <attribute name="class" add="o_cc3" remove="o_cc2" separator=" "/>
+    </xpath>
+</template>
+
 <!-- ======== STRIPED CENTER TOP ======== -->
 <template id="s_striped_center_top" inherit_id="website.s_striped_center_top">
     <!-- Title -->

--- a/theme_nano/__manifest__.py
+++ b/theme_nano/__manifest__.py
@@ -33,6 +33,7 @@
         'views/snippets/s_text_block.xml',
         'views/snippets/s_text_image.xml',
         'views/snippets/s_three_columns.xml',
+        'views/snippets/s_company_team_grid.xml',
         'views/snippets/s_unveil.xml',
         'views/snippets/s_quadrant.xml',
         'views/snippets/s_numbers_showcase.xml',

--- a/theme_nano/views/snippets/s_company_team_grid.xml
+++ b/theme_nano/views/snippets/s_company_team_grid.xml
@@ -1,0 +1,38 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+
+<template id="s_company_team_grid" inherit_id="website.s_company_team_grid">
+    <!-- Section -->
+    <xpath expr="//section" position="attributes">
+        <attribute name="class" add="o_cc5" remove="o_cc1" separator=" "/>
+    </xpath>
+    <!-- Team #01 -->
+    <xpath expr="(//div[hasclass('card')])[1]" position="attributes">
+        <attribute name="class" add="o_cc5" remove="o_cc2" separator=" "/>
+    </xpath>
+    <!-- Team #02 -->
+    <xpath expr="(//div[hasclass('card')])[2]" position="attributes">
+        <attribute name="class" add="o_cc5" remove="o_cc2" separator=" "/>
+    </xpath>
+    <!-- Team #03 -->
+    <xpath expr="(//div[hasclass('card')])[3]" position="attributes">
+        <attribute name="class" add="o_cc5" remove="o_cc2" separator=" "/>
+    </xpath>
+    <!-- Team #04 -->
+    <xpath expr="(//div[hasclass('card')])[4]" position="attributes">
+        <attribute name="class" add="o_cc5" remove="o_cc2" separator=" "/>
+    </xpath>
+    <xpath expr="(//p)[4]"  position="replace" mode="inner">
+        Designer
+    </xpath>
+    <!-- Team #05 -->
+    <xpath expr="(//div[hasclass('card')])[5]" position="attributes">
+        <attribute name="class" add="o_cc5" remove="o_cc2" separator=" "/>
+    </xpath>
+    <!-- Team #06 -->
+    <xpath expr="(//div[hasclass('card')])[6]" position="attributes">
+        <attribute name="class" add="o_cc5" remove="o_cc2" separator=" "/>
+    </xpath>
+</template>
+
+</odoo>

--- a/theme_notes/views/snippets/s_company_team_grid.xml
+++ b/theme_notes/views/snippets/s_company_team_grid.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+
+<template id="s_company_team_grid" inherit_id="website.s_company_team_grid">
+    <!-- Section -->
+    <xpath expr="//section" position="attributes">
+        <attribute name="class" add="o_cc5" remove="o_cc1" separator=" "/>
+    </xpath>
+</template>
+
+</odoo>

--- a/theme_real_estate/__manifest__.py
+++ b/theme_real_estate/__manifest__.py
@@ -27,6 +27,7 @@
         'views/snippets/s_quotes_carousel.xml',
         'views/snippets/s_quotes_carousel_minimal.xml',
         'views/snippets/s_freegrid.xml',
+        'views/snippets/s_company_team_grid.xml',
         'views/snippets/s_text_block.xml',
         'views/snippets/s_features_wall.xml',
         'views/snippets/s_masonry_block.xml',

--- a/theme_real_estate/views/snippets/s_company_team_grid.xml
+++ b/theme_real_estate/views/snippets/s_company_team_grid.xml
@@ -1,0 +1,35 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+
+<template id="s_company_team_grid" inherit_id="website.s_company_team_grid">
+    <!-- Section -->
+    <xpath expr="//section" position="attributes">
+        <attribute name="class" add="o_cc3" remove="o_cc1" separator=" "/>
+    </xpath>
+    <!-- Team #01 -->
+    <xpath expr="//div[hasclass('card')]" position="attributes">
+        <attribute name="class" add="o_cc1" remove="o_cc2" separator=" "/>
+    </xpath>
+    <!-- Team #02 -->
+    <xpath expr="(//div[hasclass('card')])[2]" position="attributes">
+        <attribute name="class" add="o_cc1" remove="o_cc2" separator=" "/>
+    </xpath>
+    <!-- Team #03 -->
+    <xpath expr="(//div[hasclass('card')])[3]" position="attributes">
+        <attribute name="class" add="o_cc1" remove="o_cc2" separator=" "/>
+    </xpath>
+    <!-- Team #04 -->
+    <xpath expr="(//div[hasclass('card')])[4]" position="attributes">
+        <attribute name="class" add="o_cc1" remove="o_cc2" separator=" "/>
+    </xpath>
+    <!-- Team #05 -->
+    <xpath expr="(//div[hasclass('card')])[5]" position="attributes">
+        <attribute name="class" add="o_cc1" remove="o_cc2" separator=" "/>
+    </xpath>
+    <!-- Team #06 -->
+    <xpath expr="(//div[hasclass('card')])[6]" position="attributes">
+        <attribute name="class" add="o_cc1" remove="o_cc2" separator=" "/>
+    </xpath>
+</template>
+
+</odoo>

--- a/theme_treehouse/__manifest__.py
+++ b/theme_treehouse/__manifest__.py
@@ -29,6 +29,7 @@
         'views/snippets/s_image_title.xml',
         'views/snippets/s_key_images.xml',
         'views/snippets/s_images_mosaic.xml',
+        'views/snippets/s_company_team_grid.xml',
         'views/snippets/s_media_list.xml',
         'views/snippets/s_numbers_list.xml',
         'views/snippets/s_picture.xml',

--- a/theme_treehouse/views/snippets/s_company_team_grid.xml
+++ b/theme_treehouse/views/snippets/s_company_team_grid.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+
+<template id="s_company_team_grid" inherit_id="website.s_company_team_grid">
+    <!-- Section -->
+    <xpath expr="//section" position="attributes">
+        <attribute name="class" add="o_cc2" remove="o_cc1" separator=" "/>
+    </xpath>
+</template>
+
+</odoo>

--- a/theme_yes/__manifest__.py
+++ b/theme_yes/__manifest__.py
@@ -36,6 +36,7 @@
         'views/snippets/s_media_list.xml',
         'views/snippets/s_picture.xml',
         'views/snippets/s_popup.xml',
+        'views/snippets/s_company_team_grid.xml',
         'views/snippets/s_freegrid.xml',
         'views/snippets/s_features_wall.xml',
         'views/snippets/s_quotes_carousel.xml',

--- a/theme_yes/views/snippets/s_company_team_grid.xml
+++ b/theme_yes/views/snippets/s_company_team_grid.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+
+<template id="s_company_team_grid" inherit_id="website.s_company_team_grid">
+    <!-- Section -->
+    <xpath expr="//section" position="attributes">
+        <attribute name="class" add="o_cc5" remove="o_cc1" separator=" "/>
+    </xpath>
+</template>
+
+</odoo>


### PR DESCRIPTION
*: anelusia, artists, beauty, bewise, bistro, bookstore, clean, cobalt, kea, kiddo, monglia, nano, notes, orchid, real_estate, treehouse, vehicle, yes

This commit adapts the design of new `s_company_team_grid` snippet for multiple themes.

task-4150614
Part-of: task-4077427

requires: https://github.com/odoo/odoo/pull/179791