### PR TITLE
[FIX] theme_notes, theme_odoo_experts: fix "Image Gallery" arrows class

### DIFF
--- a/theme_notes/views/snippets/s_image_gallery.xml
+++ b/theme_notes/views/snippets/s_image_gallery.xml
@@ -4,7 +4,7 @@
 <template id="s_image_gallery" inherit_id="website.s_image_gallery">
     <!-- Section -->
     <xpath expr="//section" position="attributes">
-        <attribute name="class" add="s_image_gallery_indicators_arrows_boxed" separator=" "/>
+        <attribute name="class" add="s_image_gallery_arrows_boxed" remove="s_image_gallery_arrows_default" separator=" "/>
     </xpath>
 </template>
 

--- a/theme_odoo_experts/views/snippets/s_image_gallery.xml
+++ b/theme_odoo_experts/views/snippets/s_image_gallery.xml
@@ -4,7 +4,7 @@
 <template id="s_image_gallery" inherit_id="website.s_image_gallery">
     <!-- Section -->
     <xpath expr="//section" position="attributes">
-        <attribute name="class" add="s_image_gallery_indicators_arrows_boxed" separator=" "/>
+        <attribute name="class" add="s_image_gallery_arrows_boxed" remove="s_image_gallery_arrows_default" separator=" "/>
     </xpath>
 </template>
 


### PR DESCRIPTION
Commit [1] adapted the "Image Gallery" new design for the different themes. In the `notes` and `odoo_experts` themes, the `s_image_gallery_indicators_arrows_boxed` class was added, in order to have squared arrows. However, this class does not exist, as the correct one is `s_image_gallery_arrows_boxed`. This made the arrows stay as the default ones in these themes.

Moreover, the default arrow class `s_image_gallery_arrows_default` was not removed in the xpath, making the two classes coexist.

This commit fixes these class issues.

[1]: https://github.com/odoo/design-themes/commit/f66833de41f757c65ecf660f7bbc033b6dc64d6a

Related to task-3654328