### PR TITLE
[FIX] theme_*: fix `s_cover` text readability

### DIFF
--- a/theme_artists/views/snippets/s_cover.xml
+++ b/theme_artists/views/snippets/s_cover.xml
@@ -5,11 +5,11 @@
     <!-- Section -->
     <xpath expr="//section" position="attributes">
         <attribute name="class" add="pt200 pb200" remove="pt232 pb232 s_parallax_bg parallax s_parallax_is_fixed bg-black-50" separator=" "/>
-        <attribute name="data-oe-shape-data">{"shape":"web_editor/Floats/02","flip":[]}</attribute>
+        <attribute name="data-oe-shape-data">{'shape':'web_editor/Floats/02','colors':{'c1':'o-color-1','c2':'o-color-1'},'flip':[]}</attribute>
     </xpath>
     <!-- Shape -->
     <xpath expr="//div[hasclass('container')]" position="before">
-        <div class="o_we_shape o_web_editor_Floats_02"/>
+        <div class="o_we_shape o_web_editor_Floats_02 o_we_animated" style="background-image: url('/web_editor/shape/web_editor/Floats/02.svg?c1=o-color-1&amp;c2=o-color-1');"/>
     </xpath>
     <!-- Remove filter & parallax -->
     <xpath expr="//div[hasclass('o_we_bg_filter')]" position="replace"/>

--- a/theme_avantgarde/views/new_page_template.xml
+++ b/theme_avantgarde/views/new_page_template.xml
@@ -36,7 +36,7 @@
 
 <template id="new_page_template_about_s_cover" inherit_id="website.new_page_template_about_s_cover">
     <xpath expr="//section" position="attributes">
-        <attribute name="class" add="o_half_screen_height o_cc5" remove="o_full_screen_height o_cc4" separator=" "/>
+        <attribute name="class" add="o_half_screen_height" remove="o_full_screen_height" separator=" "/>
     </xpath>
 </template>
 
@@ -44,19 +44,19 @@
 
 <template id="new_page_template_landing_0_s_cover" inherit_id="website.new_page_template_landing_0_s_cover">
     <xpath expr="//section" position="attributes">
-        <attribute name="class" add="o_cc5" remove="o_cc4" separator=" "/>
+        <attribute name="class" add="o_cc3" remove="o_cc5" separator=" "/>
     </xpath>
 </template>
 
 <template id="new_page_template_landing_2_s_cover" inherit_id="website.new_page_template_landing_2_s_cover">
     <xpath expr="//section" position="attributes">
-        <attribute name="class" add="o_half_screen_height o_cc5" remove="o_full_screen_height o_cc4" separator=" "/>
+        <attribute name="class" add="o_half_screen_height" remove="o_full_screen_height" separator=" "/>
     </xpath>
 </template>
 
 <template id="new_page_template_landing_4_s_cover" inherit_id="website.new_page_template_landing_4_s_cover">
     <xpath expr="//section" position="attributes">
-        <attribute name="class" add="o_cc5" remove="o_cc4" separator=" "/>
+        <attribute name="class" add="o_cc3" remove="o_cc5" separator=" "/>
     </xpath>
 </template>
 
@@ -64,7 +64,7 @@
 
 <template id="new_page_template_gallery_s_cover" inherit_id="website.new_page_template_gallery_s_cover">
     <xpath expr="//section" position="attributes">
-        <attribute name="class" add="o_half_screen_height o_cc5" remove="o_full_screen_height o_cc4" separator=" "/>
+        <attribute name="class" add="o_half_screen_height" remove="o_full_screen_height" separator=" "/>
     </xpath>
 </template>
 
@@ -80,7 +80,7 @@
 
 <template id="new_page_template_pricing_s_cover" inherit_id="website.new_page_template_pricing_s_cover">
     <xpath expr="//section" position="attributes">
-        <attribute name="class" add="o_half_screen_height o_cc5" remove="o_full_screen_height o_cc4" separator=" "/>
+        <attribute name="class" add="o_half_screen_height" remove="o_full_screen_height" separator=" "/>
     </xpath>
 </template>
 

--- a/theme_beauty/views/snippets/s_cover.xml
+++ b/theme_beauty/views/snippets/s_cover.xml
@@ -4,7 +4,7 @@
 <template id="s_cover" inherit_id="website.s_cover">
     <!-- Section -->
     <xpath expr="//section" position="attributes">
-        <attribute name="class" add="o_full_screen_height bg-black-15 o_cc5" remove="bg-black-50 o_cc4" separator=" "/>
+        <attribute name="class" add="o_full_screen_height bg-black-15" remove="bg-black-50" separator=" "/>
     </xpath>
     <!-- Change position of background image -->
     <xpath expr="//span[hasclass('s_parallax_bg')]" position="attributes">

--- a/theme_bewise/views/customizations.xml
+++ b/theme_bewise/views/customizations.xml
@@ -4,7 +4,7 @@
 <!-- ======== COVER ======== -->
 <template id="s_cover" inherit_id="website.s_cover" name="Be Wise s_cover">
     <xpath expr="//section" position="attributes">
-        <attribute name="class" add="pt200 pb200 o_cc5 oe_img_bg o_bg_img_center" remove="bg-black-50 s_parallax_is_fixed parallax pt232 pb232 o_cc4" separator=" "/>
+        <attribute name="class" add="pt200 pb200 oe_img_bg o_bg_img_center" remove="bg-black-50 s_parallax_is_fixed parallax pt232 pb232" separator=" "/>
         <attribute name="style">background-image: url('/web/image/website.s_cover_default_image'); background-position: 50% 50%;</attribute>
         <attribute name="data-oe-shape-data">{"shape":"web_editor/Rainy/08_001","flip":[]}</attribute>
         <attribute name="data-scroll-background-ratio">0</attribute>

--- a/theme_bookstore/views/snippets/s_cover.xml
+++ b/theme_bookstore/views/snippets/s_cover.xml
@@ -4,7 +4,7 @@
 <template id="s_cover" inherit_id="website.s_cover">
     <!-- Section -->
     <xpath expr="//section" position="attributes">
-        <attribute name="class" add="oe_img_bg o_full_screen_height o_cc1" remove="parallax s_parallax_is_fixed bg-black-50 o_cc4" separator=" "/>
+        <attribute name="class" add="oe_img_bg o_full_screen_height o_cc1" remove="parallax s_parallax_is_fixed bg-black-50 o_cc5" separator=" "/>
         <attribute name="data-scroll-background-ratio">0</attribute>
         <attribute name="data-oe-shape-data">{"shape":"web_editor/Floats/03","flip":[]}</attribute>
         <attribute name="style">background-image: url('/web/image/website.s_cover_default_image'); background-position: 50% 55%;</attribute>

--- a/theme_buzzy/views/snippets/s_cover.xml
+++ b/theme_buzzy/views/snippets/s_cover.xml
@@ -4,7 +4,7 @@
 <template id="s_cover" inherit_id="website.s_cover">
     <!-- Section -->
     <xpath expr="//section" position="attributes">
-        <attribute name="class" add="o_cc5 pt112 pb112" remove="pt232 pb232 bg-black-50 o_cc4" separator=" "/>
+        <attribute name="class" add="pt112 pb112" remove="pt232 pb232 bg-black-50" separator=" "/>
         <attribute name="data-oe-shape-data">{"shape":"web_editor/Airy/03_001","flip":[]}</attribute>
     </xpath>
     <!-- Filter -->

--- a/theme_cobalt/views/customizations.xml
+++ b/theme_cobalt/views/customizations.xml
@@ -500,4 +500,11 @@
     </xpath>
 </template>
 
+<!-- ==== Cover ===== -->
+<template id="s_cover" inherit_id="website.s_cover" name="Cobalt s_cover">
+    <xpath expr="//section" position="attributes">
+        <attribute name="class" add="o_cc4" remove="o_cc5" separator=" "/>
+    </xpath>
+</template>
+
 </odoo>

--- a/theme_graphene/views/customizations.xml
+++ b/theme_graphene/views/customizations.xml
@@ -4,7 +4,7 @@
 <!-- ======== COVER ======== -->
 <template id="s_cover" inherit_id="website.s_cover" name="Graphene s_cover">
     <xpath expr="//section" position="attributes">
-        <attribute name="class" add="pt160 pb240 s_parallax_no_overflow_hidden o_cc3" remove="pt232 pb232 s_parallax_is_fixed s_parallax o_cc4" separator=" "/>
+        <attribute name="class" add="pt160 pb240 s_parallax_no_overflow_hidden o_cc3" remove="pt232 pb232 s_parallax_is_fixed s_parallax o_cc5" separator=" "/>
     </xpath>
     <xpath expr="//h1" position="replace"/>
     <xpath expr="//p" position="replace"/>

--- a/theme_kiddo/views/snippets/s_cover.xml
+++ b/theme_kiddo/views/snippets/s_cover.xml
@@ -4,7 +4,7 @@
 <template id="s_cover" inherit_id="website.s_cover">
     <!-- Section -->
     <xpath expr="//section" position="attributes">
-        <attribute name="class" add="o_full_screen_height o_cc1" remove="bg-black-50 o_cc4" separator=" "/>
+        <attribute name="class" add="o_full_screen_height o_cc1" remove="bg-black-50 o_cc5" separator=" "/>
         <attribute name="data-oe-shape-data">{"shape":"web_editor/Floats/14"}</attribute>
     </xpath>
 

--- a/theme_loftspace/views/snippets/s_cover.xml
+++ b/theme_loftspace/views/snippets/s_cover.xml
@@ -4,7 +4,7 @@
 <template id="s_cover" inherit_id="website.s_cover">
     <!-- Section -->
     <xpath expr="//section" position="attributes">
-        <attribute name="class" add="o_full_screen_height o_cc3" remove="o_cc4" separator=" "/>
+        <attribute name="class" add="o_full_screen_height" separator=" "/>
     </xpath>
     <!-- Title -->
     <xpath expr="//h1" position="replace" mode="inner">

--- a/theme_monglia/views/customizations.xml
+++ b/theme_monglia/views/customizations.xml
@@ -33,7 +33,7 @@
  <template id="s_cover" inherit_id="website.s_cover" name="Monglia s_cover">
     <!-- Customize elements -->
     <xpath expr="//section" position="attributes">
-        <attribute name="class" add="o_full_screen_height o_cc5" remove="o_cc4" separator=" "/>
+        <attribute name="class" add="o_full_screen_height" separator=" "/>
     </xpath>
     <xpath expr="//div[hasclass('o_we_bg_filter')]" position="replace">
         <div class="o_we_bg_filter bg-black-25"/>

--- a/theme_nano/views/snippets/s_cover.xml
+++ b/theme_nano/views/snippets/s_cover.xml
@@ -4,7 +4,7 @@
 <template id="s_cover" inherit_id="website.s_cover">
     <!-- Section -->
     <xpath expr="//section" position="attributes">
-        <attribute name="class" add="o_cc5 pt200 pb200" remove="parallax s_parallax_is_fixed bg-black-50 pt232 pb232 o_cc4" separator=" "/>
+        <attribute name="class" add="pt200 pb200" remove="parallax s_parallax_is_fixed bg-black-50 pt232 pb232" separator=" "/>
         <attribute name="data-scroll-background-ratio">0</attribute>
         <attribute name="style">background-image: url('/web/image/website.s_cover_default_image'); background-position: 50% 0;</attribute>
     </xpath>

--- a/theme_paptic/views/customizations.xml
+++ b/theme_paptic/views/customizations.xml
@@ -15,7 +15,7 @@
 <!-- ==== Cover ===== -->
 <template id="s_cover" inherit_id="website.s_cover" name="Paptic s_cover">
     <xpath expr="//section" position="attributes">
-        <attribute name="class" add="pb0 pt192 o_cc5" remove="pt232 pb232 bg-black-50 s_parallax_is_fixed s_parallax o_cc4" separator=" "/>
+        <attribute name="class" add="pb0 pt192" remove="pt232 pb232 bg-black-50 s_parallax_is_fixed s_parallax" separator=" "/>
         <attribute name="data-scroll-background-ratio">0</attribute>
     </xpath>
 


### PR DESCRIPTION
*: artists, avantgarde, beauty, bewise, bookstore, buzzy, cobalt,
graphene, kiddo, loftspace, monglia, nano, paptic

This commit fixes a readability on the `s_cover` snippet.

- requires https://github.com/odoo/odoo/pull/180417


Prior to this commit, the background was set to `o_cc4` which was quite arbitrary, but could also create readability issues in some case.

As the image has a black filter on top of it, setting the `o_cc` class to `o_cc5` will ensure a readable text no matter the theme/industry.

task-4190912