### PR TITLE
[FIX] theme_odoo_experts: remove unused configurator snippets

### DIFF
--- a/theme_odoo_experts/views/snippets/s_picture.xml
+++ b/theme_odoo_experts/views/snippets/s_picture.xml
@@ -44,15 +44,4 @@
     <xpath expr="//figcaption" position="replace"/>
 </template>
 
-<template id="configurator_s_picture" inherit_id="website.configurator_s_picture">
-    <!-- Shape option -->
-    <xpath expr="//section" position="attributes">
-        <attribute name="data-oe-shape-data">{"shape":"web_editor/Wavy/08","flip":["y"]}</attribute>
-    </xpath>
-    <!-- Shape -->
-    <xpath expr="//div[hasclass('o_container_small')]" position="before">
-        <div class="o_we_shape o_web_editor_Wavy_08" style="background-image: url('/web_editor/shape/web_editor/Wavy/08.svg?c2=o-color-3&amp;flip=y'); background-position: 50% 100%;"/>
-    </xpath>
-</template>
-
 </odoo>


### PR DESCRIPTION
Currently, an error occurs while importing an 'Experts' theme template.

Step to produce:

- Install the ```website``` module.
- Build one website. And try to switch its theme with the 'Experts' theme which is available in odoo.

```ValueError: External ID not found in the system: website.configurator_s_picture```

When switching a website theme with the 'Experts' theme template, an error occurs during importing their XML definition because their parent template does not exist. To resolve this issue we can remove this template from XML. reference PR: https://github.com/odoo/design-themes/commit/aed6d0585be5c646e1c3cade419c706dc154efaf

Sentry-5962594281