### PR TITLE
[FIX] website: fix `s_features` snippet icons size chgo

### DIFF
--- a/theme_kea/views/snippets/s_features.xml
+++ b/theme_kea/views/snippets/s_features.xml
@@ -8,7 +8,7 @@
     </xpath>
     <!-- Column #01 -->
     <xpath expr="//div[hasclass('row')]/div[1]/i" position="replace">
-        <i class="s_features_icon fa fa-image mb-3 rounded fs-5" role="img"/>
+        <i class="s_features_icon fa fa-image mb-3 rounded" role="img"/>
     </xpath>
     <xpath expr="//div[hasclass('row')]/div[1]/div/h3" position="replace" mode="inner">
         <b>Stunning visuals</b>
@@ -18,7 +18,7 @@
     </xpath>
     <!-- Column #02 -->
     <xpath expr="//div[hasclass('row')]/div[2]/i" position="replace">
-        <i class="s_features_icon fa fa-eye mb-3 rounded fs-5" role="img"/>
+        <i class="s_features_icon fa fa-eye mb-3 rounded" role="img"/>
     </xpath>
     <xpath expr="//div[hasclass('row')]/div[2]/div/h3" position="replace" mode="inner">
         <b>360-degree vision</b>


### PR DESCRIPTION
This commit removes a `fs-5` that was added on icons within the `s_features` snippet.

- requires https://github.com/odoo/odoo/pull/180032

Currently, the size of icons are handled in two different ways :

1) if the icon has a `rounded` class, we have a CSS property setting the width to a certain size.

2) if the icon doesn't have the `rounded` class, it uses the default behaviour, meaning the `fa-*x` class will set a font-size. In this case, as there was a `fs-*` class applied, it prevented the icon to scale.

This commit fixes the issue by removing the extra class.

task-4182400
