### PR TITLE
[FIX] theme_clean: remove undefined configurator page template

### DIFF
--- a/theme_clean/views/snippets/s_cover.xml
+++ b/theme_clean/views/snippets/s_cover.xml
@@ -21,15 +21,4 @@
     <xpath expr="//p[2]" position="replace"/>
 </template>
 
-<template id="configurator_s_cover" inherit_id="website.configurator_s_cover">
-    <!-- Shape option -->
-    <xpath expr="//section" position="attributes">
-        <attribute name="data-oe-shape-data">{"shape":"web_editor/Origins/07_002","flip":[]}</attribute>
-    </xpath>
-    <!-- Shape -->
-    <xpath expr="//div[hasclass('container')]" position="before">
-        <div class="o_we_shape o_web_editor_Origins_07_002"/>
-    </xpath>
-</template>
-
 </odoo>


### PR DESCRIPTION
Since [1] `s_cover` was removed from the configurator pages defined in the manifest, however the `configurator_s_cover` template was still defined. This leads to errors because it then inherits an non-existing template.

This commit removes that template definition.

[1]: https://github.com/odoo/design-themes/commit/c31b3c7c8327b4d8c3924de4bfca9ca2db26148b#diff-f8f7a09e94b435b03c4d87735e873c98c519f4dc83f3b83feb99c34ea2208d6dL58

task-4178066