### PR TITLE
[IMP] theme_*: adapt images in `s_striped_center_top` snippet

### DIFF
--- a/theme_avantgarde/views/customizations.xml
+++ b/theme_avantgarde/views/customizations.xml
@@ -496,6 +496,10 @@
     <xpath expr="//a[hasclass('btn')]/t" position="replace" mode="inner">
         Discover More
     </xpath>
+    <!-- Image -->
+    <xpath expr="//img" position="attributes">
+        <attribute name="src">/web/image/website.s_image_title_default_image</attribute>
+    </xpath>
     <!-- Figcaption -->
     <xpath expr="//figcaption" position="replace" mode="inner">
         Where creativity knows no bounds

--- a/theme_loftspace/views/snippets/s_striped_center_top.xml
+++ b/theme_loftspace/views/snippets/s_striped_center_top.xml
@@ -14,6 +14,10 @@
     <xpath expr="//a[hasclass('btn')]/t" position="replace" mode="inner">
         Furnish Your Home
     </xpath>
+    <!-- Image -->
+    <xpath expr="//img" position="attributes">
+        <attribute name="src">/web/image/website.s_quotes_carousel_demo_image_1</attribute>
+    </xpath>
     <!-- Figcaption -->
     <xpath expr="//figcaption" position="replace" mode="inner">
         Elegance in every piece

--- a/theme_real_estate/views/snippets/s_striped_center_top.xml
+++ b/theme_real_estate/views/snippets/s_striped_center_top.xml
@@ -17,6 +17,7 @@
     <!-- Image -->
     <xpath expr="//img" position="attributes">
         <attribute name="class" remove="rounded" separator=" "/>
+        <attribute name="src">/web/image/website.s_accordion_image_default_image</attribute>
     </xpath>
     <!-- Figcaption -->
     <xpath expr="//figcaption" position="replace" mode="inner">

--- a/theme_zap/views/snippets/s_striped_center_top.xml
+++ b/theme_zap/views/snippets/s_striped_center_top.xml
@@ -20,7 +20,7 @@
     </xpath>
     <!-- Image -->
     <xpath expr="//img" position="attributes">
-        <attribute name="src">/web/image/website.s_three_columns_default_image_2</attribute>
+        <attribute name="src">/web/image/website.s_masonry_block_default_image_2</attribute>
     </xpath>
 </template>
 


### PR DESCRIPTION
*: avantgarde, loftspace, real_estate, yes, zap

This commit updates the images in the `s_striped_center_top` snippet for specific themes. The previous images were not visually good due to their height. The new, more landscape-oriented images provide a better visual fit, improving the overall design and aesthetics across the themes.

task-4105455
Part of task-4077427

related-to: https://github.com/odoo/odoo/pull/179888