### PR TITLE
[FIX] test_themes, theme_*: fix not working theme tours

### DIFF
--- a/test_themes/tests/test_crawl.py
+++ b/test_themes/tests/test_crawl.py
@@ -48,6 +48,5 @@ class Crawler(HttpCase):
         # when designing a theme at the moment.
         Website = self.env['website']
         websites_themes = Website.get_test_themes_websites()
-        websites_themes = [theme for index, theme in enumerate(websites_themes) if index not in (17, 23)]  # FIXME
         for website in websites_themes:
             self.start_tour(f"/web?fw={website.id}", 'homepage', login='admin')

--- a/theme_loftspace/static/src/js/tour.js
+++ b/theme_loftspace/static/src/js/tour.js
@@ -57,7 +57,6 @@ wTourUtils.registerThemeHomepageTour("loftspace_tour", () => [
     ...wTourUtils.insertSnippet(snippets[5]),
     ...wTourUtils.insertSnippet(snippets[6]),
     ...wTourUtils.insertSnippet(snippets[7]),
-    ...wTourUtils.insertSnippet(snippets[8]),
     ...wTourUtils.clickOnSnippet(snippets[4]),
     wTourUtils.changeBackgroundColor(),
     wTourUtils.selectColorPalette(),

--- a/theme_real_estate/static/src/js/tour.js
+++ b/theme_real_estate/static/src/js/tour.js
@@ -67,5 +67,4 @@ wTourUtils.registerThemeHomepageTour("real_estate_tour", () => [
     ...wTourUtils.insertSnippet(snippets[6]),
     ...wTourUtils.insertSnippet(snippets[7]),
     ...wTourUtils.insertSnippet(snippets[8]),
-    ...wTourUtils.insertSnippet(snippets[9]),
 ]);


### PR DESCRIPTION
*: loftspace, real_estate

In commit [1], the test for the "Loftspace" and "Real Estate" themes has been disabled, as their tour was not working.

This commit fixes the tours and reenables the test for these themes. The issue was coming from the fact that they were trying to drop more snippets than there really are, which made an acces to the array at an inexisting index.

[1]: https://github.com/odoo/design-themes/commit/04f90cd883826bb8e4cbf8975aff6c14bf3c64db