### PR TITLE
[FIX] theme_bistro, theme_beauty: adapt tours

### DIFF
--- a/theme_beauty/static/src/js/tour.js
+++ b/theme_beauty/static/src/js/tour.js
@@ -16,7 +16,7 @@ const snippets = [
     {
         id: 's_pricelist_boxed',
         name: 'Pricelist Boxed',
-        groupName: "Content",
+        groupName: "Text",
     },
     {
         id: 's_features_wall',

--- a/theme_bistro/static/src/js/tour.js
+++ b/theme_bistro/static/src/js/tour.js
@@ -16,7 +16,7 @@ const snippets = [
     {
         id: 's_pricelist_cafe',
         name: 'Pricelist cafe',
-        groupName: "Content",
+        groupName: "Text",
     },
     {
         id: 's_quotes_carousel',


### PR DESCRIPTION
Following the reorganization of price list snippets, this commit adapts the tour of themes that currently use them.

task-4212916

Requires:
- https://github.com/odoo/odoo/pull/181510