### PR TITLE
[FIX] theme_cobalt, theme_paptic: add some missing image classes

### DIFF
--- a/theme_cobalt/views/customizations.xml
+++ b/theme_cobalt/views/customizations.xml
@@ -25,7 +25,7 @@
     <!-- Image -->
     <xpath expr="//div[hasclass('col-lg-6')]" position="after">
         <div class="pt16 pb16 o_colored_level col-lg-5 offset-lg-1">
-            <img src="/web_editor/shape/theme_cobalt/s_banner.svg?c1=o-color-1" style="width: 100%;" alt="Marketing"/>
+            <img src="/web_editor/shape/theme_cobalt/s_banner.svg?c1=o-color-1" class="img img-fluid mx-auto" style="width: 100%;" alt="Marketing"/>
         </div>
     </xpath>
     <!-- Content -->
@@ -67,7 +67,7 @@
     </xpath>
     <!-- Image -->
     <xpath expr="//img" position="replace">
-        <img src="/web_editor/shape/theme_cobalt/s_image_text.svg?c1=o-color-1" style="width: 100%;" alt="Marketing"/>
+        <img src="/web_editor/shape/theme_cobalt/s_image_text.svg?c1=o-color-1" class="img img-fluid mx-auto" style="width: 100%;" alt="Marketing"/>
     </xpath>
     <!-- Content -->
     <xpath expr="//h2" position="replace" mode="inner">
@@ -100,7 +100,7 @@
         What we can do, <b>for you</b><br/>
     </xpath>
     <xpath expr="//img" position="replace">
-            <img src="/web_editor/shape/theme_cobalt/s_text_image.svg?c1=o-color-1" style="width: 100%;" alt="Marketing"/>
+            <img src="/web_editor/shape/theme_cobalt/s_text_image.svg?c1=o-color-1" class="img img-fluid mx-auto" style="width: 100%;" alt="Marketing"/>
     </xpath>
     <xpath expr="//p" position="replace"/>
     <xpath expr="//p" position="replace">

--- a/theme_paptic/views/customizations.xml
+++ b/theme_paptic/views/customizations.xml
@@ -49,7 +49,7 @@
         <div class="row">
             <div class="o_colored_level col-lg-6"/>
             <div class="o_colored_level col-lg-6">
-                <img src="/web_editor/shape/theme_paptic/s_cover_person.svg?c1=o-color-1" style="width: 100%;" alt="Man waiting at the airport"/>
+                <img src="/web_editor/shape/theme_paptic/s_cover_person.svg?c1=o-color-1" class="img img-fluid mx-auto" style="width: 100%;" alt="Man waiting at the airport"/>
             </div>
         </div>
     </xpath>


### PR DESCRIPTION
In some theme customizations, some replaced images do not have the usual image classes `img img-fluid mx-auto` anymore. The `img-fluid` one is needed for grid images in mobile view, as they are overflowing without it.

This commit adds these missing classes on the identified problematic images.