### PR TITLE
[IMP] theme_*: review `s_numbers_boxed` snippet occurrences

### DIFF
--- a/theme_anelusia/__manifest__.py
+++ b/theme_anelusia/__manifest__.py
@@ -60,6 +60,7 @@
         'views/snippets/s_wavy_grid.xml',
         'views/snippets/s_shape_image.xml',
         'views/snippets/s_empowerment.xml',
+        'views/snippets/s_numbers_boxed.xml',
         'views/new_page_template.xml',
     ],
     'images': [

--- a/theme_anelusia/views/snippets/s_numbers_boxed.xml
+++ b/theme_anelusia/views/snippets/s_numbers_boxed.xml
@@ -1,0 +1,36 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+
+<template id="s_numbers_boxed" inherit_id="website.s_numbers_boxed">
+    <!-- Section -->
+    <xpath expr="//section" position="attributes">
+        <attribute name="data-oe-shape-data">{"shape":"web_editor/Wavy/28", "colors":{"c1": "o-color-1", "c3": "o-color-5"}, "flip":[], "showOnMobile":true}</attribute>
+    </xpath>
+    <!-- Shape -->
+    <xpath expr="//div[hasclass('container')]" position="before">
+        <div class="o_we_shape o_web_editor_Wavy_28 o_we_animated" style="background-image: url('/web_editor/shape/web_editor/Wavy/28.svg?c1=o-color-1&amp;c3=o-color-5&amp;);"/>
+    </xpath>
+    <!-- Grid Item -->
+    <xpath expr="//div[hasclass('o_grid_item')][2]" position="attributes">
+        <attribute name="class" add="o_cc4" remove="o_cc3" separator=" "/>
+    </xpath>
+    <xpath expr="//div[hasclass('o_grid_item')][2]//h3" position="replace" mode="inner">
+        30+
+    </xpath>
+    <!-- Grid Item 2 -->
+    <xpath expr="(//div[hasclass('o_grid_item')])[3]" position="attributes">
+        <attribute name="class" add="o_cc4" remove="o_cc3" separator=" "/>
+    </xpath>
+    <xpath expr="(//div[hasclass('o_grid_item')])[3]//h3" position="replace" mode="inner">
+        45%
+    </xpath>
+    <!-- Grid Item 3 -->
+    <xpath expr="(//div[hasclass('o_grid_item')])[4]" position="attributes">
+        <attribute name="class" add="o_cc4" remove="o_cc3" separator=" "/>
+    </xpath>
+    <xpath expr="(//div[hasclass('o_grid_item')])[4]//h3" position="replace" mode="inner">
+        8+
+    </xpath>
+</template>
+
+</odoo>

--- a/theme_artists/__manifest__.py
+++ b/theme_artists/__manifest__.py
@@ -103,6 +103,7 @@
         'views/snippets/s_empowerment.xml',
         'views/snippets/s_cta_mobile.xml',
         'views/snippets/s_website_form_cover.xml',
+        'views/snippets/s_numbers_boxed.xml',
         'views/new_page_template.xml',
     ],
     'images': [

--- a/theme_artists/views/snippets/s_numbers_boxed.xml
+++ b/theme_artists/views/snippets/s_numbers_boxed.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+
+<template id="s_numbers_boxed" inherit_id="website.s_numbers_boxed">
+    <!-- Section -->
+    <xpath expr="//section" position="attributes">
+        <attribute name="data-oe-shape-data">{"shape":"web_editor/Float/12", "flip":[], "showOnMobile":true}</attribute>
+    </xpath>
+    <!-- Shape -->
+    <xpath expr="//div[hasclass('container')]" position="before">
+        <div class="o_we_shape o_web_editor_Floats_12 o_we_animated"/>
+    </xpath>
+</template>
+
+</odoo>

--- a/theme_avantgarde/views/customizations.xml
+++ b/theme_avantgarde/views/customizations.xml
@@ -883,4 +883,30 @@
     </xpath>
 </template>
 
+<!-- ======== Numbers boxed ======== -->
+<template id="s_numbers_boxed" inherit_id="website.s_numbers_boxed">
+    <!-- Grid Item -->
+    <xpath expr="//div[hasclass('o_grid_item')][2]" position="attributes">
+        <attribute name="class" add="o_cc4" remove="o_cc3" separator=" "/>
+    </xpath>
+    <xpath expr="//div[hasclass('o_grid_item')][2]//h3" position="replace" mode="inner">
+        30+
+    </xpath>
+    <!-- Grid Item 2 -->
+    <xpath expr="(//div[hasclass('o_grid_item')])[3]" position="attributes">
+        <attribute name="class" add="o_cc4" remove="o_cc3" separator=" "/>
+    </xpath>
+    <xpath expr="(//div[hasclass('o_grid_item')])[3]//h3" position="replace" mode="inner">
+        45%
+    </xpath>
+    <!-- Grid Item 3 -->
+    <xpath expr="(//div[hasclass('o_grid_item')])[4]" position="attributes">
+        <attribute name="class" add="o_cc4" remove="o_cc3" separator=" "/>
+    </xpath>
+    <xpath expr="(//div[hasclass('o_grid_item')])[4]//h3" position="replace" mode="inner">
+        8+
+    </xpath>
+
+</template>
+
 </odoo>

--- a/theme_aviato/__manifest__.py
+++ b/theme_aviato/__manifest__.py
@@ -56,6 +56,7 @@
         'views/snippets/s_text_cover.xml',
         'views/snippets/s_empowerment.xml',
         'views/snippets/s_company_team_spotlight.xml',
+        'views/snippets/s_numbers_boxed.xml',
         'views/new_page_template.xml',
     ],
     'images': [

--- a/theme_aviato/views/snippets/s_numbers_boxed.xml
+++ b/theme_aviato/views/snippets/s_numbers_boxed.xml
@@ -1,0 +1,36 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+
+<template id="s_numbers_boxed" inherit_id="website.s_numbers_boxed">
+    <!-- Section -->
+    <xpath expr="//section" position="attributes">
+        <attribute name="data-oe-shape-data">{"shape":"web_editor/Blobs/06", "flip":[], "showOnMobile":true}</attribute>
+    </xpath>
+    <!-- Shape -->
+    <xpath expr="//div[hasclass('container')]" position="before">
+        <div class="o_we_shape o_web_editor_Blobs_06"/>
+    </xpath>
+    <!-- Grid Item -->
+    <xpath expr="//div[hasclass('o_grid_item')][2]" position="attributes">
+        <attribute name="class" add="o_cc1" remove="o_cc3" separator=" "/>
+    </xpath>
+    <xpath expr="//div[hasclass('o_grid_item')][2]//h3" position="replace" mode="inner">
+        30+
+    </xpath>
+    <!-- Grid Item 2 -->
+    <xpath expr="(//div[hasclass('o_grid_item')])[3]" position="attributes">
+        <attribute name="class" add="o_cc1" remove="o_cc3" separator=" "/>
+    </xpath>
+    <xpath expr="(//div[hasclass('o_grid_item')])[3]//h3" position="replace" mode="inner">
+        45%
+    </xpath>
+    <!-- Grid Item 3 -->
+    <xpath expr="(//div[hasclass('o_grid_item')])[4]" position="attributes">
+        <attribute name="class" add="o_cc1" remove="o_cc3" separator=" "/>
+    </xpath>
+    <xpath expr="(//div[hasclass('o_grid_item')])[4]//h3" position="replace" mode="inner">
+        8+
+    </xpath>
+</template>
+
+</odoo>

--- a/theme_beauty/__manifest__.py
+++ b/theme_beauty/__manifest__.py
@@ -60,6 +60,7 @@
         'views/snippets/s_shape_image.xml',
         'views/snippets/s_text_cover.xml',
         'views/snippets/s_empowerment.xml',
+        'views/snippets/s_numbers_boxed.xml',
         'views/new_page_template.xml',
     ],
     'images': [

--- a/theme_beauty/views/snippets/s_numbers_boxed.xml
+++ b/theme_beauty/views/snippets/s_numbers_boxed.xml
@@ -1,0 +1,36 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+
+<template id="s_numbers_boxed" inherit_id="website.s_numbers_boxed">
+    <!-- Section -->
+    <xpath expr="//section" position="attributes">
+        <attribute name="data-oe-shape-data">{"shape":"web_editor/Blobs/12", "colors":{"c1": "o-color-2"}, "flip":[], "showOnMobile":true}</attribute>
+    </xpath>
+    <!-- Shape -->
+    <xpath expr="//div[hasclass('container')]" position="before">
+        <div class="o_we_shape o_web_editor_Blobs_12" style="background-image: url('/web_editor/shape/web_editor/Blobs/12.svg?c1=o-color-2&amp;);"/>
+    </xpath>
+    <!-- Grid Item -->
+    <xpath expr="//div[hasclass('o_grid_item')][2]" position="attributes">
+        <attribute name="class" add="o_cc1" remove="o_cc3" separator=" "/>
+    </xpath>
+    <xpath expr="//div[hasclass('o_grid_item')][2]//h3" position="replace" mode="inner">
+        30+
+    </xpath>
+    <!-- Grid Item 2 -->
+    <xpath expr="(//div[hasclass('o_grid_item')])[3]" position="attributes">
+        <attribute name="class" add="o_cc1" remove="o_cc3" separator=" "/>
+    </xpath>
+    <xpath expr="(//div[hasclass('o_grid_item')])[3]//h3" position="replace" mode="inner">
+        45%
+    </xpath>
+    <!-- Grid Item 3 -->
+    <xpath expr="(//div[hasclass('o_grid_item')])[4]" position="attributes">
+        <attribute name="class" add="o_cc1" remove="o_cc3" separator=" "/>
+    </xpath>
+    <xpath expr="(//div[hasclass('o_grid_item')])[4]//h3" position="replace" mode="inner">
+        8+
+    </xpath>
+</template>
+
+</odoo>

--- a/theme_bewise/views/customizations.xml
+++ b/theme_bewise/views/customizations.xml
@@ -1145,4 +1145,38 @@
     </xpath>
 </template>
 
+<!-- ======== NUMBERS BOXED ======== -->
+<template id="s_numbers_boxed" inherit_id="website.s_numbers_boxed">
+    <!-- Section -->
+    <xpath expr="//section" position="attributes">
+        <attribute name="data-oe-shape-data">{"shape":"web_editor/Blobs/08", "colors":{"c1": "o-color-1"}, "flip":[], "showOnMobile":true}</attribute>
+        <attribute name="class" add="o_cc3" remove="o_cc5" separator=" "/>
+    </xpath>
+    <!-- Shape -->
+    <xpath expr="//div[hasclass('container')]" position="before">
+        <div class="o_we_shape o_web_editor_Blobs_08" style="background-image: url('/web_editor/shape/web_editor/Blobs/08.svg?c1=o-color-1&amp;);"/>
+    </xpath>
+    <!-- Grid Item -->
+    <xpath expr="//div[hasclass('o_grid_item')][2]" position="attributes">
+        <attribute name="class" add="o_cc1" remove="o_cc3" separator=" "/>
+    </xpath>
+    <xpath expr="//div[hasclass('o_grid_item')][2]//h3" position="replace" mode="inner">
+        30+
+    </xpath>
+    <!-- Grid Item 2 -->
+    <xpath expr="(//div[hasclass('o_grid_item')])[3]" position="attributes">
+        <attribute name="class" add="o_cc1" remove="o_cc3" separator=" "/>
+    </xpath>
+    <xpath expr="(//div[hasclass('o_grid_item')])[3]//h3" position="replace" mode="inner">
+        45%
+    </xpath>
+    <!-- Grid Item 3 -->
+    <xpath expr="(//div[hasclass('o_grid_item')])[4]" position="attributes">
+        <attribute name="class" add="o_cc1" remove="o_cc3" separator=" "/>
+    </xpath>
+    <xpath expr="(//div[hasclass('o_grid_item')])[4]//h3" position="replace" mode="inner">
+        8+
+    </xpath>
+</template>
+
 </odoo>

--- a/theme_bistro/__manifest__.py
+++ b/theme_bistro/__manifest__.py
@@ -56,6 +56,7 @@
         'views/snippets/s_text_cover.xml',
         'views/snippets/s_empowerment.xml',
         'views/snippets/s_company_team_grid.xml',
+        'views/snippets/s_numbers_boxed.xml',
         'views/new_page_template.xml',
 
     ],

--- a/theme_bistro/views/snippets/s_numbers_boxed.xml
+++ b/theme_bistro/views/snippets/s_numbers_boxed.xml
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+
+<template id="s_numbers_boxed" inherit_id="website.s_numbers_boxed">
+    <!-- Grid Item -->
+    <xpath expr="//div[hasclass('o_grid_item')][2]" position="attributes">
+        <attribute name="class" add="o_cc4" remove="o_cc3" separator=" "/>
+    </xpath>
+    <xpath expr="//div[hasclass('o_grid_item')][2]//h3" position="replace" mode="inner">
+        30+
+    </xpath>
+    <!-- Grid Item 2 -->
+    <xpath expr="(//div[hasclass('o_grid_item')])[3]" position="attributes">
+        <attribute name="class" add="o_cc4" remove="o_cc3" separator=" "/>
+    </xpath>
+    <xpath expr="(//div[hasclass('o_grid_item')])[3]//h3" position="replace" mode="inner">
+        45%
+    </xpath>
+    <!-- Grid Item 3 -->
+    <xpath expr="(//div[hasclass('o_grid_item')])[4]" position="attributes">
+        <attribute name="class" add="o_cc4" remove="o_cc3" separator=" "/>
+    </xpath>
+    <xpath expr="(//div[hasclass('o_grid_item')])[4]//h3" position="replace" mode="inner">
+        8+
+    </xpath>
+</template>
+
+</odoo>

--- a/theme_bookstore/__manifest__.py
+++ b/theme_bookstore/__manifest__.py
@@ -61,6 +61,7 @@
         'views/snippets/s_text_cover.xml',
         'views/snippets/s_accordion.xml',
         'views/snippets/s_accordion_image.xml',
+        'views/snippets/s_numbers_boxed.xml',
         'views/new_page_template.xml',
     ],
     'images': [

--- a/theme_bookstore/views/snippets/s_numbers_boxed.xml
+++ b/theme_bookstore/views/snippets/s_numbers_boxed.xml
@@ -1,0 +1,36 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+
+<template id="s_numbers_boxed" inherit_id="website.s_numbers_boxed">
+    <!-- Section -->
+    <xpath expr="//section" position="attributes">
+        <attribute name="data-oe-shape-data">{"shape":"web_editor/Blobs/08", "colors":{"c1": "o-color-1"}, "flip":[], "showOnMobile":true}</attribute>
+    </xpath>
+    <!-- Shape -->
+    <xpath expr="//div[hasclass('container')]" position="before">
+        <div class="o_we_shape o_web_editor_Blobs_08" style="background-image: url('/web_editor/shape/web_editor/Blobs/08.svg?c1=o-color-1&amp;);"/>
+    </xpath>
+    <!-- Grid Item -->
+    <xpath expr="//div[hasclass('o_grid_item')][2]" position="attributes">
+        <attribute name="class" add="o_cc2" remove="o_cc3" separator=" "/>
+    </xpath>
+    <xpath expr="//div[hasclass('o_grid_item')][2]//h3" position="replace" mode="inner">
+        30+
+    </xpath>
+    <!-- Grid Item 2 -->
+    <xpath expr="(//div[hasclass('o_grid_item')])[3]" position="attributes">
+        <attribute name="class" add="o_cc2" remove="o_cc3" separator=" "/>
+    </xpath>
+    <xpath expr="(//div[hasclass('o_grid_item')])[3]//h3" position="replace" mode="inner">
+        45%
+    </xpath>
+    <!-- Grid Item 3 -->
+    <xpath expr="(//div[hasclass('o_grid_item')])[4]" position="attributes">
+        <attribute name="class" add="o_cc2" remove="o_cc3" separator=" "/>
+    </xpath>
+    <xpath expr="(//div[hasclass('o_grid_item')])[4]//h3" position="replace" mode="inner">
+        8+
+    </xpath>
+</template>
+
+</odoo>

--- a/theme_buzzy/__manifest__.py
+++ b/theme_buzzy/__manifest__.py
@@ -64,6 +64,7 @@
         'views/snippets/s_image_frame.xml',
         'views/snippets/s_wavy_grid.xml',
         'views/snippets/s_empowerment.xml',
+        'views/snippets/s_numbers_boxed.xml',
         'views/new_page_template.xml',
     ],
     'images': [

--- a/theme_buzzy/views/snippets/s_numbers_boxed.xml
+++ b/theme_buzzy/views/snippets/s_numbers_boxed.xml
@@ -1,0 +1,32 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+
+<template id="s_numbers_boxed" inherit_id="website.s_numbers_boxed">
+    <!-- Section -->
+    <xpath expr="//section" position="attributes">
+        <attribute name="class" add="o_cc2" remove="o_cc5" separator=" "/>
+    </xpath>
+    <!-- Grid Item -->
+    <xpath expr="//div[hasclass('o_grid_item')][2]" position="attributes">
+        <attribute name="class" add="o_cc1" remove="o_cc3" separator=" "/>
+    </xpath>
+    <xpath expr="//div[hasclass('o_grid_item')][2]//h3" position="replace" mode="inner">
+        30+
+    </xpath>
+    <!-- Grid Item 2 -->
+    <xpath expr="(//div[hasclass('o_grid_item')])[3]" position="attributes">
+        <attribute name="class" add="o_cc1" remove="o_cc3" separator=" "/>
+    </xpath>
+    <xpath expr="(//div[hasclass('o_grid_item')])[3]//h3" position="replace" mode="inner">
+        45%
+    </xpath>
+    <!-- Grid Item 3 -->
+    <xpath expr="(//div[hasclass('o_grid_item')])[4]" position="attributes">
+        <attribute name="class" add="o_cc1" remove="o_cc3" separator=" "/>
+    </xpath>
+    <xpath expr="(//div[hasclass('o_grid_item')])[4]//h3" position="replace" mode="inner">
+        8+
+    </xpath>
+</template>
+
+</odoo>

--- a/theme_clean/__manifest__.py
+++ b/theme_clean/__manifest__.py
@@ -45,6 +45,7 @@
         'views/snippets/s_shape_image.xml',
         'views/snippets/s_images_constellation.xml',
         'views/snippets/s_empowerment.xml',
+        'views/snippets/s_numbers_boxed.xml',
         'views/new_page_template.xml',
     ],
     'images': [

--- a/theme_clean/views/snippets/s_numbers_boxed.xml
+++ b/theme_clean/views/snippets/s_numbers_boxed.xml
@@ -1,0 +1,32 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+
+<template id="s_numbers_boxed" inherit_id="website.s_numbers_boxed">
+    <!-- Section -->
+    <xpath expr="//section" position="attributes">
+        <attribute name="class" add="o_cc3" remove="o_cc5" separator=" "/>
+    </xpath>
+    <!-- Grid Item -->
+    <xpath expr="//div[hasclass('o_grid_item')][2]" position="attributes">
+        <attribute name="class" add="o_cc4" remove="o_cc3" separator=" "/>
+    </xpath>
+    <xpath expr="//div[hasclass('o_grid_item')][2]//h3" position="replace" mode="inner">
+        30+
+    </xpath>
+    <!-- Grid Item 2 -->
+    <xpath expr="(//div[hasclass('o_grid_item')])[3]" position="attributes">
+        <attribute name="class" add="o_cc4" remove="o_cc3" separator=" "/>
+    </xpath>
+    <xpath expr="(//div[hasclass('o_grid_item')])[3]//h3" position="replace" mode="inner">
+        45%
+    </xpath>
+    <!-- Grid Item 3 -->
+    <xpath expr="(//div[hasclass('o_grid_item')])[4]" position="attributes">
+        <attribute name="class" add="o_cc4" remove="o_cc3" separator=" "/>
+    </xpath>
+    <xpath expr="(//div[hasclass('o_grid_item')])[4]//h3" position="replace" mode="inner">
+        8+
+    </xpath>
+</template>
+
+</odoo>

--- a/theme_cobalt/views/customizations.xml
+++ b/theme_cobalt/views/customizations.xml
@@ -714,4 +714,20 @@
     </xpath>
 </template>
 
+<!-- ======== NUMBERS BOXED ======== -->
+<template id="s_numbers_boxed" inherit_id="website.s_numbers_boxed">
+    <!-- Grid Item -->
+    <xpath expr="//div[hasclass('o_grid_item')][2]" position="attributes">
+        <attribute name="class" add="o_cc5" remove="o_cc3" separator=" "/>
+    </xpath>
+    <!-- Grid Item 2 -->
+    <xpath expr="(//div[hasclass('o_grid_item')])[3]" position="attributes">
+        <attribute name="class" add="o_cc5" remove="o_cc3" separator=" "/>
+    </xpath>
+    <!-- Grid Item 3 -->
+    <xpath expr="(//div[hasclass('o_grid_item')])[4]" position="attributes">
+        <attribute name="class" add="o_cc5" remove="o_cc3" separator=" "/>
+    </xpath>
+</template>
+
 </odoo>

--- a/theme_enark/__manifest__.py
+++ b/theme_enark/__manifest__.py
@@ -52,6 +52,7 @@
         'views/snippets/s_images_constellation.xml',
         'views/snippets/s_text_cover.xml',
         'views/snippets/s_empowerment.xml',
+        'views/snippets/s_numbers_boxed.xml',
         'views/new_page_template.xml',
     ],
     'images': [

--- a/theme_enark/views/snippets/s_numbers_boxed.xml
+++ b/theme_enark/views/snippets/s_numbers_boxed.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+
+<template id="s_numbers_boxed" inherit_id="website.s_numbers_boxed">
+    <!-- Grid Item -->
+    <xpath expr="//div[hasclass('o_grid_item')][2]" position="attributes">
+        <attribute name="class" add="o_cc5" remove="o_cc3" separator=" "/>
+    </xpath>
+    <!-- Grid Item 2 -->
+    <xpath expr="(//div[hasclass('o_grid_item')])[3]" position="attributes">
+        <attribute name="class" add="o_cc5" remove="o_cc3" separator=" "/>
+    </xpath>
+    <!-- Grid Item 3 -->
+    <xpath expr="(//div[hasclass('o_grid_item')])[4]" position="attributes">
+        <attribute name="class" add="o_cc5" remove="o_cc3" separator=" "/>
+    </xpath>
+</template>
+
+</odoo>

--- a/theme_kea/__manifest__.py
+++ b/theme_kea/__manifest__.py
@@ -54,6 +54,7 @@
         'views/snippets/s_wavy_grid.xml',
         'views/snippets/s_text_cover.xml',
         'views/snippets/s_empowerment.xml',
+        'views/snippets/s_numbers_boxed.xml',
         'views/new_page_template.xml',
     ],
     'images': [

--- a/theme_kea/views/snippets/s_numbers_boxed.xml
+++ b/theme_kea/views/snippets/s_numbers_boxed.xml
@@ -1,0 +1,36 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+
+<template id="s_numbers_boxed" inherit_id="website.s_numbers_boxed">
+    <!-- Section -->
+    <xpath expr="//section" position="attributes">
+        <attribute name="class" add="o_cc2" remove="o_cc5" separator=" "/>
+        <attribute name="data-oe-shape-data">{'shape':'web_editor/Blobs/02','flip':[],'showOnMobile':false}</attribute>
+    </xpath>
+    <xpath expr="//div[hasclass('container')]" position="before">
+        <div class="o_we_shape o_web_editor_Blobs_02"/>
+    </xpath>
+    <!-- Grid Item -->
+    <xpath expr="//div[hasclass('o_grid_item')][2]" position="attributes">
+        <attribute name="class" add="o_cc1" remove="o_cc3" separator=" "/>
+    </xpath>
+    <xpath expr="//div[hasclass('o_grid_item')][2]//h3" position="replace" mode="inner">
+        30+
+    </xpath>
+    <!-- Grid Item 2 -->
+    <xpath expr="(//div[hasclass('o_grid_item')])[3]" position="attributes">
+        <attribute name="class" add="o_cc1" remove="o_cc3" separator=" "/>
+    </xpath>
+    <xpath expr="(//div[hasclass('o_grid_item')])[3]//h3" position="replace" mode="inner">
+        45%
+    </xpath>
+    <!-- Grid Item 3 -->
+    <xpath expr="(//div[hasclass('o_grid_item')])[4]" position="attributes">
+        <attribute name="class" add="o_cc1" remove="o_cc3" separator=" "/>
+    </xpath>
+    <xpath expr="(//div[hasclass('o_grid_item')])[4]//h3" position="replace" mode="inner">
+        8+
+    </xpath>
+</template>
+
+</odoo>

--- a/theme_kiddo/__manifest__.py
+++ b/theme_kiddo/__manifest__.py
@@ -56,6 +56,7 @@
         'views/snippets/s_text_cover.xml',
         'views/snippets/s_empowerment.xml',
         'views/snippets/s_company_team_grid.xml',
+        'views/snippets/s_numbers_boxed.xml',
         'views/new_page_template.xml',
     ],
     'images': [

--- a/theme_kiddo/views/snippets/s_numbers_boxed.xml
+++ b/theme_kiddo/views/snippets/s_numbers_boxed.xml
@@ -1,0 +1,32 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+
+<template id="s_numbers_boxed" inherit_id="website.s_numbers_boxed">
+    <!-- Section -->
+    <xpath expr="//section" position="attributes">
+        <attribute name="class" add="o_cc3" remove="o_cc5" separator=" "/>
+    </xpath>
+    <!-- Grid Item -->
+    <xpath expr="//div[hasclass('o_grid_item')][2]" position="attributes">
+        <attribute name="class" add="o_cc1" remove="o_cc3" separator=" "/>
+    </xpath>
+    <xpath expr="//div[hasclass('o_grid_item')][2]//h3" position="replace" mode="inner">
+        30+
+    </xpath>
+    <!-- Grid Item 2 -->
+    <xpath expr="(//div[hasclass('o_grid_item')])[3]" position="attributes">
+        <attribute name="class" add="o_cc1" remove="o_cc3" separator=" "/>
+    </xpath>
+    <xpath expr="(//div[hasclass('o_grid_item')])[3]//h3" position="replace" mode="inner">
+        45%
+    </xpath>
+    <!-- Grid Item 3 -->
+    <xpath expr="(//div[hasclass('o_grid_item')])[4]" position="attributes">
+        <attribute name="class" add="o_cc1" remove="o_cc3" separator=" "/>
+    </xpath>
+    <xpath expr="(//div[hasclass('o_grid_item')])[4]//h3" position="replace" mode="inner">
+        8+
+    </xpath>
+</template>
+
+</odoo>

--- a/theme_loftspace/__manifest__.py
+++ b/theme_loftspace/__manifest__.py
@@ -54,6 +54,7 @@
         'views/snippets/s_wavy_grid.xml',
         'views/snippets/s_text_cover.xml',
         'views/snippets/s_empowerment.xml',
+        'views/snippets/s_numbers_boxed.xml',
         'views/new_page_template.xml',
     ],
     'images': [

--- a/theme_loftspace/views/snippets/s_numbers_boxed.xml
+++ b/theme_loftspace/views/snippets/s_numbers_boxed.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+
+<template id="s_numbers_boxed" inherit_id="website.s_numbers_boxed">
+    <!-- Grid Item -->
+    <xpath expr="//div[hasclass('o_grid_item')][2]" position="attributes">
+        <attribute name="class" add="o_cc5" remove="o_cc3" separator=" "/>
+    </xpath>
+    <!-- Grid Item 2 -->
+    <xpath expr="(//div[hasclass('o_grid_item')])[3]" position="attributes">
+        <attribute name="class" add="o_cc5" remove="o_cc3" separator=" "/>
+    </xpath>
+    <!-- Grid Item 3 -->
+    <xpath expr="(//div[hasclass('o_grid_item')])[4]" position="attributes">
+        <attribute name="class" add="o_cc5" remove="o_cc3" separator=" "/>
+    </xpath>
+</template>
+
+</odoo>

--- a/theme_monglia/views/customizations.xml
+++ b/theme_monglia/views/customizations.xml
@@ -1068,4 +1068,20 @@
     </xpath>
 </template>
 
+<!-- ======== NUMBERS BOXED ======== -->
+<template id="s_numbers_boxed" inherit_id="website.s_numbers_boxed">
+    <!-- Grid Item -->
+    <xpath expr="//div[hasclass('o_grid_item')][2]" position="attributes">
+        <attribute name="class" add="o_cc5" remove="o_cc3" separator=" "/>
+    </xpath>
+    <!-- Grid Item 2 -->
+    <xpath expr="(//div[hasclass('o_grid_item')])[3]" position="attributes">
+        <attribute name="class" add="o_cc5" remove="o_cc3" separator=" "/>
+    </xpath>
+    <!-- Grid Item 3 -->
+    <xpath expr="(//div[hasclass('o_grid_item')])[4]" position="attributes">
+        <attribute name="class" add="o_cc5" remove="o_cc3" separator=" "/>
+    </xpath>
+</template>
+
 </odoo>

--- a/theme_nano/__manifest__.py
+++ b/theme_nano/__manifest__.py
@@ -51,6 +51,7 @@
         'views/snippets/s_cta_mobile.xml',
         'views/snippets/s_company_team_spotlight.xml',
         'views/snippets/s_website_form_cover.xml',
+        'views/snippets/s_numbers_boxed.xml',
         'views/new_page_template.xml',
     ],
     'images': [

--- a/theme_nano/views/snippets/s_numbers_boxed.xml
+++ b/theme_nano/views/snippets/s_numbers_boxed.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+
+<template id="s_numbers_boxed" inherit_id="website.s_numbers_boxed">
+    <!-- Grid Item -->
+    <xpath expr="//div[hasclass('o_grid_item')][2]" position="attributes">
+        <attribute name="class" add="o_cc5" remove="o_cc3" separator=" "/>
+    </xpath>
+    <!-- Grid Item 2 -->
+    <xpath expr="(//div[hasclass('o_grid_item')])[3]" position="attributes">
+        <attribute name="class" add="o_cc5" remove="o_cc3" separator=" "/>
+    </xpath>
+    <!-- Grid Item 3 -->
+    <xpath expr="(//div[hasclass('o_grid_item')])[4]" position="attributes">
+        <attribute name="class" add="o_cc5" remove="o_cc3" separator=" "/>
+    </xpath>
+</template>
+
+</odoo>

--- a/theme_notes/__manifest__.py
+++ b/theme_notes/__manifest__.py
@@ -66,6 +66,7 @@
         'views/snippets/s_text_cover.xml',
         'views/snippets/s_empowerment.xml',
         'views/snippets/s_website_form_cover.xml',
+        'views/snippets/s_numbers_boxed.xml',
         'views/new_page_template.xml',
     ],
     'images': [

--- a/theme_notes/views/snippets/s_numbers_boxed.xml
+++ b/theme_notes/views/snippets/s_numbers_boxed.xml
@@ -1,0 +1,32 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+
+<template id="s_numbers_boxed" inherit_id="website.s_numbers_boxed">
+    <!-- Section -->
+    <xpath expr="//section" position="attributes">
+        <attribute name="class" add="o_cc3" remove="o_cc5" separator=" "/>
+    </xpath>
+    <!-- Grid Item -->
+    <xpath expr="//div[hasclass('o_grid_item')][2]" position="attributes">
+        <attribute name="class" add="o_cc4" remove="o_cc3" separator=" "/>
+    </xpath>
+    <xpath expr="//div[hasclass('o_grid_item')][2]//h3" position="replace" mode="inner">
+        30+
+    </xpath>
+    <!-- Grid Item 2 -->
+    <xpath expr="(//div[hasclass('o_grid_item')])[3]" position="attributes">
+        <attribute name="class" add="o_cc4" remove="o_cc3" separator=" "/>
+    </xpath>
+    <xpath expr="(//div[hasclass('o_grid_item')])[3]//h3" position="replace" mode="inner">
+        45%
+    </xpath>
+    <!-- Grid Item 3 -->
+    <xpath expr="(//div[hasclass('o_grid_item')])[4]" position="attributes">
+        <attribute name="class" add="o_cc4" remove="o_cc3" separator=" "/>
+    </xpath>
+    <xpath expr="(//div[hasclass('o_grid_item')])[4]//h3" position="replace" mode="inner">
+        8+
+    </xpath>
+</template>
+
+</odoo>

--- a/theme_odoo_experts/__manifest__.py
+++ b/theme_odoo_experts/__manifest__.py
@@ -52,6 +52,7 @@
         'views/snippets/s_numbers_list.xml',
         'views/snippets/s_showcase.xml',
         'views/snippets/s_mockup_image.xml',
+        'views/snippets/s_numbers_boxed.xml',
         'views/new_page_template.xml',
     ],
     'images': [

--- a/theme_odoo_experts/views/snippets/s_numbers_boxed.xml
+++ b/theme_odoo_experts/views/snippets/s_numbers_boxed.xml
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+
+<template id="s_numbers_boxed" inherit_id="website.s_numbers_boxed">
+    <!-- Grid Item -->
+    <xpath expr="//div[hasclass('o_grid_item')][2]" position="attributes">
+        <attribute name="class" add="o_cc4" remove="o_cc3" separator=" "/>
+    </xpath>
+    <xpath expr="//div[hasclass('o_grid_item')][2]//h3" position="replace" mode="inner">
+        30+
+    </xpath>
+    <!-- Grid Item 2 -->
+    <xpath expr="(//div[hasclass('o_grid_item')])[3]" position="attributes">
+        <attribute name="class" add="o_cc4" remove="o_cc3" separator=" "/>
+    </xpath>
+    <xpath expr="(//div[hasclass('o_grid_item')])[3]//h3" position="replace" mode="inner">
+        45%
+    </xpath>
+    <!-- Grid Item 3 -->
+    <xpath expr="(//div[hasclass('o_grid_item')])[4]" position="attributes">
+        <attribute name="class" add="o_cc4" remove="o_cc3" separator=" "/>
+    </xpath>
+    <xpath expr="(//div[hasclass('o_grid_item')])[4]//h3" position="replace" mode="inner">
+        8+
+    </xpath>
+</template>
+
+</odoo>

--- a/theme_orchid/__manifest__.py
+++ b/theme_orchid/__manifest__.py
@@ -55,6 +55,7 @@
         'views/snippets/s_shape_image.xml',
         'views/snippets/s_references.xml',
         'views/snippets/s_empowerment.xml',
+        'views/snippets/s_numbers_boxed.xml',
         'views/new_page_template.xml',
     ],
     'images': [

--- a/theme_orchid/views/snippets/s_numbers_boxed.xml
+++ b/theme_orchid/views/snippets/s_numbers_boxed.xml
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+
+<template id="s_numbers_boxed" inherit_id="website.s_numbers_boxed">
+    <!-- Grid Item -->
+    <xpath expr="//div[hasclass('o_grid_item')][2]" position="attributes">
+        <attribute name="class" add="o_cc4" remove="o_cc3" separator=" "/>
+    </xpath>
+    <xpath expr="//div[hasclass('o_grid_item')][2]//h3" position="replace" mode="inner">
+        30+
+    </xpath>
+    <!-- Grid Item 2 -->
+    <xpath expr="(//div[hasclass('o_grid_item')])[3]" position="attributes">
+        <attribute name="class" add="o_cc4" remove="o_cc3" separator=" "/>
+    </xpath>
+    <xpath expr="(//div[hasclass('o_grid_item')])[3]//h3" position="replace" mode="inner">
+        45%
+    </xpath>
+    <!-- Grid Item 3 -->
+    <xpath expr="(//div[hasclass('o_grid_item')])[4]" position="attributes">
+        <attribute name="class" add="o_cc4" remove="o_cc3" separator=" "/>
+    </xpath>
+    <xpath expr="(//div[hasclass('o_grid_item')])[4]//h3" position="replace" mode="inner">
+        8+
+    </xpath>
+</template>
+
+</odoo>

--- a/theme_paptic/views/customizations.xml
+++ b/theme_paptic/views/customizations.xml
@@ -781,4 +781,24 @@
     </xpath>
 </template>
 
+<!-- ==== Numbers Boxed ===== -->
+<template id="s_numbers_boxed" inherit_id="website.s_numbers_boxed">
+    <!-- Section -->
+    <xpath expr="//section" position="attributes">
+        <attribute name="class" add="o_cc3" remove="o_cc5" separator=" "/>
+    </xpath>
+    <!-- Grid Item -->
+    <xpath expr="//div[hasclass('o_grid_item')][2]" position="attributes">
+        <attribute name="class" add="o_cc5" remove="o_cc3" separator=" "/>
+    </xpath>
+    <!-- Grid Item 2 -->
+    <xpath expr="(//div[hasclass('o_grid_item')])[3]" position="attributes">
+        <attribute name="class" add="o_cc5" remove="o_cc3" separator=" "/>
+    </xpath>
+    <!-- Grid Item 3 -->
+    <xpath expr="(//div[hasclass('o_grid_item')])[4]" position="attributes">
+        <attribute name="class" add="o_cc5" remove="o_cc3" separator=" "/>
+    </xpath>
+</template>
+
 </odoo>

--- a/theme_real_estate/__manifest__.py
+++ b/theme_real_estate/__manifest__.py
@@ -50,6 +50,7 @@
         'views/snippets/s_shape_image.xml',
         'views/snippets/s_images_constellation.xml',
         'views/snippets/s_empowerment.xml',
+        'views/snippets/s_numbers_boxed.xml',
         'views/new_page_template.xml',
     ],
     'images': [

--- a/theme_real_estate/views/snippets/s_numbers_boxed.xml
+++ b/theme_real_estate/views/snippets/s_numbers_boxed.xml
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+
+<template id="s_numbers_boxed" inherit_id="website.s_numbers_boxed">
+    <!-- Section -->
+    <xpath expr="//section" position="attributes">
+        <attribute name="class" add="o_cc3" remove="o_cc5" separator=" "/>
+    </xpath>
+    <!-- Grid Item -->
+    <xpath expr="//div[hasclass('o_grid_item')][2]" position="attributes">
+        <attribute name="class" add="o_cc4" remove="o_cc3" separator=" "/>
+    </xpath>
+    <!-- Grid Item 2 -->
+    <xpath expr="(//div[hasclass('o_grid_item')])[3]" position="attributes">
+        <attribute name="class" add="o_cc4" remove="o_cc3" separator=" "/>
+    </xpath>
+    <!-- Grid Item 3 -->
+    <xpath expr="(//div[hasclass('o_grid_item')])[4]" position="attributes">
+        <attribute name="class" add="o_cc4" remove="o_cc3" separator=" "/>
+    </xpath>
+</template>
+
+</odoo>

--- a/theme_treehouse/__manifest__.py
+++ b/theme_treehouse/__manifest__.py
@@ -55,6 +55,7 @@
         'views/snippets/s_wavy_grid.xml',
         'views/snippets/s_text_cover.xml',
         'views/snippets/s_empowerment.xml',
+        'views/snippets/s_numbers_boxed.xml',
         'views/new_page_template.xml',
     ],
     'images': [

--- a/theme_treehouse/views/snippets/s_numbers_boxed.xml
+++ b/theme_treehouse/views/snippets/s_numbers_boxed.xml
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+
+<template id="s_numbers_boxed" inherit_id="website.s_numbers_boxed">
+    <!-- Section -->
+    <xpath expr="//section" position="attributes">
+        <attribute name="class" add="o_cc4" remove="o_cc5" separator=" "/>
+    </xpath>
+    <!-- Grid Item -->
+    <xpath expr="//div[hasclass('o_grid_item')][2]" position="attributes">
+        <attribute name="class" add="o_cc5" remove="o_cc3" separator=" "/>
+    </xpath>
+    <!-- Grid Item 2 -->
+    <xpath expr="(//div[hasclass('o_grid_item')])[3]" position="attributes">
+        <attribute name="class" add="o_cc5" remove="o_cc3" separator=" "/>
+    </xpath>
+    <!-- Grid Item 3 -->
+    <xpath expr="(//div[hasclass('o_grid_item')])[4]" position="attributes">
+        <attribute name="class" add="o_cc5" remove="o_cc3" separator=" "/>
+    </xpath>
+</template>
+
+</odoo>

--- a/theme_vehicle/views/customizations.xml
+++ b/theme_vehicle/views/customizations.xml
@@ -937,4 +937,19 @@
     </xpath>
 </template>
 
+<template id="s_numbers_boxed" inherit_id="website.s_numbers_boxed">
+    <!-- Grid Item -->
+    <xpath expr="//div[hasclass('o_grid_item')][2]" position="attributes">
+        <attribute name="class" add="o_cc5" remove="o_cc3" separator=" "/>
+    </xpath>
+    <!-- Grid Item 2 -->
+    <xpath expr="(//div[hasclass('o_grid_item')])[3]" position="attributes">
+        <attribute name="class" add="o_cc5" remove="o_cc3" separator=" "/>
+    </xpath>
+    <!-- Grid Item 3 -->
+    <xpath expr="(//div[hasclass('o_grid_item')])[4]" position="attributes">
+        <attribute name="class" add="o_cc5" remove="o_cc3" separator=" "/>
+    </xpath>
+</template>
+
 </odoo>

--- a/theme_yes/__manifest__.py
+++ b/theme_yes/__manifest__.py
@@ -60,6 +60,7 @@
         'views/snippets/s_empowerment.xml',
         'views/snippets/s_image_text_overlap.xml',
         'views/snippets/s_features.xml',
+        'views/snippets/s_numbers_boxed.xml',
         'views/new_page_template.xml',
     ],
     'images': [

--- a/theme_yes/views/snippets/s_numbers_boxed.xml
+++ b/theme_yes/views/snippets/s_numbers_boxed.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+
+<template id="s_numbers_boxed" inherit_id="website.s_numbers_boxed">
+    <!-- Grid Item -->
+    <xpath expr="//div[hasclass('o_grid_item')][2]" position="attributes">
+        <attribute name="class" add="o_cc4" remove="o_cc3" separator=" "/>
+    </xpath>
+    <!-- Grid Item 2 -->
+    <xpath expr="(//div[hasclass('o_grid_item')])[3]" position="attributes">
+        <attribute name="class" add="o_cc4" remove="o_cc3" separator=" "/>
+    </xpath>
+    <!-- Grid Item 3 -->
+    <xpath expr="(//div[hasclass('o_grid_item')])[4]" position="attributes">
+        <attribute name="class" add="o_cc4" remove="o_cc3" separator=" "/>
+    </xpath>
+</template>
+
+</odoo>

--- a/theme_zap/__manifest__.py
+++ b/theme_zap/__manifest__.py
@@ -51,6 +51,7 @@
         'views/snippets/s_big_number.xml',
         'views/snippets/s_images_constellation.xml',
         'views/snippets/s_empowerment.xml',
+        'views/snippets/s_numbers_boxed.xml',
         'views/new_page_template.xml',
     ],
     'images': [

--- a/theme_zap/views/snippets/s_numbers_boxed.xml
+++ b/theme_zap/views/snippets/s_numbers_boxed.xml
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+
+<template id="s_numbers_boxed" inherit_id="website.s_numbers_boxed">
+    <!-- Section -->
+    <xpath expr="//section" position="attributes">
+        <attribute name="class" add="o_cc3" remove="o_cc5" separator=" "/>
+    </xpath>
+    <!-- Grid Item -->
+    <xpath expr="//div[hasclass('o_grid_item')][2]" position="attributes">
+        <attribute name="class" add="o_cc5" remove="o_cc3" separator=" "/>
+    </xpath>
+    <!-- Grid Item 2 -->
+    <xpath expr="(//div[hasclass('o_grid_item')])[3]" position="attributes">
+        <attribute name="class" add="o_cc5" remove="o_cc3" separator=" "/>
+    </xpath>
+    <!-- Grid Item 3 -->
+    <xpath expr="(//div[hasclass('o_grid_item')])[4]" position="attributes">
+        <attribute name="class" add="o_cc5" remove="o_cc3" separator=" "/>
+    </xpath>
+</template>
+
+</odoo>


### PR DESCRIPTION
*: anelusia, artists, avantgarde, aviato, beauty, bewise, bistro, bookstore, buzzy, clean, cobalt, enark, kea, kiddo, loftspace, monglia, nano, notes, odoo_experts, orchid, paptic, real_estate, treehouse, vehicle, yes, zap

This commit reviews the occurrences of the `s_numbers_boxed` snippet within themes

task-4094382
Part of task-4077427

- requires https://github.com/odoo/odoo/pull/175701