### PR TITLE
[IMP] test_themes: verify separators used for attributes

### DIFF
--- a/test_themes/tests/test_new_page_templates.py
+++ b/test_themes/tests/test_new_page_templates.py
@@ -190,6 +190,12 @@ class TestNewPageTemplates(TransactionCase):
                                 conflict.difference_update(white_list)
                                 if len(conflict) > 1:
                                     errors.append("Using %r, view %r contains conflicting classes: %r in %r (according to pattern %r)" % (theme_name, view.key, conflict, classes, conflicting_classes_re.pattern))
+                        for el in html_tree.xpath('//*[@style]'):
+                            styles = el.attrib['style'].split(';')
+                            non_empty_styles = filter(lambda style: style, styles)
+                            property_names = list(map(lambda style: style.split(':')[0].strip(), non_empty_styles))
+                            if len(property_names) != len(set(property_names)):
+                                errors.append("Using %r, view %r contains duplicate style properties: %r" % (theme_name, view.key, el.attrib['style']))
                     except Exception:
                         _logger.error("Using %r, view %r cannot be rendered", theme_name, view.key)
                         errors.append("Using %r, view %r cannot be rendered" % (theme_name, view.key))

--- a/test_themes/tests/test_new_page_templates.py
+++ b/test_themes/tests/test_new_page_templates.py
@@ -1,6 +1,6 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
-from lxml import html
+from lxml import etree, html
 
 import logging
 import re
@@ -209,4 +209,42 @@ class TestNewPageTemplates(TransactionCase):
         for known_classes_re in CONFLICTUAL_CLASSES_RE:
             classes_inventory = [cl for cl in filter(lambda cl: not known_classes_re.findall(cl), classes_inventory)]
         _logger.info("Unknown classes encountered: %r", sorted(list(classes_inventory)))
+        self.assertFalse(errors, "No error should have been collected")
+
+    def test_attribute_separator(self):
+        ATTRIBUTE_SEPARATORS = {
+            'class': ' ',
+            'style': ';',
+            'sizes': ',',
+            'itemref': ' ',
+        }
+        View = self.env['ir.ui.view']
+        errors = []
+        view_count = 0
+
+        for module_name in ['website', *map(lambda website: website.theme_id.name, self.env['website'].get_test_themes_websites())]:
+            views = View.search([
+                '|', '|',
+                ('key', 'like', escape_psql(f'{module_name}.s_')),
+                ('key', 'like', escape_psql(f'{module_name}.configurator')),
+                ('key', 'like', escape_psql(f'{module_name}.new_page')),
+            ])
+            for view in views:
+                try:
+                    xml_tree = etree.fromstring(view.arch_db)
+                except etree.LxmlError:
+                    _logger.error("Using %r, view %r cannot be parsed: %r", module_name, view.key, view.arch_db)
+                    errors.append("Using %r, view %r cannot be parsed: %r" % (module_name, view.key, view.arch_db))
+                    continue
+                for el in xml_tree.xpath('//attribute[@add] | //attribute[@remove]'):
+                    attribute_name = el.attrib['name']
+                    if attribute_name in ATTRIBUTE_SEPARATORS:
+                        current_separator = el.attrib.get('separator', ',')
+                        expected_separator = ATTRIBUTE_SEPARATORS[attribute_name]
+                        if current_separator != expected_separator:
+                            errors.append("Using %r, view %r uses separator %r to modify attribute %r" % (module_name, view.key, current_separator, attribute_name))
+            view_count += len(views)
+
+        _logger.info("Tested %s views", view_count)
+        self.assertGreater(view_count, 2500, "Test should have checked many views")
         self.assertFalse(errors, "No error should have been collected")

--- a/theme_anelusia/views/snippets/s_image_hexagonal.xml
+++ b/theme_anelusia/views/snippets/s_image_hexagonal.xml
@@ -9,7 +9,7 @@
         <attribute name="class" add="o_snippet_mobile_invisible d-none d-lg-block" separator=" "/>
     </xpath>
     <xpath expr="(//div[hasclass('o_grid_item')])[2]" position="attributes">
-        <attribute name="style" add="--grid-item-padding-x: 24px; --grid-item-padding-y: 24px;" separator=" "/>
+        <attribute name="style" add="--grid-item-padding-x: 24px; --grid-item-padding-y: 24px;" separator=";"/>
     </xpath>
     <xpath expr="(//div[hasclass('o_grid_item')])[3]" position="attributes">
         <attribute name="class" remove="o_snippet_mobile_invisible d-none d-lg-block" separator=" "/>

--- a/theme_artists/views/snippets/s_cards_grid.xml
+++ b/theme_artists/views/snippets/s_cards_grid.xml
@@ -14,7 +14,7 @@
     <!-- Card 1 -->
     <xpath expr="(//div[hasclass('s_card')])[1]" position="attributes">
         <attribute name="class" add="border" separator=" "/>
-        <attribute name="style" add="border-width: 0px !important;" separator=" "/>
+        <attribute name="style" add="border-width: 0px !important;" separator=";"/>
     </xpath>
     <xpath expr="(//h5)[1]" position="replace" mode="inner">
         Unique Creative Vision
@@ -25,7 +25,7 @@
     <!-- Card 2 -->
     <xpath expr="(//div[hasclass('s_card')])[2]" position="attributes">
         <attribute name="class" add="border" separator=" "/>
-        <attribute name="style" add="border-width: 0px !important;" separator=" "/>
+        <attribute name="style" add="border-width: 0px !important;" separator=";"/>
     </xpath>
     <xpath expr="(//h5)[2]" position="replace" mode="inner">
         Original and Handcrafted Works
@@ -36,7 +36,7 @@
     <!-- Card 3 -->
     <xpath expr="(//div[hasclass('s_card')])[3]" position="attributes">
         <attribute name="class" add="border" separator=" "/>
-        <attribute name="style" add="border-width: 0px !important;" separator=" "/>
+        <attribute name="style" add="border-width: 0px !important;" separator=";"/>
     </xpath>
     <xpath expr="(//h5)[3]" position="replace" mode="inner">
         Bold Use of Color and Texture
@@ -47,7 +47,7 @@
     <!-- Card 4 -->
     <xpath expr="(//div[hasclass('s_card')])[4]" position="attributes">
         <attribute name="class" add="border" separator=" "/>
-        <attribute name="style" add="border-width: 0px !important;" separator=" "/>
+        <attribute name="style" add="border-width: 0px !important;" separator=";"/>
     </xpath>
     <xpath expr="(//h5)[4]" position="replace" mode="inner">
         Personalized Art Commissions

--- a/theme_avantgarde/views/customizations.xml
+++ b/theme_avantgarde/views/customizations.xml
@@ -51,14 +51,14 @@
         <attribute name="class" add="pt144 pb128" remove="pt64 pb64" separator=" "/>
     </xpath>
     <xpath expr="//h2" position="attributes">
-        <attribute name="style" remove="text-align: center;" separator=" "/>
+        <attribute name="style" remove="text-align: center;" separator=";"/>
         <attribute name="class" add="text-break" separator=" "/>
     </xpath>
     <xpath expr="//h2" position="replace" mode="inner">
         Design Methodology
     </xpath>
     <xpath expr="//p" position="attributes">
-        <attribute name="style" remove="text-align: center;" separator=" "/>
+        <attribute name="style" remove="text-align: center;" separator=";"/>
     </xpath>
     <xpath expr="//p" position="replace" mode="inner">
         Our design methodology is rooted in our core values.<br/>
@@ -72,7 +72,7 @@
         <attribute name="data-shape-colors">;o-color-2;;;</attribute>
     </xpath>
     <xpath expr="//figcaption" position="attributes">
-        <attribute name="style" add="text-align: right;" separator=" "/>
+        <attribute name="style" add="text-align: right;" separator=";"/>
     </xpath>
     <xpath expr="//figcaption" position="replace" mode="inner">
         We carry out an interdisciplinary design process.
@@ -188,7 +188,7 @@
         <attribute name="class" add="col-lg-8" remove="col-lg-9" separator=" "/>
     </xpath>
     <xpath expr="//div[hasclass('col-lg-8')]/p" position="attributes">
-        <attribute name="style" add="text-align: right;" separator=" "/>
+        <attribute name="style" add="text-align: right;" separator=";"/>
     </xpath>
     <xpath expr="//div[hasclass('col-lg-3')]" position="attributes">
         <attribute name="class" add="col-lg-4" remove="col-lg-3" separator=" "/>

--- a/theme_avantgarde/views/customizations.xml
+++ b/theme_avantgarde/views/customizations.xml
@@ -16,7 +16,7 @@
         <attribute name="data-oe-shape-data">{"shape":"web_editor/Origins/18","flip":["x"]}</attribute>
     </xpath>
     <xpath expr="//span[hasclass('s_parallax_bg')]" position="attributes">
-        <attribute name="style" remove="background-position: 50% 0;" add="background-position: 50% 80%;" separator=";"/>
+        <attribute name="style" remove="background-position: 50% 75%;" add="background-position: 50% 80%;" separator=";"/>
     </xpath>
     <xpath expr="//div[hasclass('s_allow_columns')]" position="before">
         <div class="o_we_shape o_web_editor_Origins_18" style="background-image: url('/web_editor/shape/web_editor/Origins/18.svg?c1=o-color-2&amp;flip=x'); background-position: 50% 50%;"/>

--- a/theme_aviato/views/snippets/s_framed_intro.xml
+++ b/theme_aviato/views/snippets/s_framed_intro.xml
@@ -4,7 +4,7 @@
 <template id="s_framed_intro" inherit_id="website.s_framed_intro">
     <!-- Image -->
     <xpath expr="//div[hasclass('col-lg-5')]" position="attributes">
-        <attribute name="style" add="border-radius: 8px !important;" separator=" "/>
+        <attribute name="style" add="border-radius: 8px !important;" separator=";"/>
     </xpath>
     <xpath expr="//img" position="attributes">
         <attribute name="class" add="rounded" separator=" "/>

--- a/theme_aviato/views/snippets/s_three_columns.xml
+++ b/theme_aviato/views/snippets/s_three_columns.xml
@@ -8,7 +8,7 @@
     </xpath>
     <!-- Column #01 -->
     <xpath expr="//*[hasclass('s_card')]" position="attributes">
-        <attribute name="style" add="--card-img-aspect-ratio: 132%" separator="; "/>
+        <attribute name="style" add="--card-img-aspect-ratio: 132%" separator=";"/>
     </xpath>
     <xpath expr="//figure" position="attributes">
         <attribute name="class" remove="ratio-16x9" add="o_card_img_ratio_custom" separator=" "/>
@@ -24,7 +24,7 @@
     </xpath>
     <!-- Column #02 -->
     <xpath expr="(//*[hasclass('s_card')])[2]" position="attributes">
-        <attribute name="style" add="--card-img-aspect-ratio: 132%" separator="; "/>
+        <attribute name="style" add="--card-img-aspect-ratio: 132%" separator=";"/>
     </xpath>
     <xpath expr="(//figure)[2]"  position="attributes">
         <attribute name="class" remove="ratio-16x9" add="o_card_img_ratio_custom" separator=" "/>
@@ -40,7 +40,7 @@
     </xpath>
     <!-- Column #03 -->
     <xpath expr="(//*[hasclass('s_card')])[3]" position="attributes">
-        <attribute name="style" add="--card-img-aspect-ratio: 132%" separator="; "/>
+        <attribute name="style" add="--card-img-aspect-ratio: 132%" separator=";"/>
     </xpath>
     <xpath expr="(//figure)[3]"  position="attributes">
         <attribute name="class" remove="ratio-16x9" add="o_card_img_ratio_custom" separator=" "/>

--- a/theme_beauty/views/snippets/s_cover.xml
+++ b/theme_beauty/views/snippets/s_cover.xml
@@ -8,7 +8,7 @@
     </xpath>
     <!-- Change position of background image -->
     <xpath expr="//span[hasclass('s_parallax_bg')]" position="attributes">
-        <attribute name="style" add="background-position: 50% 50%;" remove="background-position: 50% 0;" separator=";"/>
+        <attribute name="style" add="background-position: 50% 50%;" remove="background-position: 50% 75%;" separator=";"/>
     </xpath>
     <!-- Filter -->
     <xpath expr="//div[hasclass('o_we_bg_filter')]" position="attributes">

--- a/theme_bistro/views/snippets/s_cover.xml
+++ b/theme_bistro/views/snippets/s_cover.xml
@@ -4,7 +4,7 @@
 <template id="s_cover" inherit_id="website.s_cover">
     <!-- Parallax -->
     <xpath expr="//*[hasclass('s_parallax_bg')]" position="attributes">
-        <attribute name="style" add="background-position: 50% 100%;" remove="background-position: 50% 0;" separator=";"/>
+        <attribute name="style" add="background-position: 50% 100%;" remove="background-position: 50% 75%;" separator=";"/>
     </xpath>
     <!-- Title -->
     <xpath expr="//h1" position="replace" mode="inner">

--- a/theme_bistro/views/snippets/s_cover.xml
+++ b/theme_bistro/views/snippets/s_cover.xml
@@ -4,7 +4,7 @@
 <template id="s_cover" inherit_id="website.s_cover">
     <!-- Parallax -->
     <xpath expr="//*[hasclass('s_parallax_bg')]" position="attributes">
-        <attribute name="style" add="background-position: 50% 100%;" remove="background-position: 50% 0;" separator=" "/>
+        <attribute name="style" add="background-position: 50% 100%;" remove="background-position: 50% 0;" separator=";"/>
     </xpath>
     <!-- Title -->
     <xpath expr="//h1" position="replace" mode="inner">

--- a/theme_bistro/views/snippets/s_image_text.xml
+++ b/theme_bistro/views/snippets/s_image_text.xml
@@ -9,7 +9,7 @@
     <!-- Image -->
     <xpath expr="//img" position="attributes">
         <attribute name="class" add="img-thumbnail" separator=" "/>
-        <attribute name="style" add="padding: 20px !important;" separator=" "/>
+        <attribute name="style" add="padding: 20px !important;" separator=";"/>
     </xpath>
 </template>
 

--- a/theme_bookstore/views/snippets/s_masonry_block.xml
+++ b/theme_bookstore/views/snippets/s_masonry_block.xml
@@ -10,7 +10,7 @@
     <!-- Main div -->
     <xpath expr="//div[hasclass('col-lg-4')]" position="attributes">
         <attribute name="class" add="rounded" remove="rounded-4" separator=" "/>
-        <attribute name="style" remove="background-image: linear-gradient(135deg, var(--o-color-4) -400%, var(--o-color-2) 100%);" separator=" "/>
+        <attribute name="style" remove="background-image: linear-gradient(135deg, var(--o-color-4) -400%, var(--o-color-2) 100%);" separator=";"/>
     </xpath>
     <!-- Title -->
     <xpath expr="//div[hasclass('col-lg-4')]/h3" position="replace" mode="inner">
@@ -25,7 +25,7 @@
     <!-- Main div -->
     <xpath expr="//div[hasclass('col-lg-4')][2]" position="attributes">
         <attribute name="class" add="rounded" remove="rounded-4" separator=" "/>
-        <attribute name="style" remove="background-image: linear-gradient(135deg, var(--o-color-4) -400%, var(--o-color-1) 100%);" separator=" "/>
+        <attribute name="style" remove="background-image: linear-gradient(135deg, var(--o-color-4) -400%, var(--o-color-1) 100%);" separator=";"/>
     </xpath>
     <!-- Title -->
     <xpath expr="//div[hasclass('col-lg-4')][2]/h3" position="replace" mode="inner">

--- a/theme_bookstore/views/snippets/s_wavy_grid.xml
+++ b/theme_bookstore/views/snippets/s_wavy_grid.xml
@@ -10,16 +10,16 @@
         <div class="o_we_shape o_web_editor_Blobs_09"/>
     </xpath>
     <xpath expr="//h3" position="attributes">
-        <attribute name="class" add="h4-fs" remove="h5-fs"/>
+        <attribute name="class" add="h4-fs" remove="h5-fs" separator=" "/>
     </xpath>
     <xpath expr="(//h3)[2]" position="attributes">
-        <attribute name="class" add="h4-fs" remove="h5-fs"/>
+        <attribute name="class" add="h4-fs" remove="h5-fs" separator=" "/>
     </xpath>
     <xpath expr="(//h3)[3]" position="attributes">
-        <attribute name="class" add="h4-fs" remove="h5-fs"/>
+        <attribute name="class" add="h4-fs" remove="h5-fs" separator=" "/>
     </xpath>
     <xpath expr="(//h3)[4]" position="attributes">
-        <attribute name="class" add="h4-fs" remove="h5-fs"/>
+        <attribute name="class" add="h4-fs" remove="h5-fs" separator=" "/>
     </xpath>
 
     <!-- Texts -->

--- a/theme_buzzy/views/snippets/s_big_number.xml
+++ b/theme_buzzy/views/snippets/s_big_number.xml
@@ -18,7 +18,7 @@
         90%
     </xpath>
     <xpath expr="//h2/following-sibling::div" position="attributes">
-        <attribute name="style" add="font-size: 7.75rem;" remove="font-size: 10.75rem;" separator=";"/>
+        <attribute name="style" add="font-size: 7.75rem;" remove="font-size: 2.25rem;" separator=";"/>
     </xpath>
 </template>
 

--- a/theme_buzzy/views/snippets/s_quotes_carousel.xml
+++ b/theme_buzzy/views/snippets/s_quotes_carousel.xml
@@ -23,13 +23,13 @@
     </xpath>
     <!-- Authors -->
     <xpath expr="(//div[hasclass('s_blockquote_author')])[1]//span//span" position="attributes">
-        <attribute name="class" add="text-o-color-2" remove="text-muted"/>
+        <attribute name="class" add="text-o-color-2" remove="text-muted" separator=" "/>
     </xpath>
     <xpath expr="(//div[hasclass('s_blockquote_author')])[2]//span//span" position="attributes">
-        <attribute name="class" add="text-o-color-2" remove="text-muted"/>
+        <attribute name="class" add="text-o-color-2" remove="text-muted" separator=" "/>
     </xpath>
     <xpath expr="(//div[hasclass('s_blockquote_author')])[3]//span//span" position="attributes">
-        <attribute name="class" add="text-o-color-2" remove="text-muted"/>
+        <attribute name="class" add="text-o-color-2" remove="text-muted" separator=" "/>
     </xpath>
 </template>
 

--- a/theme_clean/views/snippets/s_banner.xml
+++ b/theme_clean/views/snippets/s_banner.xml
@@ -12,7 +12,7 @@
     <!-- Image Layout -->
     <xpath expr="//div[hasclass('o_grid_item_image')]" position="attributes">
         <attribute name="class" add="g-col-lg-6 col-lg-6" remove="o_grid_item g-col-lg-4 col-lg-4" separator=" "/>
-        <attribute name="style" add="grid-area: 1 / 7 / 11 / 13;" remove="grid-area: 1 / 8 / 11 / 12;" separator=" "/>
+        <attribute name="style" add="grid-area: 1 / 7 / 11 / 13;" remove="grid-area: 1 / 8 / 11 / 12;" separator=";"/>
     </xpath>
     <!-- Img -->
     <xpath expr="//img" position="attributes">

--- a/theme_clean/views/snippets/s_big_number.xml
+++ b/theme_clean/views/snippets/s_big_number.xml
@@ -18,7 +18,7 @@
         90%
     </xpath>
     <xpath expr="//h2/following-sibling::div" position="attributes">
-        <attribute name="style" add="font-size: 7.75rem;" remove="font-size: 10.75rem;" separator=";"/>
+        <attribute name="style" add="font-size: 7.75rem;" remove="font-size: 2.25rem;" separator=";"/>
     </xpath>
 </template>
 

--- a/theme_clean/views/snippets/s_carousel.xml
+++ b/theme_clean/views/snippets/s_carousel.xml
@@ -35,7 +35,7 @@
 
     <!-- Background -->
     <xpath expr="//div[hasclass('carousel-item')]" position="attributes">
-        <attribute name="style" add="background-position: 50% 10%;" separator=" "/>
+        <attribute name="style" add="background-position: 50% 10%;" separator=";"/>
     </xpath>
 </template>
 

--- a/theme_cobalt/views/customizations.xml
+++ b/theme_cobalt/views/customizations.xml
@@ -526,7 +526,7 @@
         90%
     </xpath>
     <xpath expr="//h2/following-sibling::div" position="attributes">
-        <attribute name="style" add="font-size: 7.75rem;" remove="font-size: 10.75rem;" separator=";"/>
+        <attribute name="style" add="font-size: 7.75rem;" remove="font-size: 2.25rem;" separator=";"/>
     </xpath>
 </template>
 

--- a/theme_enark/views/snippets/s_cta_box.xml
+++ b/theme_enark/views/snippets/s_cta_box.xml
@@ -9,7 +9,7 @@
     <!-- Card -->
     <xpath expr="//div[hasclass('card')]" position="attributes">
         <attribute name="class" add="o_cc5" remove="o_cc4" separator=" "/>
-        <attribute name="style" add="border-radius: 0px !important;" separator=" "/>
+        <attribute name="style" add="border-radius: 0px !important;" separator=";"/>
     </xpath>
     <!-- Title -->
     <xpath expr="//h2" position="replace" mode="inner">

--- a/theme_enark/views/snippets/s_text_image.xml
+++ b/theme_enark/views/snippets/s_text_image.xml
@@ -9,7 +9,7 @@
     <!-- Wrapper -->
     <xpath expr="//div[hasclass('col-lg-5')]" position="attributes">        
         <attribute name="class" add="border" separator=" "/>
-        <attribute name="style" add="padding:24px; border-width: 1px !important; border-color: rgb(70, 77, 83) !important; border-radius: 4px !important;"/>
+        <attribute name="style" add="padding:24px; border-width: 1px !important; border-color: rgb(70, 77, 83) !important; border-radius: 4px !important;" separator=";"/>
     </xpath>
     <xpath expr="//div[hasclass('col-lg-6')]" position="attributes">
         <attribute name="class" add="col-lg-5" remove="col-lg-6" separator=" "/>

--- a/theme_graphene/views/customizations.xml
+++ b/theme_graphene/views/customizations.xml
@@ -213,7 +213,7 @@
         <attribute name="class" add="col-lg-8" remove="col-lg-9" separator=" "/>
     </xpath>
     <xpath expr="//div[hasclass('col-lg-8')]/p" position="attributes">
-        <attribute name="style" add="text-align: right;" separator=" "/>
+        <attribute name="style" add="text-align: right;" separator=";"/>
     </xpath>
 </template>
 

--- a/theme_graphene/views/customizations.xml
+++ b/theme_graphene/views/customizations.xml
@@ -591,7 +591,7 @@
         90%
     </xpath>
     <xpath expr="//h2/following-sibling::div" position="attributes">
-        <attribute name="style" add="font-size: 7.75rem;" remove="font-size: 10.75rem;" separator=";"/>
+        <attribute name="style" add="font-size: 7.75rem;" remove="font-size: 2.25rem;" separator=";"/>
     </xpath>
 </template>
 

--- a/theme_graphene/views/new_page_template.xml
+++ b/theme_graphene/views/new_page_template.xml
@@ -99,7 +99,7 @@
 <template id="new_page_template_about_personal_s_numbers" inherit_id="website.new_page_template_about_personal_s_numbers">
     <xpath expr="//section" position="attributes">
         <attribute name="class" add="o_cc5" remove="o_cc3 parallax pt0" separator=" "/>
-        <attribute name="style" remove="background-image: none;" separator=" "/>
+        <attribute name="style" remove="background-image: none;" separator=";"/>
     </xpath>
     <xpath expr="//div" position="attributes">
         <attribute name="class" remove="bg-black-75" separator=" "/>

--- a/theme_kea/views/snippets/s_framed_intro.xml
+++ b/theme_kea/views/snippets/s_framed_intro.xml
@@ -4,7 +4,7 @@
 <template id="s_framed_intro" inherit_id="website.s_framed_intro">
     <!-- Image -->
     <xpath expr="//div[hasclass('col-lg-5')]" position="attributes">
-        <attribute name="style" add="border-radius: 8px !important;" separator=" "/>
+        <attribute name="style" add="border-radius: 8px !important;" separator=";"/>
     </xpath>
     <xpath expr="//img" position="attributes">
         <attribute name="class" add="rounded" separator=" "/>

--- a/theme_kea/views/snippets/s_picture.xml
+++ b/theme_kea/views/snippets/s_picture.xml
@@ -22,7 +22,7 @@
         Put yourself at the center of an extraordinary gaming universe with exclusive games.
     </xpath>
     <xpath expr="//p" position="attributes">
-        <attribute name="style" add="text-align: center;" separator=" "/>
+        <attribute name="style" add="text-align: center;" separator=";"/>
     </xpath>
     <!-- Caption -->
     <xpath expr="//figcaption" position="replace">

--- a/theme_kea/views/snippets/s_picture.xml
+++ b/theme_kea/views/snippets/s_picture.xml
@@ -21,9 +21,6 @@
     <xpath expr="//p" position="replace" mode="inner">
         Put yourself at the center of an extraordinary gaming universe with exclusive games.
     </xpath>
-    <xpath expr="//p" position="attributes">
-        <attribute name="style" add="text-align: center;" separator=";"/>
-    </xpath>
     <!-- Caption -->
     <xpath expr="//figcaption" position="replace">
         <figcaption class="figure-caption text-muted py-3">Watch as a living game world comes alive all around you, with a seamless field of view wherever you look.</figcaption>

--- a/theme_kiddo/views/snippets/s_framed_intro.xml
+++ b/theme_kiddo/views/snippets/s_framed_intro.xml
@@ -8,7 +8,7 @@
     </xpath>
     <!-- Image -->
     <xpath expr="//div[hasclass('col-lg-5')]" position="attributes">
-        <attribute name="style" add="border-radius: 8px !important;" separator=" "/>
+        <attribute name="style" add="border-radius: 8px !important;" separator=";"/>
     </xpath>
     <xpath expr="//img" position="attributes">
         <attribute name="class" add="rounded" separator=" "/>

--- a/theme_monglia/views/new_page_template.xml
+++ b/theme_monglia/views/new_page_template.xml
@@ -108,7 +108,7 @@
         <attribute name="class" add="pt40" remove="pt0" separator=" "/>
     </xpath>
     <xpath expr="//p" position="attributes">
-        <attribute name="style" remove="font-size:36px;" separator=" "/>
+        <attribute name="style" remove="font-size:36px;" separator=";"/>
     </xpath>
 </template>
 

--- a/theme_nano/views/snippets/s_framed_intro.xml
+++ b/theme_nano/views/snippets/s_framed_intro.xml
@@ -8,7 +8,7 @@
     </xpath>
     <!-- Image -->
     <xpath expr="//div[hasclass('col-lg-5')]" position="attributes">
-        <attribute name="style" add="border-radius: 8px !important;" separator=" "/>
+        <attribute name="style" add="border-radius: 8px !important;" separator=";"/>
     </xpath>
     <xpath expr="//img" position="attributes">
         <attribute name="class" add="rounded" separator=" "/>

--- a/theme_notes/views/snippets/s_cards_grid.xml
+++ b/theme_notes/views/snippets/s_cards_grid.xml
@@ -13,7 +13,7 @@
         <!-- Card 1 -->
         <xpath expr="(//div[hasclass('s_card')])[1]" position="attributes">
             <attribute name="class" add="border" separator=" "/>
-            <attribute name="style" add="border-width: 0px !important;" separator=" "/>
+            <attribute name="style" add="border-width: 0px !important;" separator=";"/>
         </xpath>
         <xpath expr="(//h5)[1]" position="replace" mode="inner">
             Engaging Social Activities
@@ -24,7 +24,7 @@
         <!-- Card 2 -->
         <xpath expr="(//div[hasclass('s_card')])[2]" position="attributes">
             <attribute name="class" add="border" separator=" "/>
-            <attribute name="style" add="border-width: 0px !important;" separator=" "/>
+            <attribute name="style" add="border-width: 0px !important;" separator=";"/>
         </xpath>
         <xpath expr="(//h5)[2]" position="replace" mode="inner">
             Incredible Lineup of Artists
@@ -35,7 +35,7 @@
         <!-- Card 3 -->
         <xpath expr="(//div[hasclass('s_card')])[3]" position="attributes">
             <attribute name="class" add="border" separator=" "/>
-            <attribute name="style" add="border-width: 0px !important;" separator=" "/>
+            <attribute name="style" add="border-width: 0px !important;" separator=";"/>
         </xpath>
         <xpath expr="(//h5)[3]" position="replace" mode="inner">
             Exclusive Festival Merchandise
@@ -46,7 +46,7 @@
         <!-- Card 4 -->
         <xpath expr="(//div[hasclass('s_card')])[4]" position="attributes">
             <attribute name="class" add="border" separator=" "/>
-            <attribute name="style" add="border-width: 0px !important;" separator=" "/>
+            <attribute name="style" add="border-width: 0px !important;" separator=";"/>
         </xpath>
         <xpath expr="(//h5)[4]" position="replace" mode="inner">
             High-Quality Music Experience

--- a/theme_notes/views/snippets/s_wavy_grid.xml
+++ b/theme_notes/views/snippets/s_wavy_grid.xml
@@ -4,7 +4,7 @@
 <template id="s_wavy_grid" inherit_id="website.s_wavy_grid">
     <!-- Layout -->
     <xpath expr="//section" position="attributes">
-        <attribute name="class" add="o_cc o_cc5"/>
+        <attribute name="class" add="o_cc o_cc5" separator=" "/>
         <attribute name="data-oe-shape-data">{'shape':'web_editor/Wavy/10','colors':{'c1':'o-color-1','c2':'o-color-1'},'flip':[],'showOnMobile':false,'shapeAnimationSpeed':'0'}</attribute>
     </xpath>
     <xpath expr="//div[hasclass('o_we_shape')]" position="replace">

--- a/theme_odoo_experts/views/snippets/s_wavy_grid.xml
+++ b/theme_odoo_experts/views/snippets/s_wavy_grid.xml
@@ -3,7 +3,7 @@
 
 <template id="s_wavy_grid" inherit_id="website.s_wavy_grid">
     <xpath expr="//section" position="attributes">
-        <attribute name="class" add="o_cc o_cc2"/>
+        <attribute name="class" add="o_cc o_cc2" separator=" "/>
         <attribute name="data-oe-shape-data">{'shape':'web_editor/Origins/04_001','colors':{'c3':'o-color-1'},'flip':[],'showOnMobile':false,'shapeAnimationSpeed':'0'}</attribute>
     </xpath>
     <xpath expr="//div[hasclass('o_we_shape')]" position="replace">

--- a/theme_paptic/views/customizations.xml
+++ b/theme_paptic/views/customizations.xml
@@ -757,7 +757,7 @@
 <!-- ===== WAVY GRID ======== -->
 <template id="s_wavy_grid" inherit_id="website.s_wavy_grid">
     <xpath expr="//section" position="attributes">
-        <attribute name="class" add="o_cc o_cc3"/>
+        <attribute name="class" add="o_cc o_cc3" separator=" "/>
         <attribute name="data-oe-shape-data"/>
     </xpath>
     <xpath expr="//div[hasclass('o_we_shape')]" position="replace"/>
@@ -785,22 +785,22 @@
     <!-- Card 1 -->
     <xpath expr="(//div[hasclass('s_card')])[1]" position="attributes">
         <attribute name="class" add="border" separator=" "/>
-        <attribute name="style" add="border-width: 0px !important;" separator=" "/>
+        <attribute name="style" add="border-width: 0px !important;" separator=";"/>
     </xpath>
     <!-- Card 2 -->
     <xpath expr="(//div[hasclass('s_card')])[2]" position="attributes">
         <attribute name="class" add="border" separator=" "/>
-        <attribute name="style" add="border-width: 0px !important;" separator=" "/>
+        <attribute name="style" add="border-width: 0px !important;" separator=";"/>
     </xpath>
     <!-- Card 3 -->
     <xpath expr="(//div[hasclass('s_card')])[3]" position="attributes">
         <attribute name="class" add="border" separator=" "/>
-        <attribute name="style" add="border-width: 0px !important;" separator=" "/>
+        <attribute name="style" add="border-width: 0px !important;" separator=";"/>
     </xpath>
     <!-- Card 4 -->
     <xpath expr="(//div[hasclass('s_card')])[4]" position="attributes">
         <attribute name="class" add="border" separator=" "/>
-        <attribute name="style" add="border-width: 0px !important;" separator=" "/>
+        <attribute name="style" add="border-width: 0px !important;" separator=";"/>
     </xpath>
 </template>
 

--- a/theme_real_estate/views/snippets/s_wavy_grid.xml
+++ b/theme_real_estate/views/snippets/s_wavy_grid.xml
@@ -4,7 +4,7 @@
 <template id="s_wavy_grid" inherit_id="website.s_wavy_grid">
     <!-- Layout -->
     <xpath expr="//section" position="attributes">
-        <attribute name="class" add="o_cc o_cc2"/>
+        <attribute name="class" add="o_cc o_cc2" separator=" "/>
         <attribute name="data-oe-shape-data">{'shape':'web_editor/Origins/09_001','colors':{'c3':'o-color-4'},'flip':[],'showOnMobile':false,'shapeAnimationSpeed':'0'}</attribute>
     </xpath>
     <xpath expr="//div[hasclass('o_we_shape')]" position="replace">

--- a/theme_treehouse/views/snippets/s_image_text.xml
+++ b/theme_treehouse/views/snippets/s_image_text.xml
@@ -5,7 +5,7 @@
     <!-- Image -->
     <xpath expr="//img" position="attributes">
         <attribute name="class" add="img-thumbnail" separator=" "/>
-        <attribute name="style" add="padding: 15px;" separator=" "/>
+        <attribute name="style" add="padding: 15px;" separator=";"/>
     </xpath>
     <xpath expr="//p[2]" position="after">
         <p><br/></p>

--- a/theme_treehouse/views/snippets/s_text_cover.xml
+++ b/theme_treehouse/views/snippets/s_text_cover.xml
@@ -3,7 +3,7 @@
 
 <template id="s_text_cover" inherit_id="website.s_text_cover">
     <xpath expr="//div[hasclass('col-lg-6')][1]" position="attributes">
-        <attribute name="style" add="grid-area: 2 / 3 / 11 / 9;" remove="grid-area: 2 / 3 / 11 / 8;" separator="; "/>
+        <attribute name="style" add="grid-area: 2 / 3 / 11 / 9;" remove="grid-area: 2 / 3 / 11 / 8;" separator=";"/>
         <attribute name="class" add="g-col-lg-6" remove="g-col-lg-5" separator=" "/>
     </xpath>
     <!-- Title -->

--- a/theme_vehicle/views/customizations.xml
+++ b/theme_vehicle/views/customizations.xml
@@ -197,13 +197,13 @@
         <b>50,000 pre-orders</b> already registered.
     </xpath>
     <xpath expr="//h3" position="attributes">
-        <attribute name="style" add="text-align: left;" separator=" "/>
+        <attribute name="style" add="text-align: left;" separator=";"/>
     </xpath>
     <xpath expr="//p" position="replace" mode="inner">
         Join the early joiners or request for a trial on track.
     </xpath>
     <xpath expr="//p" position="attributes">
-        <attribute name="style" add="text-align: left;" separator=" "/>
+        <attribute name="style" add="text-align: left;" separator=";"/>
     </xpath>
     <xpath expr="//a" position="attributes">
         <attribute name="class" remove="btn-lg" separator=" "/>

--- a/theme_yes/views/snippets/s_popup.xml
+++ b/theme_yes/views/snippets/s_popup.xml
@@ -16,7 +16,7 @@
     </xpath>
     <!-- Close Button -->
     <xpath expr="//*[hasclass('s_popup_close')]" position="attributes">
-        <attribute name="style" add="border-radius: 0 4px 0 4px" separator="; "/>
+        <attribute name="style" add="border-radius: 0 4px 0 4px" separator=";"/>
     </xpath>
 </template>
 

--- a/theme_yes/views/snippets/s_quotes_carousel.xml
+++ b/theme_yes/views/snippets/s_quotes_carousel.xml
@@ -7,7 +7,7 @@
     </xpath>
     <!-- Quote 1 -->
     <xpath expr="//div[hasclass('carousel-item')]" position="attributes">
-        <attribute name="style" add="background-image: url('/web/image/website.s_quotes_carousel_demo_image_0'); background-position: 50% 25%;" separator="; "/>
+        <attribute name="style" add="background-image: url('/web/image/website.s_quotes_carousel_demo_image_0'); background-position: 50% 25%;" separator=";"/>
     </xpath>
     <xpath expr="//blockquote" position="before">
         <div class="o_we_bg_filter" style="background-color: rgba(25, 41, 37, 0.55) !important;"/>
@@ -23,7 +23,7 @@
     </xpath>
     <!-- Quote 2 -->
     <xpath expr="(//*[hasclass('carousel-item')])[2]" position="attributes">
-        <attribute name="style" add="background-position: 50% 25%;" remove="background-position: 50% 50%;" separator="; "/>
+        <attribute name="style" add="background-position: 50% 25%;" remove="background-position: 50% 50%;" separator=";"/>
     </xpath>
     <xpath expr="(//blockquote)[2]" position="before">
         <div class="o_we_bg_filter" style="background-color: rgba(25, 41, 37, 0.55) !important;"/>
@@ -36,7 +36,7 @@
     </xpath>
     <!-- Quote 3 -->
     <xpath expr="(//*[hasclass('carousel-item')])[3]" position="attributes">
-        <attribute name="style" add="background-position: 50% 20%;" remove="background-position: 50% 50%;" separator="; "/>
+        <attribute name="style" add="background-position: 50% 20%;" remove="background-position: 50% 50%;" separator=";"/>
     </xpath>
     <xpath expr="(//blockquote)[3]" position="before">
         <div class="o_we_bg_filter" style="background-color: rgba(25, 41, 37, 0.55) !important;"/>

--- a/theme_yes/views/snippets/s_quotes_carousel.xml
+++ b/theme_yes/views/snippets/s_quotes_carousel.xml
@@ -7,7 +7,7 @@
     </xpath>
     <!-- Quote 1 -->
     <xpath expr="//div[hasclass('carousel-item')]" position="attributes">
-        <attribute name="style" add="background-image: url('/web/image/website.s_quotes_carousel_demo_image_0'); background-position: 50% 25%;" separator=";"/>
+        <attribute name="style" remove="background-position: 50% 50%;" add="background-position: 50% 25%;" separator=";"/>
     </xpath>
     <xpath expr="//blockquote" position="before">
         <div class="o_we_bg_filter" style="background-color: rgba(25, 41, 37, 0.55) !important;"/>

--- a/theme_zap/views/snippets/s_features.xml
+++ b/theme_zap/views/snippets/s_features.xml
@@ -9,7 +9,7 @@
     <!-- Column #01 -->
     <xpath expr="//*[hasclass('row')]/*[1]" position="attributes">
         <attribute name="class" add="o_cc o_cc1 pt32 pb32 rounded text-center" separator=" "/>
-        <attribute name="style" add="box-shadow: rgba(0, 0, 0, 0.15) 0px 2px 4px 0px !important;" separator=" "/>
+        <attribute name="style" add="box-shadow: rgba(0, 0, 0, 0.15) 0px 2px 4px 0px !important;" separator=";"/>
     </xpath>
     <xpath expr="//div[hasclass('row')]/div[1]/div[hasclass('s_hr')]" position="replace"/>
     <xpath expr="//i" position="replace">
@@ -24,7 +24,7 @@
     <!-- Column #02 -->
     <xpath expr="//*[hasclass('row')]/*[2]" position="attributes">
         <attribute name="class" add="o_cc o_cc1 pt32 pb32 rounded text-center" separator=" "/>
-        <attribute name="style" add="box-shadow: rgba(0, 0, 0, 0.15) 0px 2px 4px 0px !important;" separator=" "/>
+        <attribute name="style" add="box-shadow: rgba(0, 0, 0, 0.15) 0px 2px 4px 0px !important;" separator=";"/>
     </xpath>
     <xpath expr="//div[hasclass('row')]/div[2]/div[hasclass('s_hr')]" position="replace"/>
     <xpath expr="(//i)[2]" position="replace">
@@ -39,7 +39,7 @@
     <!-- Column #03 -->
     <xpath expr="//*[hasclass('row')]/*[3]" position="attributes">
         <attribute name="class" add="o_cc o_cc1 pt32 pb32 rounded text-center" separator=" "/>
-        <attribute name="style" add="box-shadow: rgba(0, 0, 0, 0.15) 0px 2px 4px 0px !important;" separator=" "/>
+        <attribute name="style" add="box-shadow: rgba(0, 0, 0, 0.15) 0px 2px 4px 0px !important;" separator=";"/>
     </xpath>
     <xpath expr="//div[hasclass('row')]/div[3]/div[hasclass('s_hr')]" position="replace"/>
     <xpath expr="(//i)[3]" position="replace">

--- a/theme_zap/views/snippets/s_image_text.xml
+++ b/theme_zap/views/snippets/s_image_text.xml
@@ -9,7 +9,7 @@
     <!-- Image -->
     <xpath expr="//img" position="attributes">
         <attribute name="class" add="img-thumbnail" separator=" "/>
-        <attribute name="style" add="padding: 15px;" separator=" "/>
+        <attribute name="style" add="padding: 15px;" separator=";"/>
     </xpath>
     <xpath expr="//p[2]" position="after">
         <p><br/></p>

--- a/theme_zap/views/snippets/s_masonry_block.xml
+++ b/theme_zap/views/snippets/s_masonry_block.xml
@@ -33,7 +33,7 @@
     <xpath expr="//*[hasclass('col-lg-3')][2]" position="replace" mode="inner"/>
 
     <xpath expr="//*[hasclass('col-lg-3')][2]" position="attributes">
-        <attribute name="style" add="background-image:url(/web/image/website.s_masonry_block_default_image_2)" separator="; "/>
+        <attribute name="style" add="background-image:url(/web/image/website.s_masonry_block_default_image_2)" separator=";"/>
         <attribute name="class" add="oe_img_bg o_bg_img_center" separator=" "/>
     </xpath>
 </template>

--- a/theme_zap/views/snippets/s_media_list.xml
+++ b/theme_zap/views/snippets/s_media_list.xml
@@ -5,15 +5,15 @@
     <!-- Items -->
     <xpath expr="//*[hasclass('s_media_list_item')][1]/div" position="attributes">
         <attribute name="class" add="rounded" separator=" "/>
-        <attribute name="style" add="box-shadow: rgba(0, 0, 0, 0.15) 0px 2px 4px 0px !important;"/>
+        <attribute name="style" add="box-shadow: rgba(0, 0, 0, 0.15) 0px 2px 4px 0px !important;" separator=";"/>
     </xpath>
     <xpath expr="//*[hasclass('s_media_list_item')][2]/div" position="attributes">
         <attribute name="class" add="rounded" separator=" "/>
-        <attribute name="style" add="box-shadow: rgba(0, 0, 0, 0.15) 0px 2px 4px 0px !important;"/>
+        <attribute name="style" add="box-shadow: rgba(0, 0, 0, 0.15) 0px 2px 4px 0px !important;" separator=";"/>
     </xpath>
     <xpath expr="//*[hasclass('s_media_list_item')][3]/div" position="attributes">
         <attribute name="class" add="rounded" separator=" "/>
-        <attribute name="style" add="box-shadow: rgba(0, 0, 0, 0.15) 0px 2px 4px 0px !important;"/>
+        <attribute name="style" add="box-shadow: rgba(0, 0, 0, 0.15) 0px 2px 4px 0px !important;" separator=";"/>
     </xpath>
 </template>
 

--- a/theme_zap/views/snippets/s_numbers.xml
+++ b/theme_zap/views/snippets/s_numbers.xml
@@ -9,7 +9,7 @@
     <!-- Column #2 -->
     <xpath expr="(//div[hasclass('col-lg-4')])[2]" position="attributes">
         <attribute name="class" add="o_cc o_cc1 rounded pt64 pb64" remove="pt24 pb24" separator=" "/>
-        <attribute name="style" add="box-shadow: rgba(0, 0, 0, 0.15) 0px 2px 4px 0px !important;" separator=" "/>
+        <attribute name="style" add="box-shadow: rgba(0, 0, 0, 0.15) 0px 2px 4px 0px !important;" separator=";"/>
     </xpath>
     <xpath expr="//span[hasclass('h5-fs')]" position="replace" mode="inner">
         <font class="text-o-color-1">Solutions</font>
@@ -17,7 +17,7 @@
     <!-- Column #3 -->
     <xpath expr="(//div[hasclass('col-lg-4')])[3]" position="attributes">
         <attribute name="class" add="o_cc o_cc1 rounded pt64 pb64" remove="pt24 pb24" separator=" "/>
-        <attribute name="style" add="box-shadow: rgba(0, 0, 0, 0.15) 0px 2px 4px 0px !important;" separator=" "/>
+        <attribute name="style" add="box-shadow: rgba(0, 0, 0, 0.15) 0px 2px 4px 0px !important;" separator=";"/>
     </xpath>
     <xpath expr="(//span[hasclass('s_number')])[2]" position="replace" mode="inner">
         98%
@@ -28,7 +28,7 @@
     <!-- Column #4 -->
     <xpath expr="(//div[hasclass('col-lg-4')])[4]" position="attributes">
         <attribute name="class" add="o_cc o_cc1 rounded pt64 pb64" remove="pt24 pb24" separator=" "/>
-        <attribute name="style" add="box-shadow: rgba(0, 0, 0, 0.15) 0px 2px 4px 0px !important;" separator=" "/>
+        <attribute name="style" add="box-shadow: rgba(0, 0, 0, 0.15) 0px 2px 4px 0px !important;" separator=";"/>
     </xpath>
     <xpath expr="(//span[hasclass('h5-fs')])[3]" position="replace" mode="inner">
         <font class="text-o-color-1">Languages</font>

--- a/theme_zap/views/snippets/s_references.xml
+++ b/theme_zap/views/snippets/s_references.xml
@@ -17,32 +17,32 @@
     <!-- Column #01 -->
     <xpath expr="//div[hasclass('col-lg-2')][1]" position="attributes">
         <attribute name="class" add="o_cc o_cc1 rounded pt48 pb48" remove="pt16 pb16" separator=" "/>
-        <attribute name="style" add="box-shadow: rgba(0, 0, 0, 0.15) 0px 2px 4px 0px !important;" separator=" "/>
+        <attribute name="style" add="box-shadow: rgba(0, 0, 0, 0.15) 0px 2px 4px 0px !important;" separator=";"/>
     </xpath>
     <!-- Column #02 -->
     <xpath expr="//div[hasclass('col-lg-2')][2]" position="attributes">
         <attribute name="class" add="o_cc o_cc1 rounded pt48 pb48" remove="pt16 pb16" separator=" "/>
-        <attribute name="style" add="box-shadow: rgba(0, 0, 0, 0.15) 0px 2px 4px 0px !important;" separator=" "/>
+        <attribute name="style" add="box-shadow: rgba(0, 0, 0, 0.15) 0px 2px 4px 0px !important;" separator=";"/>
     </xpath>
     <!-- Column #03 -->
     <xpath expr="//div[hasclass('col-lg-2')][3]" position="attributes">
         <attribute name="class" add="o_cc o_cc1 rounded pt48 pb48" remove="pt16 pb16" separator=" "/>
-        <attribute name="style" add="box-shadow: rgba(0, 0, 0, 0.15) 0px 2px 4px 0px !important;" separator=" "/>
+        <attribute name="style" add="box-shadow: rgba(0, 0, 0, 0.15) 0px 2px 4px 0px !important;" separator=";"/>
     </xpath>
     <!-- Column #04 -->
     <xpath expr="//div[hasclass('col-lg-2')][4]" position="attributes">
         <attribute name="class" add="o_cc o_cc1 rounded pt48 pb48" remove="pt16 pb16" separator=" "/>
-        <attribute name="style" add="box-shadow: rgba(0, 0, 0, 0.15) 0px 2px 4px 0px !important;" separator=" "/>
+        <attribute name="style" add="box-shadow: rgba(0, 0, 0, 0.15) 0px 2px 4px 0px !important;" separator=";"/>
     </xpath>
     <!-- Column #05 -->
     <xpath expr="//div[hasclass('col-lg-2')][5]" position="attributes">
         <attribute name="class" add="o_cc o_cc1 rounded pt48 pb48" remove="pt16 pb16" separator=" "/>
-        <attribute name="style" add="box-shadow: rgba(0, 0, 0, 0.15) 0px 2px 4px 0px !important;" separator=" "/>
+        <attribute name="style" add="box-shadow: rgba(0, 0, 0, 0.15) 0px 2px 4px 0px !important;" separator=";"/>
     </xpath>
     <!-- Column #06 -->
     <xpath expr="//div[hasclass('col-lg-2')][6]" position="attributes">
         <attribute name="class" add="o_cc o_cc1 rounded pt48 pb48" remove="pt16 pb16" separator=" "/>
-        <attribute name="style" add="box-shadow: rgba(0, 0, 0, 0.15) 0px 2px 4px 0px !important;" separator=" "/>
+        <attribute name="style" add="box-shadow: rgba(0, 0, 0, 0.15) 0px 2px 4px 0px !important;" separator=";"/>
     </xpath>
 </template>
 

--- a/theme_zap/views/snippets/s_references_grid.xml
+++ b/theme_zap/views/snippets/s_references_grid.xml
@@ -8,7 +8,7 @@
     </xpath>
     <!-- Grid gap -->
     <xpath expr="//div[hasclass('o_grid_mode')]" position="attributes">
-        <attribute name="style" add="gap: 8px;" separator=" "/>
+        <attribute name="style" add="gap: 8px;" separator=";"/>
     </xpath>
     <!-- Title -->
     <xpath expr="//h2" position="replace" mode="inner">
@@ -17,32 +17,32 @@
     <!-- Column #01 -->
     <xpath expr="//div[hasclass('col-lg-2')][1]" position="attributes">
         <attribute name="class" add="o_cc o_cc1" separator=" "/>
-        <attribute name="style" add="box-shadow: rgba(0, 0, 0, 0.15) 0px 2px 2px 0px !important;" separator=" "/>
+        <attribute name="style" add="box-shadow: rgba(0, 0, 0, 0.15) 0px 2px 2px 0px !important;" separator=";"/>
     </xpath>
     <!-- Column #02 -->
     <xpath expr="//div[hasclass('col-lg-2')][2]" position="attributes">
         <attribute name="class" add="o_cc o_cc1" separator=" "/>
-        <attribute name="style" add="box-shadow: rgba(0, 0, 0, 0.15) 0px 2px 2px 0px !important;" separator=" "/>
+        <attribute name="style" add="box-shadow: rgba(0, 0, 0, 0.15) 0px 2px 2px 0px !important;" separator=";"/>
     </xpath>
     <!-- Column #03 -->
     <xpath expr="//div[hasclass('col-lg-2')][3]" position="attributes">
         <attribute name="class" add="o_cc o_cc1" separator=" "/>
-        <attribute name="style" add="box-shadow: rgba(0, 0, 0, 0.15) 0px 2px 2px 0px !important;" separator=" "/>
+        <attribute name="style" add="box-shadow: rgba(0, 0, 0, 0.15) 0px 2px 2px 0px !important;" separator=";"/>
     </xpath>
     <!-- Column #04 -->
     <xpath expr="//div[hasclass('col-lg-2')][4]" position="attributes">
         <attribute name="class" add="o_cc o_cc1" separator=" "/>
-        <attribute name="style" add="box-shadow: rgba(0, 0, 0, 0.15) 0px 2px 2px 0px !important;" separator=" "/>
+        <attribute name="style" add="box-shadow: rgba(0, 0, 0, 0.15) 0px 2px 2px 0px !important;" separator=";"/>
     </xpath>
     <!-- Column #05 -->
     <xpath expr="//div[hasclass('col-lg-2')][5]" position="attributes">
         <attribute name="class" add="o_cc o_cc1" separator=" "/>
-        <attribute name="style" add="box-shadow: rgba(0, 0, 0, 0.15) 0px 2px 2px 0px !important;" separator=" "/>
+        <attribute name="style" add="box-shadow: rgba(0, 0, 0, 0.15) 0px 2px 2px 0px !important;" separator=";"/>
     </xpath>
     <!-- Column #06 -->
     <xpath expr="//div[hasclass('col-lg-2')][6]" position="attributes">
         <attribute name="class" add="o_cc o_cc1" separator=" "/>
-        <attribute name="style" add="box-shadow: rgba(0, 0, 0, 0.15) 0px 2px 2px 0px !important;" separator=" "/>
+        <attribute name="style" add="box-shadow: rgba(0, 0, 0, 0.15) 0px 2px 2px 0px !important;" separator=";"/>
     </xpath>
 </template>
 

--- a/theme_zap/views/snippets/s_references_social.xml
+++ b/theme_zap/views/snippets/s_references_social.xml
@@ -9,22 +9,22 @@
     <!-- Column #01 -->
     <xpath expr="//div[hasclass('row')]/div[2]" position="attributes">
         <attribute name="class" add="o_cc o_cc1" separator=" "/>
-        <attribute name="style" add="box-shadow: rgba(0, 0, 0, 0.15) 0px 2px 4px 0px !important;" separator=" "/>
+        <attribute name="style" add="box-shadow: rgba(0, 0, 0, 0.15) 0px 2px 4px 0px !important;" separator=";"/>
     </xpath>
     <!-- Column #02 -->
     <xpath expr="//div[hasclass('row')]/div[3]" position="attributes">
         <attribute name="class" add="o_cc o_cc1" separator=" "/>
-        <attribute name="style" add="box-shadow: rgba(0, 0, 0, 0.15) 0px 2px 4px 0px !important;" separator=" "/>
+        <attribute name="style" add="box-shadow: rgba(0, 0, 0, 0.15) 0px 2px 4px 0px !important;" separator=";"/>
     </xpath>
     <!-- Column #03 -->
     <xpath expr="//div[hasclass('row')]/div[4]" position="attributes">
         <attribute name="class" add="o_cc o_cc1" separator=" "/>
-        <attribute name="style" add="box-shadow: rgba(0, 0, 0, 0.15) 0px 2px 4px 0px !important;" separator=" "/>
+        <attribute name="style" add="box-shadow: rgba(0, 0, 0, 0.15) 0px 2px 4px 0px !important;" separator=";"/>
     </xpath>
     <!-- Column #04 -->
     <xpath expr="//div[hasclass('row')]/div[5]" position="attributes">
         <attribute name="class" add="o_cc o_cc1" separator=" "/>
-        <attribute name="style" add="box-shadow: rgba(0, 0, 0, 0.15) 0px 2px 4px 0px !important;" separator=" "/>
+        <attribute name="style" add="box-shadow: rgba(0, 0, 0, 0.15) 0px 2px 4px 0px !important;" separator=";"/>
     </xpath>
 </template>
 

--- a/theme_zap/views/snippets/s_three_columns.xml
+++ b/theme_zap/views/snippets/s_three_columns.xml
@@ -8,21 +8,21 @@
     </xpath>
     <!-- Column #01 -->
     <xpath expr="//*[hasclass('card')]" position="attributes">
-        <attribute name="style" add="box-shadow: rgba(0, 0, 0, 0.15) 0px 2px 4px 0px !important;" separator=" "/>
+        <attribute name="style" add="box-shadow: rgba(0, 0, 0, 0.15) 0px 2px 4px 0px !important;" separator=";"/>
     </xpath>
     <xpath expr="//*[hasclass('card-title')]" position="replace" mode="inner">
         Services
     </xpath>
     <!-- Column #02 -->
     <xpath expr="(//*[hasclass('card')])[2]" position="attributes">
-        <attribute name="style" add="box-shadow: rgba(0, 0, 0, 0.15) 0px 2px 4px 0px !important;" separator=" "/>
+        <attribute name="style" add="box-shadow: rgba(0, 0, 0, 0.15) 0px 2px 4px 0px !important;" separator=";"/>
     </xpath>
     <xpath expr="(//*[hasclass('card-title')])[2]" position="replace" mode="inner">
         Features
     </xpath>
     <!-- Column #03 -->
     <xpath expr="(//*[hasclass('card')])[3]" position="attributes">
-        <attribute name="style" add="box-shadow: rgba(0, 0, 0, 0.15) 0px 2px 4px 0px !important;" separator=" "/>
+        <attribute name="style" add="box-shadow: rgba(0, 0, 0, 0.15) 0px 2px 4px 0px !important;" separator=";"/>
     </xpath>
     <xpath expr="(//*[hasclass('card-title')])[3]" position="replace" mode="inner">
         Benefits


### PR DESCRIPTION
This commit adds a test that verifies that a specific `separator` is
used when an `attribute` tag is used with either `add` or `remove`.

task-4206845
