### PR TITLE
[FIX] theme_artists: add missing `o_colored_level` class

### DIFF
--- a/theme_artists/views/snippets/s_image_text_box.xml
+++ b/theme_artists/views/snippets/s_image_text_box.xml
@@ -4,7 +4,7 @@
 <template id="s_image_text_box" inherit_id="website.s_image_text_box">
     <!-- Section -->
     <xpath expr="//section" position="attributes">
-        <attribute name="class" add="o_cc o_cc5" separator=" "/>
+        <attribute name="class" add="o_colored_level o_cc o_cc5" separator=" "/>
         <attribute name="data-oe-shape-data">{'shape': 'web_editor/Connections/08','colors':{'c5':'o-color-1'}}</attribute>
     </xpath>
     <xpath expr="//div[hasclass('o_we_shape')]" position="attributes">


### PR DESCRIPTION
This PR adds a missing `o_colored_level` class on the section.

With the themes revamp, we reviewed the design of a lot of snippets, which sometimes included colors adjustments using `o_cc o_cc*` classes.

While the visual result is okay on the page, the title of the snippet will be invisible in the modal as two `o_cc o_cc*` are nested without having an `o_colored_level` class on the section.

| Master | This PR |
|--------|--------|
| <img width="467" alt="image" src="https://github.com/user-attachments/assets/9498a409-608e-4efb-b333-396b572d124c"> | <img width="466" alt="image" src="https://github.com/user-attachments/assets/1f6a6632-0ef8-4188-912f-307897aeae6e"> | 

task-4255088
related to task-4177975