### PR TITLE
[FIX] website: adapt `s_key_benefits` `col-lg-*` xpath selectors

### DIFF
--- a/theme_artists/views/snippets/s_key_benefits.xml
+++ b/theme_artists/views/snippets/s_key_benefits.xml
@@ -13,13 +13,13 @@
         Exclusive Artworks
     </xpath>
     <!-- Paragraphs -->
-    <xpath expr="//div[hasclass('col-lg-4')][2]/p" position="replace" mode="inner">
+    <xpath expr="//div[hasclass('col-lg-4')][1]/p" position="replace" mode="inner">
         We craft personalized artworks that capture your vision and style, delivering unique pieces that reflect your individuality.
     </xpath>
-    <xpath expr="//div[hasclass('col-lg-4')][3]/p" position="replace" mode="inner">
+    <xpath expr="//div[hasclass('col-lg-4')][2]/p" position="replace" mode="inner">
         Receive ongoing guidance and assistance throughout your project, ensuring that your artistic needs and preferences are fully realized.
     </xpath>
-    <xpath expr="//div[hasclass('col-lg-4')][4]/p" position="replace" mode="inner">
+    <xpath expr="//div[hasclass('col-lg-4')][3]/p" position="replace" mode="inner">
         Explore one-of-a-kind pieces and limited editions that showcase exceptional creativity and offer a distinctive touch to your collection.
     </xpath>
 </template>

--- a/theme_avantgarde/views/customizations.xml
+++ b/theme_avantgarde/views/customizations.xml
@@ -339,13 +339,13 @@
         Tax-Free Services
     </xpath>
     <!-- Paragraphs -->
-    <xpath expr="//div[hasclass('col-lg-4')][2]/p" position="replace" mode="inner">
+    <xpath expr="//div[hasclass('col-lg-4')][1]/p" position="replace" mode="inner">
         We provide custom pricing based on the unique needs of your project, ensuring you receive exceptional design services that fit your budget.
     </xpath>
-    <xpath expr="//div[hasclass('col-lg-4')][3]/p" position="replace" mode="inner">
+    <xpath expr="//div[hasclass('col-lg-4')][2]/p" position="replace" mode="inner">
         Our team is here to assist you at every stage of your project, ensuring a smooth and stress-free process for your project.
     </xpath>
-    <xpath expr="//div[hasclass('col-lg-4')][4]/p" position="replace" mode="inner">
+    <xpath expr="//div[hasclass('col-lg-4')][3]/p" position="replace" mode="inner">
         We maximize value by offering tax-efficient design services, helping you achieve your vision while keeping your project financially streamlined.
     </xpath>
 </template>

--- a/theme_aviato/views/snippets/s_key_benefits.xml
+++ b/theme_aviato/views/snippets/s_key_benefits.xml
@@ -16,13 +16,13 @@
         <h5>Exclusive Experiences</h5>
     </xpath>
     <!-- Paragraphs -->
-    <xpath expr="//div[hasclass('col-lg-4')][2]/p" position="replace" mode="inner">
+    <xpath expr="//div[hasclass('col-lg-4')][1]/p" position="replace" mode="inner">
         We craft custom travel plans that suit your interests and needs, ensuring every trip is unique and unforgettable.
     </xpath>
-    <xpath expr="//div[hasclass('col-lg-4')][3]/p" position="replace" mode="inner">
+    <xpath expr="//div[hasclass('col-lg-4')][2]/p" position="replace" mode="inner">
         Our dedicated team is here to assist you at any time, from the moment you book until you return home safely.
     </xpath>
-    <xpath expr="//div[hasclass('col-lg-4')][4]/p" position="replace" mode="inner">
+    <xpath expr="//div[hasclass('col-lg-4')][3]/p" position="replace" mode="inner">
         Gain access to curated experiences and hidden gems that go beyond the usual tourist paths, making your journey truly special.
     </xpath>
 </template>

--- a/theme_beauty/views/snippets/s_key_benefits.xml
+++ b/theme_beauty/views/snippets/s_key_benefits.xml
@@ -13,13 +13,13 @@
         Exclusive Cosmetics Offers
     </xpath>
     <!-- Paragraphs -->
-    <xpath expr="//div[hasclass('col-lg-4')][2]/p" position="replace" mode="inner">
+    <xpath expr="//div[hasclass('col-lg-4')][1]/p" position="replace" mode="inner">
         We provide custom pricing based on the unique needs of your project, ensuring you receive exceptional design services that fit your budget.
     </xpath>
-    <xpath expr="//div[hasclass('col-lg-4')][3]/p" position="replace" mode="inner">
+    <xpath expr="//div[hasclass('col-lg-4')][2]/p" position="replace" mode="inner">
         Our team is here to assist you at every stage of your project, ensuring a smooth and stress-free process for your project.
     </xpath>
-    <xpath expr="//div[hasclass('col-lg-4')][4]/p" position="replace" mode="inner">
+    <xpath expr="//div[hasclass('col-lg-4')][3]/p" position="replace" mode="inner">
         Enjoy access to special promotions and exclusive deals that elevate your beauty routine while offering great value.
     </xpath>
 </template>

--- a/theme_bewise/views/customizations.xml
+++ b/theme_bewise/views/customizations.xml
@@ -591,13 +591,13 @@
         Exclusive Opportunities
     </xpath>
     <!-- Paragraphs -->
-    <xpath expr="//div[hasclass('col-lg-4')][2]/p" position="replace" mode="inner">
+    <xpath expr="//div[hasclass('col-lg-4')][1]/p" position="replace" mode="inner">
         Explore customized academic programs designed to match your interests and career goals, providing a personalized educational experience.
     </xpath>
-    <xpath expr="//div[hasclass('col-lg-4')][3]/p" position="replace" mode="inner">
+    <xpath expr="//div[hasclass('col-lg-4')][2]/p" position="replace" mode="inner">
         Receive continuous assistance and guidance from our dedicated staff, available around the clock to help with your academic needs.
     </xpath>
-    <xpath expr="//div[hasclass('col-lg-4')][4]/p" position="replace" mode="inner">
+    <xpath expr="//div[hasclass('col-lg-4')][3]/p" position="replace" mode="inner">
         Gain access to unique scholarships, internships, and research programs that enhance your educational journey and career prospects.
     </xpath>
 </template>

--- a/theme_bistro/views/snippets/s_key_benefits.xml
+++ b/theme_bistro/views/snippets/s_key_benefits.xml
@@ -13,13 +13,13 @@
         Exclusive Events
     </xpath>
     <!-- Paragraphs -->
-    <xpath expr="//div[hasclass('col-lg-4')][2]/p" position="replace" mode="inner">
+    <xpath expr="//div[hasclass('col-lg-4')][1]/p" position="replace" mode="inner">
         Enjoy thoughtfully crafted dishes that highlight seasonal ingredients and local flavors, offering a unique dining experience.
     </xpath>
-    <xpath expr="//div[hasclass('col-lg-4')][3]/p" position="replace" mode="inner">
+    <xpath expr="//div[hasclass('col-lg-4')][2]/p" position="replace" mode="inner">
         Our team is here to provide warm, personalized service, ensuring that every visit is comfortable and memorable.
     </xpath>
-    <xpath expr="//div[hasclass('col-lg-4')][4]/p" position="replace" mode="inner">
+    <xpath expr="//div[hasclass('col-lg-4')][3]/p" position="replace" mode="inner">
         Take part in special events and tasting nights that showcase new dishes, local wines, and culinary creativity.
     </xpath>
 </template>

--- a/theme_bookstore/views/snippets/s_key_benefits.xml
+++ b/theme_bookstore/views/snippets/s_key_benefits.xml
@@ -13,13 +13,13 @@
         Exclusive Book Events
     </xpath>
     <!-- Paragraphs -->
-    <xpath expr="//div[hasclass('col-lg-4')][2]/p" position="replace" mode="inner">
+    <xpath expr="//div[hasclass('col-lg-4')][1]/p" position="replace" mode="inner">
         Explore handpicked books that cater to all interests, offering a carefully selected range of genres and authors.
     </xpath>
-    <xpath expr="//div[hasclass('col-lg-4')][3]/p" position="replace" mode="inner">
+    <xpath expr="//div[hasclass('col-lg-4')][2]/p" position="replace" mode="inner">
         Our knowledgeable staff provides tailored book suggestions, helping you discover new favorites that match your taste.
     </xpath>
-    <xpath expr="//div[hasclass('col-lg-4')][4]/p" position="replace" mode="inner">
+    <xpath expr="//div[hasclass('col-lg-4')][3]/p" position="replace" mode="inner">
         Join us for author signings, readings, and special events that connect you with the literary community.
     </xpath>
 </template>

--- a/theme_buzzy/views/snippets/s_key_benefits.xml
+++ b/theme_buzzy/views/snippets/s_key_benefits.xml
@@ -13,13 +13,13 @@
         Exclusive Partnerships
     </xpath>
     <!-- Paragraphs -->
-    <xpath expr="//div[hasclass('col-lg-4')][2]/p" position="replace" mode="inner">
+    <xpath expr="//div[hasclass('col-lg-4')][1]/p" position="replace" mode="inner">
         We offer tailored strategies that align with your business goals, driving growth and maximizing efficiency.
     </xpath>
-    <xpath expr="//div[hasclass('col-lg-4')][3]/p" position="replace" mode="inner">
+    <xpath expr="//div[hasclass('col-lg-4')][2]/p" position="replace" mode="inner">
         Our team provides continuous support, ensuring your projects run smoothly and challenges are addressed promptly.
     </xpath>
-    <xpath expr="//div[hasclass('col-lg-4')][4]/p" position="replace" mode="inner">
+    <xpath expr="//div[hasclass('col-lg-4')][3]/p" position="replace" mode="inner">
         Benefit from unique collaborations and partnerships that give your business a competitive edge in the market.
     </xpath>
 </template>

--- a/theme_clean/views/snippets/s_key_benefits.xml
+++ b/theme_clean/views/snippets/s_key_benefits.xml
@@ -13,13 +13,13 @@
         Exclusive Legal Resources
     </xpath>
     <!-- Paragraphs -->
-    <xpath expr="//div[hasclass('col-lg-4')][2]/p" position="replace" mode="inner">
+    <xpath expr="//div[hasclass('col-lg-4')][1]/p" position="replace" mode="inner">
         We develop tailored legal strategies that align with your specific needs, ensuring effective and precise solutions.
     </xpath>
-    <xpath expr="//div[hasclass('col-lg-4')][3]/p" position="replace" mode="inner">
+    <xpath expr="//div[hasclass('col-lg-4')][2]/p" position="replace" mode="inner">
         Our team provides continuous support throughout your legal journey, guiding you through every step with clarity and care.
     </xpath>
-    <xpath expr="//div[hasclass('col-lg-4')][4]/p" position="replace" mode="inner">
+    <xpath expr="//div[hasclass('col-lg-4')][3]/p" position="replace" mode="inner">
         Access specialized resources and expert insights that strengthen your case and keep you informed on all legal matters.
     </xpath>
 </template>

--- a/theme_cobalt/views/customizations.xml
+++ b/theme_cobalt/views/customizations.xml
@@ -310,13 +310,13 @@
         Innovative Solutions
     </xpath>
     <!-- Paragraphs -->
-    <xpath expr="//div[hasclass('col-lg-4')][2]/p" position="replace" mode="inner">
+    <xpath expr="//div[hasclass('col-lg-4')][1]/p" position="replace" mode="inner">
         We create customized development strategies that meet your project’s unique requirements, ensuring successful outcomes.
     </xpath>
-    <xpath expr="//div[hasclass('col-lg-4')][3]/p" position="replace" mode="inner">
+    <xpath expr="//div[hasclass('col-lg-4')][2]/p" position="replace" mode="inner">
         Our team offers ongoing support throughout every phase of development, ensuring your project stays on track and on time.
     </xpath>
-    <xpath expr="//div[hasclass('col-lg-4')][4]/p" position="replace" mode="inner">
+    <xpath expr="//div[hasclass('col-lg-4')][3]/p" position="replace" mode="inner">
         Leverage cutting-edge technologies and innovative approaches that drive your development projects forward and deliver exceptional results.
     </xpath>
 </template>

--- a/theme_enark/views/snippets/s_key_benefits.xml
+++ b/theme_enark/views/snippets/s_key_benefits.xml
@@ -13,13 +13,13 @@
         Innovative Architecture
     </xpath>
     <!-- Paragraphs -->
-    <xpath expr="//div[hasclass('col-lg-4')][2]/p" position="replace" mode="inner">
+    <xpath expr="//div[hasclass('col-lg-4')][1]/p" position="replace" mode="inner">
         We create tailored architectural designs that reflect your vision and meet the unique needs of your project.
     </xpath>
-    <xpath expr="//div[hasclass('col-lg-4')][3]/p" position="replace" mode="inner">
+    <xpath expr="//div[hasclass('col-lg-4')][2]/p" position="replace" mode="inner">
         Our team provides comprehensive support from concept to completion, ensuring every detail of your project is expertly managed.
     </xpath>
-    <xpath expr="//div[hasclass('col-lg-4')][4]/p" position="replace" mode="inner">
+    <xpath expr="//div[hasclass('col-lg-4')][3]/p" position="replace" mode="inner">
         Experience cutting-edge designs that blend creativity with functionality, pushing the boundaries of modern architecture.
     </xpath>
 </template>

--- a/theme_graphene/views/customizations.xml
+++ b/theme_graphene/views/customizations.xml
@@ -335,13 +335,13 @@
         Exclusive Service Benefits
     </xpath>
     <!-- Paragraphs -->
-    <xpath expr="//div[hasclass('col-lg-4')][2]/p" position="replace" mode="inner">
+    <xpath expr="//div[hasclass('col-lg-4')][1]/p" position="replace" mode="inner">
         We provide customized service offerings designed to meet your specific needs, ensuring optimal results and client satisfaction.
     </xpath>
-    <xpath expr="//div[hasclass('col-lg-4')][3]/p" position="replace" mode="inner">
+    <xpath expr="//div[hasclass('col-lg-4')][2]/p" position="replace" mode="inner">
         Our team is available around the clock to assist you, providing prompt and reliable support whenever you need it.
     </xpath>
-    <xpath expr="//div[hasclass('col-lg-4')][4]/p" position="replace" mode="inner">
+    <xpath expr="//div[hasclass('col-lg-4')][3]/p" position="replace" mode="inner">
         Take advantage of unique benefits and value-added services that set us apart and enhance your overall experience.
     </xpath>
 </template>

--- a/theme_kea/views/snippets/s_key_benefits.xml
+++ b/theme_kea/views/snippets/s_key_benefits.xml
@@ -13,13 +13,13 @@
         Cutting-Edge Innovations
     </xpath>
     <!-- Paragraphs -->
-    <xpath expr="//div[hasclass('col-lg-4')][2]/p" position="replace" mode="inner">
+    <xpath expr="//div[hasclass('col-lg-4')][1]/p" position="replace" mode="inner">
         We develop tailored technology solutions that address your unique challenges, driving innovation and efficiency.
     </xpath>
-    <xpath expr="//div[hasclass('col-lg-4')][3]/p" position="replace" mode="inner">
+    <xpath expr="//div[hasclass('col-lg-4')][2]/p" position="replace" mode="inner">
         Our dedicated support team is available around the clock to ensure your systems run smoothly and any issues are quickly resolved.
     </xpath>
-    <xpath expr="//div[hasclass('col-lg-4')][4]/p" position="replace" mode="inner">
+    <xpath expr="//div[hasclass('col-lg-4')][3]/p" position="replace" mode="inner">
         Stay ahead with our latest advancements and technologies designed to give you a competitive edge in the ever-evolving tech landscape.
     </xpath>
 </template>

--- a/theme_kiddo/views/snippets/s_key_benefits.xml
+++ b/theme_kiddo/views/snippets/s_key_benefits.xml
@@ -13,13 +13,13 @@
         Enriching Activities
     </xpath>
     <!-- Paragraphs -->
-    <xpath expr="//div[hasclass('col-lg-4')][2]/p" position="replace" mode="inner">
+    <xpath expr="//div[hasclass('col-lg-4')][1]/p" position="replace" mode="inner">
         We provide tailored care and learning programs that cater to the unique needs of each child, fostering their growth and development.
     </xpath>
-    <xpath expr="//div[hasclass('col-lg-4')][3]/p" position="replace" mode="inner">
+    <xpath expr="//div[hasclass('col-lg-4')][2]/p" position="replace" mode="inner">
         Our dedicated staff is here to support you and your child, offering guidance and assistance whenever you need it.
     </xpath>
-    <xpath expr="//div[hasclass('col-lg-4')][4]/p" position="replace" mode="inner">
+    <xpath expr="//div[hasclass('col-lg-4')][3]/p" position="replace" mode="inner">
         Your child will enjoy a variety of carefully curated activities designed to nurture creativity, curiosity, and social skills.
     </xpath>
 </template>

--- a/theme_loftspace/views/snippets/s_key_benefits.xml
+++ b/theme_loftspace/views/snippets/s_key_benefits.xml
@@ -13,13 +13,13 @@
         Exclusive Collections
     </xpath>
     <!-- Paragraphs -->
-    <xpath expr="//div[hasclass('col-lg-4')][2]/p" position="replace" mode="inner">
+    <xpath expr="//div[hasclass('col-lg-4')][1]/p" position="replace" mode="inner">
         We offer personalized furniture designs that match your style and space, ensuring each piece fits perfectly into your home.
     </xpath>
-    <xpath expr="//div[hasclass('col-lg-4')][3]/p" position="replace" mode="inner">
+    <xpath expr="//div[hasclass('col-lg-4')][2]/p" position="replace" mode="inner">
         Our team is here to assist you from selection to delivery, ensuring a seamless experience and satisfaction with every purchase.
     </xpath>
-    <xpath expr="//div[hasclass('col-lg-4')][4]/p" position="replace" mode="inner">
+    <xpath expr="//div[hasclass('col-lg-4')][3]/p" position="replace" mode="inner">
         Discover unique, high-quality furniture collections that combine craftsmanship with timeless design, adding elegance to any room.
     </xpath>
 </template>

--- a/theme_monglia/views/customizations.xml
+++ b/theme_monglia/views/customizations.xml
@@ -386,13 +386,13 @@
         Exclusive Experiences
     </xpath>
     <!-- Paragraphs -->
-    <xpath expr="//div[hasclass('col-lg-4')][2]/p" position="replace" mode="inner">
+    <xpath expr="//div[hasclass('col-lg-4')][1]/p" position="replace" mode="inner">
         We create custom event experiences designed to match your vision, ensuring every detail aligns perfectly with your goals.
     </xpath>
-    <xpath expr="//div[hasclass('col-lg-4')][3]/p" position="replace" mode="inner">
+    <xpath expr="//div[hasclass('col-lg-4')][2]/p" position="replace" mode="inner">
         Our team provides full support from planning to execution, making sure your event runs smoothly and leaves a lasting impression.
     </xpath>
-    <xpath expr="//div[hasclass('col-lg-4')][4]/p" position="replace" mode="inner">
+    <xpath expr="//div[hasclass('col-lg-4')][3]/p" position="replace" mode="inner">
         Access unique venues, entertainment, and services that elevate your event and make it truly unforgettable.
     </xpath>
 </template>

--- a/theme_nano/views/snippets/s_key_benefits.xml
+++ b/theme_nano/views/snippets/s_key_benefits.xml
@@ -13,13 +13,13 @@
         Exclusive Designs
     </xpath>
     <!-- Paragraphs -->
-    <xpath expr="//div[hasclass('col-lg-4')][2]/p" position="replace" mode="inner">
+    <xpath expr="//div[hasclass('col-lg-4')][1]/p" position="replace" mode="inner">
         We design and build bespoke items tailored to your specifications, ensuring each piece is unique and meets your exact needs.
     </xpath>
-    <xpath expr="//div[hasclass('col-lg-4')][3]/p" position="replace" mode="inner">
+    <xpath expr="//div[hasclass('col-lg-4')][2]/p" position="replace" mode="inner">
         Receive hands-on assistance throughout the creation process, from concept to completion, to ensure your vision comes to life.
     </xpath>
-    <xpath expr="//div[hasclass('col-lg-4')][4]/p" position="replace" mode="inner">
+    <xpath expr="//div[hasclass('col-lg-4')][3]/p" position="replace" mode="inner">
         Explore one-of-a-kind designs and limited-edition pieces that showcase exceptional craftsmanship and creativity.
     </xpath>
 </template>

--- a/theme_notes/views/snippets/s_key_benefits.xml
+++ b/theme_notes/views/snippets/s_key_benefits.xml
@@ -13,13 +13,13 @@
         Exclusive Performances
     </xpath>
     <!-- Paragraphs -->
-    <xpath expr="//div[hasclass('col-lg-4')][2]/p" position="replace" mode="inner">
+    <xpath expr="//div[hasclass('col-lg-4')][1]/p" position="replace" mode="inner">
         We craft personalized setlists that match the mood and theme of your event, delivering a memorable musical experience.
     </xpath>
-    <xpath expr="//div[hasclass('col-lg-4')][3]/p" position="replace" mode="inner">
+    <xpath expr="//div[hasclass('col-lg-4')][2]/p" position="replace" mode="inner">
         Our team is available around the clock to handle bookings and logistics, ensuring a smooth and hassle-free process.
     </xpath>
-    <xpath expr="//div[hasclass('col-lg-4')][4]/p" position="replace" mode="inner">
+    <xpath expr="//div[hasclass('col-lg-4')][3]/p" position="replace" mode="inner">
         Experience unique and special performances that highlight our band's signature style and offer an unforgettable show.
     </xpath>
 </template>

--- a/theme_odoo_experts/views/snippets/s_key_benefits.xml
+++ b/theme_odoo_experts/views/snippets/s_key_benefits.xml
@@ -13,13 +13,13 @@
         Exclusive Insights
     </xpath>
     <!-- Paragraphs -->
-    <xpath expr="//div[hasclass('col-lg-4')][2]/p" position="replace" mode="inner">
+    <xpath expr="//div[hasclass('col-lg-4')][1]/p" position="replace" mode="inner">
         Receive tailored advice and strategies designed to meet your specific goals and needs, ensuring effective and actionable solutions.
     </xpath>
-    <xpath expr="//div[hasclass('col-lg-4')][3]/p" position="replace" mode="inner">
+    <xpath expr="//div[hasclass('col-lg-4')][2]/p" position="replace" mode="inner">
         Our advisory team offers continuous support and updates, providing you with reliable assistance whenever you need it.
     </xpath>
-    <xpath expr="//div[hasclass('col-lg-4')][4]/p" position="replace" mode="inner">
+    <xpath expr="//div[hasclass('col-lg-4')][3]/p" position="replace" mode="inner">
         Gain access to specialized knowledge and unique insights that give you a competitive edge and inform your decision-making.
     </xpath>
 </template>

--- a/theme_orchid/views/snippets/s_key_benefits.xml
+++ b/theme_orchid/views/snippets/s_key_benefits.xml
@@ -13,13 +13,13 @@
         Exclusive Designs
     </xpath>
     <!-- Paragraphs -->
-    <xpath expr="//div[hasclass('col-lg-4')][2]/p" position="replace" mode="inner">
+    <xpath expr="//div[hasclass('col-lg-4')][1]/p" position="replace" mode="inner">
         We create personalized flower arrangements that match your style and occasion, ensuring a beautiful and unique presentation.
     </xpath>
-    <xpath expr="//div[hasclass('col-lg-4')][3]/p" position="replace" mode="inner">
+    <xpath expr="//div[hasclass('col-lg-4')][2]/p" position="replace" mode="inner">
         Our team provides attentive service, guiding you through selection and delivery to ensure your floral needs are perfectly met.
     </xpath>
-    <xpath expr="//div[hasclass('col-lg-4')][4]/p" position="replace" mode="inner">
+    <xpath expr="//div[hasclass('col-lg-4')][3]/p" position="replace" mode="inner">
         Explore our one-of-a-kind floral designs and seasonal specials that add a touch of elegance and freshness to any event.
     </xpath>
 </template>

--- a/theme_paptic/views/customizations.xml
+++ b/theme_paptic/views/customizations.xml
@@ -540,13 +540,13 @@
         Exclusive Insights
     </xpath>
     <!-- Paragraphs -->
-    <xpath expr="//div[hasclass('col-lg-4')][2]/p" position="replace" mode="inner">
+    <xpath expr="//div[hasclass('col-lg-4')][1]/p" position="replace" mode="inner">
         We provide tailored consulting strategies that address your unique challenges and objectives, ensuring effective and practical outcomes.
     </xpath>
-    <xpath expr="//div[hasclass('col-lg-4')][3]/p" position="replace" mode="inner">
+    <xpath expr="//div[hasclass('col-lg-4')][2]/p" position="replace" mode="inner">
         Our consultants offer ongoing support and expert advice, guiding you through each phase of your project with personalized attention.
     </xpath>
-    <xpath expr="//div[hasclass('col-lg-4')][4]/p" position="replace" mode="inner">
+    <xpath expr="//div[hasclass('col-lg-4')][3]/p" position="replace" mode="inner">
         Access cutting-edge insights and industry expertise that give you a strategic advantage and enhance your decision-making process.
     </xpath>
 </template>

--- a/theme_real_estate/views/snippets/s_key_benefits.xml
+++ b/theme_real_estate/views/snippets/s_key_benefits.xml
@@ -13,13 +13,13 @@
         Exclusive Listings
     </xpath>
     <!-- Paragraphs -->
-    <xpath expr="//div[hasclass('col-lg-4')][2]/p" position="replace" mode="inner">
+    <xpath expr="//div[hasclass('col-lg-4')][1]/p" position="replace" mode="inner">
         We offer customized property searches based on your specific preferences and needs, helping you find the perfect home or investment.
     </xpath>
-    <xpath expr="//div[hasclass('col-lg-4')][3]/p" position="replace" mode="inner">
+    <xpath expr="//div[hasclass('col-lg-4')][2]/p" position="replace" mode="inner">
         Our team provides continuous support throughout the buying or selling process, ensuring a smooth and stress-free experience.
     </xpath>
-    <xpath expr="//div[hasclass('col-lg-4')][4]/p" position="replace" mode="inner">
+    <xpath expr="//div[hasclass('col-lg-4')][3]/p" position="replace" mode="inner">
         Access unique and high-value properties that are not widely available, giving you an edge in finding exceptional real estate opportunities.
     </xpath>
 </template>

--- a/theme_treehouse/views/snippets/s_key_benefits.xml
+++ b/theme_treehouse/views/snippets/s_key_benefits.xml
@@ -13,13 +13,13 @@
         Exclusive Insights
     </xpath>
     <!-- Paragraphs -->
-    <xpath expr="//div[hasclass('col-lg-4')][2]/p" position="replace" mode="inner">
+    <xpath expr="//div[hasclass('col-lg-4')][1]/p" position="replace" mode="inner">
         We develop tailored strategies and solutions to address your unique environmental challenges and goals, promoting sustainability and impact.
     </xpath>
-    <xpath expr="//div[hasclass('col-lg-4')][3]/p" position="replace" mode="inner">
+    <xpath expr="//div[hasclass('col-lg-4')][2]/p" position="replace" mode="inner">
         Our team provides continuous assistance and expertise, ensuring you receive guidance and support throughout your environmental initiatives.
     </xpath>
-    <xpath expr="//div[hasclass('col-lg-4')][4]/p" position="replace" mode="inner">
+    <xpath expr="//div[hasclass('col-lg-4')][3]/p" position="replace" mode="inner">
         Access specialized knowledge and innovative practices that enhance your understanding and effectiveness in environmental stewardship.
     </xpath>
 </template>

--- a/theme_vehicle/views/customizations.xml
+++ b/theme_vehicle/views/customizations.xml
@@ -523,13 +523,13 @@
         Exclusive Features
     </xpath>
     <!-- Paragraphs -->
-    <xpath expr="//div[hasclass('col-lg-4')][2]/p" position="replace" mode="inner">
+    <xpath expr="//div[hasclass('col-lg-4')][1]/p" position="replace" mode="inner">
         We offer personalized vehicle configurations to match your preferences and needs, ensuring you get the perfect fit for your lifestyle.
     </xpath>
-    <xpath expr="//div[hasclass('col-lg-4')][3]/p" position="replace" mode="inner">
+    <xpath expr="//div[hasclass('col-lg-4')][2]/p" position="replace" mode="inner">
         Our team provides full support throughout your vehicle purchase and ownership experience, from initial consultation to ongoing service.
     </xpath>
-    <xpath expr="//div[hasclass('col-lg-4')][4]/p" position="replace" mode="inner">
+    <xpath expr="//div[hasclass('col-lg-4')][3]/p" position="replace" mode="inner">
         Discover unique and advanced features that set our vehicles apart, providing you with exceptional performance and cutting-edge technology.
     </xpath>
 </template>

--- a/theme_yes/views/snippets/s_key_benefits.xml
+++ b/theme_yes/views/snippets/s_key_benefits.xml
@@ -13,13 +13,13 @@
         Exclusive Vendor Access
     </xpath>
     <!-- Paragraphs -->
-    <xpath expr="//div[hasclass('col-lg-4')][2]/p" position="replace" mode="inner">
+    <xpath expr="//div[hasclass('col-lg-4')][1]/p" position="replace" mode="inner">
         We create personalized wedding plans that reflect your vision and style, ensuring every detail is crafted to perfection for your special day.
     </xpath>
-    <xpath expr="//div[hasclass('col-lg-4')][3]/p" position="replace" mode="inner">
+    <xpath expr="//div[hasclass('col-lg-4')][2]/p" position="replace" mode="inner">
         Our team provides comprehensive support from initial consultation to the big day, handling every aspect to ensure a smooth and stress-free experience.
     </xpath>
-    <xpath expr="//div[hasclass('col-lg-4')][4]/p" position="replace" mode="inner">
+    <xpath expr="//div[hasclass('col-lg-4')][3]/p" position="replace" mode="inner">
         Gain access to a curated list of top-tier vendors and unique venues, offering exclusive options that enhance the elegance and individuality of your wedding.
     </xpath>
 </template>

--- a/theme_zap/views/snippets/s_key_benefits.xml
+++ b/theme_zap/views/snippets/s_key_benefits.xml
@@ -13,13 +13,13 @@
         Cutting-Edge Technology
     </xpath>
     <!-- Paragraphs -->
-    <xpath expr="//div[hasclass('col-lg-4')][2]/p" position="replace" mode="inner">
+    <xpath expr="//div[hasclass('col-lg-4')][1]/p" position="replace" mode="inner">
         We provide tailored digital strategies and solutions that align with your specific goals, driving innovation and efficiency in your online presence.
     </xpath>
-    <xpath expr="//div[hasclass('col-lg-4')][3]/p" position="replace" mode="inner">
+    <xpath expr="//div[hasclass('col-lg-4')][2]/p" position="replace" mode="inner">
         Our team offers round-the-clock support to ensure your digital platforms run smoothly and any issues are swiftly addressed.
     </xpath>
-    <xpath expr="//div[hasclass('col-lg-4')][4]/p" position="replace" mode="inner">
+    <xpath expr="//div[hasclass('col-lg-4')][3]/p" position="replace" mode="inner">
         Access the latest advancements and tools that enhance your digital experience and keep you ahead in the ever-evolving tech landscape.
     </xpath>
 </template>


### PR DESCRIPTION
This commit adapts the xpath for the `s_key_benefits` snippet that were targeting `col-lg-4`.

*: artists, avantgarde, aviato, beauty, bewise, bistro, bookstore,
buzzy, clean, cobalt, enark, graphene, kea, kiddo, loftspace, monglia,
nano, notes, odoo_experts, orchid, paptic, real_estate, treehouse,
vehicle, yes, zap

- requires https://github.com/odoo/odoo/pull/180332

As we switched the layout of this snippet to columns, we reviewed the layout a bit, resulting in one single `col-12` on top, rather than `col-4` and `col-12`.

As we remove this `col-lg-4`, we need to adapt all the xpaths.

task-4188740
part of task-4077427