### PR TITLE
[FIX] theme_bewise, *: adapt `s_image_title` without `display: flex`

### DIFF
--- a/theme_anelusia/views/snippets/s_card_offset.xml
+++ b/theme_anelusia/views/snippets/s_card_offset.xml
@@ -2,6 +2,10 @@
 <odoo>
 
 <template id="s_card_offset" inherit_id="website.s_card_offset">
+    <!-- Grid items -->
+    <xpath expr="(//div[hasclass('o_grid_item')])[2]" position="attributes">
+        <attribute name="style" add="--grid-item-padding-y: 56px;" remove="--grid-item-padding-y: 40px;" separator=";"/>
+    </xpath>
     <!-- Image -->
     <xpath expr="//img" position="attributes">
         <attribute name="src">/web/image/website.s_carousel_default_image_3</attribute>

--- a/theme_avantgarde/views/customizations.xml
+++ b/theme_avantgarde/views/customizations.xml
@@ -523,6 +523,10 @@
     <xpath expr="//section" position="attributes">
         <attribute name="class" add="o_cc4" remove="o_cc1" separator=" "/>
     </xpath>
+    <!-- Grid items -->
+    <xpath expr="(//div[hasclass('o_grid_item')])[2]" position="attributes">
+        <attribute name="style" add="--grid-item-padding-y: 56px;" remove="--grid-item-padding-y: 40px;" separator=";"/>
+    </xpath>
     <!-- Image -->
     <xpath expr="//img" position="attributes">
         <attribute name="src">/web/image/website.s_carousel_default_image_3</attribute>

--- a/theme_beauty/views/snippets/s_card_offset.xml
+++ b/theme_beauty/views/snippets/s_card_offset.xml
@@ -6,6 +6,10 @@
     <xpath expr="//section" position="attributes">
         <attribute name="class" add="o_cc4" remove="o_cc1" separator=" "/>
     </xpath>
+    <!-- Grid items -->
+    <xpath expr="(//div[hasclass('o_grid_item')])[2]" position="attributes">
+        <attribute name="style" add="--grid-item-padding-y: 56px;" remove="--grid-item-padding-y: 40px;" separator=";"/>
+    </xpath>
     <!-- Image -->
     <xpath expr="//img" position="attributes">
         <attribute name="src">/web/image/website.s_carousel_default_image_3</attribute>

--- a/theme_bewise/views/customizations.xml
+++ b/theme_bewise/views/customizations.xml
@@ -484,6 +484,9 @@
 
 <!-- ======== CAROUSEL INTRO ======== -->
 <template id="s_carousel_intro" inherit_id="website.s_carousel_intro" name="Be Wise s_carousel_intro">
+    <xpath expr="//div[hasclass('carousel-item')][2]//div[hasclass('o_grid_item')][2]" position="attributes">
+        <attribute name="style" add="--grid-item-padding-y: 0px;" remove="--grid-item-padding-y: 20px;" separator=";"/>
+    </xpath>
     <xpath expr="//h1" position="replace" mode="inner">
         Empowering your academic future
     </xpath>

--- a/theme_bewise/views/customizations.xml
+++ b/theme_bewise/views/customizations.xml
@@ -771,6 +771,10 @@
     <xpath expr="//p[hasclass('lead')]" position="replace" mode="inner">
         Transform your future with our cutting-edge programs, where education meets opportunity. Elevate your learning experience with courses that blend academic excellence and practical skills seamlessly.
     </xpath>
+    <xpath expr="//div[hasclass('o_grid_item')][2]" position="attributes" mode="inner">
+        <attribute name="class" add="g-height-4" remove="g-height-3" separator=" "/>
+        <attribute name="style" add="--grid-item-padding-y: 32px; grid-area: 6 / 6 / 10 / 13;" remove="--grid-item-padding-y: 24px; grid-area: 7 / 6 / 10 / 13;" separator=";"/>
+    </xpath>
 </template>
 
 

--- a/theme_bistro/views/snippets/s_card_offset.xml
+++ b/theme_bistro/views/snippets/s_card_offset.xml
@@ -6,6 +6,10 @@
     <xpath expr="//section" position="attributes">
         <attribute name="class" add="o_cc5 o_colored_level" remove="o_cc1" separator=" "/>
     </xpath>
+    <!-- Grid items -->
+    <xpath expr="(//div[hasclass('o_grid_item')])[2]" position="attributes">
+        <attribute name="style" add="--grid-item-padding-y: 60px;" remove="--grid-item-padding-y: 40px;" separator=";"/>
+    </xpath>
     <!-- Image -->
     <xpath expr="//img" position="attributes">
         <attribute name="src">/web/image/website.s_carousel_default_image_3</attribute>

--- a/theme_bookstore/views/snippets/s_card_offset.xml
+++ b/theme_bookstore/views/snippets/s_card_offset.xml
@@ -2,6 +2,10 @@
 <odoo>
 
 <template id="s_card_offset" inherit_id="website.s_card_offset">
+    <!-- Grid items -->
+    <xpath expr="(//div[hasclass('o_grid_item')])[2]" position="attributes">
+        <attribute name="style" add="--grid-item-padding-y: 56px;" remove="--grid-item-padding-y: 40px;" separator=";"/>
+    </xpath>
     <!-- Image -->
     <xpath expr="//img" position="attributes">
         <attribute name="src">/web/image/website.s_carousel_default_image_3</attribute>

--- a/theme_enark/views/snippets/s_card_offset.xml
+++ b/theme_enark/views/snippets/s_card_offset.xml
@@ -6,6 +6,10 @@
     <xpath expr="//section" position="attributes">
         <attribute name="class" add="o_cc5 o_colored_level" remove="o_cc1" separator=" "/>
     </xpath>
+    <!-- Grid items -->
+    <xpath expr="(//div[hasclass('o_grid_item')])[2]" position="attributes">
+        <attribute name="style" add="--grid-item-padding-y: 56px;" remove="--grid-item-padding-y: 40px;" separator=";"/>
+    </xpath>
     <!-- Image -->
     <xpath expr="//img" position="attributes">
         <attribute name="src">/web/image/website.library_image_13</attribute>

--- a/theme_kiddo/views/snippets/s_card_offset.xml
+++ b/theme_kiddo/views/snippets/s_card_offset.xml
@@ -2,6 +2,10 @@
 <odoo>
 
 <template id="s_card_offset" inherit_id="website.s_card_offset">
+    <!-- Grid items -->
+    <xpath expr="(//div[hasclass('o_grid_item')])[2]" position="attributes">
+        <attribute name="style" add="--grid-item-padding-y: 56px;" remove="--grid-item-padding-y: 40px;" separator=";"/>
+    </xpath>
     <!-- Image -->
     <xpath expr="//img" position="attributes">
         <attribute name="src">/web/image/website.s_carousel_default_image_3</attribute>

--- a/theme_loftspace/views/snippets/s_card_offset.xml
+++ b/theme_loftspace/views/snippets/s_card_offset.xml
@@ -6,6 +6,10 @@
     <xpath expr="//section" position="attributes">
         <attribute name="class" add="o_cc4" remove="o_cc1" separator=" "/>
     </xpath>
+    <!-- Grid items -->
+    <xpath expr="(//div[hasclass('o_grid_item')])[2]" position="attributes">
+        <attribute name="style" add="--grid-item-padding-y: 56px;" remove="--grid-item-padding-y: 40px;" separator=";"/>
+    </xpath>
     <!-- Image -->
     <xpath expr="//img" position="attributes">
         <attribute name="src">/web/image/website.s_carousel_default_image_3</attribute>

--- a/theme_loftspace/views/snippets/s_carousel_intro.xml
+++ b/theme_loftspace/views/snippets/s_carousel_intro.xml
@@ -15,6 +15,10 @@
     <xpath expr="(//div[hasclass('carousel-item')])[3]" position="attributes">
         <attribute name="class" add="o_cc5" remove="o_cc1" separator=" "/>
     </xpath>
+    <xpath expr="//div[hasclass('carousel-item')][2]//div[hasclass('o_grid_item')][2]" position="attributes">
+        <attribute name="class" add="g-height-3" remove="g-height-2" separator=" "/>
+        <attribute name="style" add="grid-area: 6 / 7 / 9 / 11;" remove="grid-area: 7 / 7 / 9 / 11;" separator=";"/>
+    </xpath>
 
     <!-- Texts -->
     <xpath expr="//h1" position="replace" mode="inner">

--- a/theme_monglia/views/customizations.xml
+++ b/theme_monglia/views/customizations.xml
@@ -219,6 +219,15 @@
     <xpath expr="//div[hasclass('carousel-inner')]" position="before">
         <div class="o_we_shape o_web_editor_Wavy_08"/>
     </xpath>
+    <xpath expr="//div[hasclass('carousel-item')]" position="attributes">
+        <attribute name="class" remove="o_cc o_cc1" separator=" "/>
+    </xpath>
+    <xpath expr="(//div[hasclass('carousel-item')])[2]" position="attributes">
+        <attribute name="class" remove="o_cc o_cc1" separator=" "/>
+    </xpath>
+    <xpath expr="(//div[hasclass('carousel-item')])[3]" position="attributes">
+        <attribute name="class" remove="o_cc o_cc1" separator=" "/>
+    </xpath>
 
     <!-- Texts -->
     <xpath expr="//h1" position="replace" mode="inner">

--- a/theme_monglia/views/customizations.xml
+++ b/theme_monglia/views/customizations.xml
@@ -723,6 +723,10 @@
     <xpath expr="//section" position="attributes">
         <attribute name="class" add="o_cc4" remove="o_cc1" separator=" "/>
     </xpath>
+    <!-- Grid items -->
+    <xpath expr="(//div[hasclass('o_grid_item')])[2]" position="attributes">
+        <attribute name="style" add="--grid-item-padding-y: 48px;" remove="--grid-item-padding-y: 40px;" separator=";"/>
+    </xpath>
     <!-- Image -->
     <xpath expr="//img" position="attributes">
         <attribute name="src">/web/image/website.s_carousel_default_image_3</attribute>

--- a/theme_nano/views/snippets/s_card_offset.xml
+++ b/theme_nano/views/snippets/s_card_offset.xml
@@ -6,6 +6,10 @@
     <xpath expr="//section" position="attributes">
         <attribute name="class" add="o_cc5 o_colored_level" remove="o_cc1" separator=" "/>
     </xpath>
+    <!-- Grid items -->
+    <xpath expr="(//div[hasclass('o_grid_item')])[2]" position="attributes">
+        <attribute name="style" add="--grid-item-padding-y: 32px;" remove="--grid-item-padding-y: 40px;" separator=";"/>
+    </xpath>
     <!-- Image -->
     <xpath expr="//img" position="attributes">
         <attribute name="src">/web/image/website.library_image_03</attribute>

--- a/theme_notes/views/snippets/s_card_offset.xml
+++ b/theme_notes/views/snippets/s_card_offset.xml
@@ -2,6 +2,10 @@
 <odoo>
 
 <template id="s_card_offset" inherit_id="website.s_card_offset">
+    <!-- Grid items -->
+    <xpath expr="(//div[hasclass('o_grid_item')])[2]" position="attributes">
+        <attribute name="style" add="--grid-item-padding-y: 72px;" remove="--grid-item-padding-y: 40px;" separator=";"/>
+    </xpath>
     <!-- Image -->
     <xpath expr="//img" position="attributes">
         <attribute name="src">/web/image/website.s_carousel_default_image_3</attribute>

--- a/theme_notes/views/snippets/s_carousel_intro.xml
+++ b/theme_notes/views/snippets/s_carousel_intro.xml
@@ -15,6 +15,10 @@
     <xpath expr="(//div[hasclass('carousel-item')])[3]" position="attributes">
         <attribute name="class" add="o_cc5" remove="o_cc1" separator=" "/>
     </xpath>
+    <xpath expr="//div[hasclass('carousel-item')][2]//div[hasclass('o_grid_item')][2]" position="attributes">
+        <attribute name="class" add="g-height-3" remove="g-height-2" separator=" "/>
+        <attribute name="style" add="grid-area: 6 / 7 / 9 / 11;" remove="grid-area: 7 / 7 / 9 / 11;" separator=";"/>
+    </xpath>
 
     <!-- Texts -->
     <xpath expr="//h1" position="replace" mode="inner">

--- a/theme_odoo_experts/views/snippets/s_card_offset.xml
+++ b/theme_odoo_experts/views/snippets/s_card_offset.xml
@@ -2,6 +2,10 @@
 <odoo>
 
 <template id="s_card_offset" inherit_id="website.s_card_offset">
+    <!-- Grid items -->
+    <xpath expr="(//div[hasclass('o_grid_item')])[2]" position="attributes">
+        <attribute name="style" add="--grid-item-padding-y: 48px;" remove="--grid-item-padding-y: 40px;" separator=";"/>
+    </xpath>
     <!-- Image -->
     <xpath expr="//img" position="attributes">
         <attribute name="src">/web/image/website.s_carousel_default_image_3</attribute>

--- a/theme_paptic/views/customizations.xml
+++ b/theme_paptic/views/customizations.xml
@@ -723,9 +723,25 @@
 
 <!-- ======== CARD OFFSET ======== -->
 <template id="s_card_offset" inherit_id="website.s_card_offset">
+    <!-- Grid items -->
+    <xpath expr="(//div[hasclass('o_grid_item')])[2]" position="attributes">
+        <attribute name="style" add="--grid-item-padding-y: 64px;" remove="--grid-item-padding-y: 40px;" separator=";"/>
+    </xpath>
     <!-- Image -->
     <xpath expr="//img" position="attributes">
         <attribute name="src">/web/image/website.s_carousel_default_image_3</attribute>
+    </xpath>
+    <!-- Title -->
+    <xpath expr="//h3" position="replace" mode="inner">
+        Expert Consultancy in Tech &amp; Design
+    </xpath>
+    <!-- Paragraph 1 -->
+    <xpath expr="(//p[hasclass('lead')])[1]" position="replace" mode="inner">
+        Optimize your business with our consultancy services in technology and design. We provide strategic advice and innovative solutions to help you stay ahead in the digital age.
+    </xpath>
+    <!-- Paragraph 2 -->
+    <xpath expr="(//p[hasclass('lead')])[2]" position="replace" mode="inner">
+        Unlock your business potential.
     </xpath>
 </template>
 
@@ -762,24 +778,7 @@
     </xpath>
     <xpath expr="//div[hasclass('o_we_shape')]" position="replace"/>
 </template>
-<template id="s_card_offset" inherit_id="website.s_card_offset">
-    <!-- Image -->
-    <xpath expr="//img" position="attributes">
-        <attribute name="src">/web/image/website.s_carousel_default_image_3</attribute>
-    </xpath>
-    <!-- Title -->
-    <xpath expr="//h3" position="replace" mode="inner">
-        Expert Consultancy in Tech &amp; Design
-    </xpath>
-    <!-- Paragraph 1 -->
-    <xpath expr="(//p[hasclass('lead')])[1]" position="replace" mode="inner">
-        Optimize your business with our consultancy services in technology and design. We provide strategic advice and innovative solutions to help you stay ahead in the digital age.
-    </xpath>
-    <!-- Paragraph 2 -->
-    <xpath expr="(//p[hasclass('lead')])[2]" position="replace" mode="inner">
-        Unlock your business potential.
-    </xpath>
-</template>
+
 <!-- ==== Cards Grid ===== -->
 <template id="s_cards_grid" inherit_id="website.s_cards_grid">
     <!-- Card 1 -->

--- a/theme_real_estate/views/snippets/s_card_offset.xml
+++ b/theme_real_estate/views/snippets/s_card_offset.xml
@@ -6,6 +6,10 @@
     <xpath expr="//section" position="attributes">
         <attribute name="class" add="o_cc4" remove="o_cc1" separator=" "/>
     </xpath>
+    <!-- Grid items -->
+    <xpath expr="(//div[hasclass('o_grid_item')])[2]" position="attributes">
+        <attribute name="style" add="--grid-item-padding-y: 64px;" remove="--grid-item-padding-y: 40px;" separator=";"/>
+    </xpath>
     <!-- Image -->
     <xpath expr="//img" position="attributes">
         <attribute name="src">/web/image/website.library_image_16</attribute>

--- a/theme_treehouse/views/snippets/s_card_offset.xml
+++ b/theme_treehouse/views/snippets/s_card_offset.xml
@@ -2,6 +2,10 @@
 <odoo>
 
 <template id="s_card_offset" inherit_id="website.s_card_offset">
+    <!-- Grid items -->
+    <xpath expr="(//div[hasclass('o_grid_item')])[2]" position="attributes">
+        <attribute name="style" add="--grid-item-padding-y: 56px;" remove="--grid-item-padding-y: 40px;" separator=";"/>
+    </xpath>
     <!-- Image -->
     <xpath expr="//img" position="attributes">
         <attribute name="src">/web/image/website.s_carousel_default_image_3</attribute>

--- a/theme_vehicle/views/customizations.xml
+++ b/theme_vehicle/views/customizations.xml
@@ -562,6 +562,10 @@
 
 <!-- ======== CAROUSEL INTRO ======== -->
 <template id="s_carousel_intro" inherit_id="website.s_carousel_intro" name="Vehicle s_carousel_intro">
+    <xpath expr="//div[hasclass('carousel-item')][2]//div[hasclass('o_grid_item')][2]" position="attributes">
+        <attribute name="class" add="g-height-3" remove="g-height-2" separator=" "/>
+        <attribute name="style" add="grid-area: 6 / 7 / 9 / 11;" remove="grid-area: 7 / 7 / 9 / 11;" separator=";"/>
+    </xpath>
     <xpath expr="//h1" position="replace" mode="inner">
         Driving excellence with luxury vehicles
     </xpath>

--- a/theme_vehicle/views/customizations.xml
+++ b/theme_vehicle/views/customizations.xml
@@ -689,6 +689,9 @@
     <xpath expr="//p[hasclass('lead')]" position="replace" mode="inner">
         Transform your driving experience with our exclusive collection, where opulence meets cutting-edge technology. Elevate your journey with vehicles that blend sophistication and performance seamlessly.
     </xpath>
+    <xpath expr="//div[hasclass('o_grid_item')][2]" position="attributes" mode="inner">
+        <attribute name="style" add="--grid-item-padding-y: 12px;" remove="--grid-item-padding-y: 24px;" separator=";"/>
+    </xpath>
 </template>
 
 <!-- ======== KEY IMAGES ======== -->

--- a/theme_yes/views/snippets/s_card_offset.xml
+++ b/theme_yes/views/snippets/s_card_offset.xml
@@ -6,6 +6,10 @@
     <xpath expr="//section" position="attributes">
         <attribute name="class" add="o_cc5 o_colored_level" remove="o_cc1" separator=" "/>
     </xpath>
+    <!-- Grid items -->
+    <xpath expr="(//div[hasclass('o_grid_item')])[2]" position="attributes">
+        <attribute name="style" add="--grid-item-padding-y: 52px;" remove="--grid-item-padding-y: 40px;" separator=";"/>
+    </xpath>
     <!-- Image -->
     <xpath expr="//img" position="attributes">
         <attribute name="src">/web/image/website.s_carousel_default_image_3</attribute>

--- a/theme_zap/views/snippets/s_card_offset.xml
+++ b/theme_zap/views/snippets/s_card_offset.xml
@@ -2,6 +2,10 @@
 <odoo>
 
 <template id="s_card_offset" inherit_id="website.s_card_offset">
+    <!-- Grid items -->
+    <xpath expr="(//div[hasclass('o_grid_item')])[2]" position="attributes">
+        <attribute name="style" add="--grid-item-padding-y: 48px;" remove="--grid-item-padding-y: 40px;" separator=";"/>
+    </xpath>
     <!-- Image -->
     <xpath expr="//img" position="attributes">
         <attribute name="src">/web/image/website.s_carousel_default_image_3</attribute>


### PR DESCRIPTION
*: vehicle

In the community PR, the `s_image_title` snippet has been modified in order to not be in `display: flex` anymore, as it could cause issues with images. The same visual was obtained by setting a `grid-area` in a way that the text block is at the bottom right.

This commit adapts this snippet customizations to these changes. More precisely, it adapts the `grid-area` and padding to the text content, in order to avoid having an overflow while still looking like before.

Related to task-4105319