### PR TITLE
[IMP] theme_*: adapt `s_comparisons_horizontal` to themes

### DIFF
--- a/theme_anelusia/__manifest__.py
+++ b/theme_anelusia/__manifest__.py
@@ -21,6 +21,7 @@
         'views/snippets/s_image_gallery.xml',
         'views/snippets/s_carousel.xml',
         'views/snippets/s_carousel_intro.xml',
+        'views/snippets/s_comparisons_horizontal.xml',
         'views/snippets/s_media_list.xml',
         'views/snippets/s_image_title.xml',
         'views/snippets/s_text_cover.xml',

--- a/theme_anelusia/views/snippets/s_comparisons_horizontal.xml
+++ b/theme_anelusia/views/snippets/s_comparisons_horizontal.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+
+<template id="s_comparisons_horizontal" inherit_id="website.s_comparisons_horizontal">
+    <xpath expr="//h2" position="replace" mode="inner">
+        <font style="background-image: linear-gradient(135deg, var(--o-color-1) 0%, var(--o-color-2) 100%);" class="text-gradient">Our Style Plans</font>
+    </xpath>
+</template>
+
+</odoo>

--- a/theme_artists/__manifest__.py
+++ b/theme_artists/__manifest__.py
@@ -20,6 +20,7 @@
         'views/snippets/s_text_image.xml',
         'views/snippets/s_framed_intro.xml',
         'views/snippets/s_card_offset.xml',
+        'views/snippets/s_comparisons_horizontal.xml',
         'views/snippets/s_three_columns.xml',
         'views/snippets/s_call_to_action.xml',
         'views/snippets/s_cards_grid.xml',

--- a/theme_artists/views/snippets/s_comparisons_horizontal.xml
+++ b/theme_artists/views/snippets/s_comparisons_horizontal.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+
+    <template id="s_comparisons_horizontal" inherit_id="website.s_comparisons_horizontal">
+        <!-- Section -->
+        <xpath expr="//section" position="attributes">
+            <attribute name="class" add="o_cc o_cc5" separator=" "/>
+        </xpath>
+    </template>
+
+</odoo>

--- a/theme_avantgarde/views/customizations.xml
+++ b/theme_avantgarde/views/customizations.xml
@@ -801,4 +801,12 @@
     </xpath>
 </template>
 
+<!-- ======== COMPARISONS HORIZONTAL ======== -->
+<template id="s_comparisons_horizontal" inherit_id="website.s_comparisons_horizontal">
+    <!-- Section -->
+    <xpath expr="//section" position="attributes">
+        <attribute name="class" add="o_cc o_cc3" separator=" "/>
+    </xpath>
+</template>
+
 </odoo>

--- a/theme_aviato/__manifest__.py
+++ b/theme_aviato/__manifest__.py
@@ -17,6 +17,7 @@
         'views/snippets/s_cta_box.xml',
         'views/snippets/s_cover.xml',
         'views/snippets/s_company_team.xml',
+        'views/snippets/s_comparisons_horizontal.xml',
         'views/snippets/s_striped_top.xml',
         'views/snippets/s_features.xml',
         'views/snippets/s_sidegrid.xml',

--- a/theme_aviato/views/snippets/s_comparisons_horizontal.xml
+++ b/theme_aviato/views/snippets/s_comparisons_horizontal.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+
+<template id="s_comparisons_horizontal" inherit_id="website.s_comparisons_horizontal">
+    <!-- Card 1 -->
+    <xpath expr="//div[hasclass('s_card')]" position="attributes">
+        <attribute name="class" add="o_cc2" remove="o_cc1" separator=" "/>
+    </xpath>
+    <!-- Card 2 -->
+    <xpath expr="(//div[hasclass('s_card')])[2]" position="attributes">
+        <attribute name="class" add="o_cc2" remove="o_cc1" separator=" "/>
+    </xpath>
+</template>
+
+</odoo>

--- a/theme_beauty/__manifest__.py
+++ b/theme_beauty/__manifest__.py
@@ -38,6 +38,7 @@
         'views/snippets/s_company_team_detail.xml',
         'views/snippets/s_media_list.xml',
         'views/snippets/s_comparisons.xml',
+        'views/snippets/s_comparisons_horizontal.xml',
         'views/snippets/s_product_catalog.xml',
         'views/snippets/s_quadrant.xml',
         'views/snippets/s_unveil.xml',

--- a/theme_beauty/views/snippets/s_comparisons_horizontal.xml
+++ b/theme_beauty/views/snippets/s_comparisons_horizontal.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+
+<template id="s_comparisons_horizontal" inherit_id="website.s_comparisons_horizontal">
+    <!-- Section -->
+    <xpath expr="//section" position="attributes">
+        <attribute name="class" add="o_cc o_cc2" separator=" "/>
+    </xpath>
+</template>
+
+</odoo>

--- a/theme_bistro/__manifest__.py
+++ b/theme_bistro/__manifest__.py
@@ -19,6 +19,7 @@
         'views/snippets/s_cards_grid.xml',
         'views/snippets/s_cover.xml',
         'views/snippets/s_card_offset.xml',
+        'views/snippets/s_comparisons_horizontal.xml',
         'views/snippets/s_features.xml',
         'views/snippets/s_image_text.xml',
         'views/snippets/s_freegrid.xml',

--- a/theme_bistro/views/snippets/s_comparisons_horizontal.xml
+++ b/theme_bistro/views/snippets/s_comparisons_horizontal.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+
+<template id="s_comparisons_horizontal" inherit_id="website.s_comparisons_horizontal">
+    <!-- Section -->
+    <xpath expr="//section" position="attributes">
+        <attribute name="class" add="o_cc o_cc4" separator=" "/>
+    </xpath>
+</template>
+
+</odoo>

--- a/theme_enark/__manifest__.py
+++ b/theme_enark/__manifest__.py
@@ -17,6 +17,7 @@
         'views/snippets/s_banner.xml',
         'views/snippets/s_striped_top.xml',
         'views/snippets/s_cards_grid.xml',
+        'views/snippets/s_comparisons_horizontal.xml',
         'views/snippets/s_cover.xml',
         'views/snippets/s_card_offset.xml',
         'views/snippets/s_company_team_detail.xml',

--- a/theme_enark/views/snippets/s_comparisons_horizontal.xml
+++ b/theme_enark/views/snippets/s_comparisons_horizontal.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+
+<template id="s_comparisons_horizontal" inherit_id="website.s_comparisons_horizontal">
+    <!-- Section -->
+    <xpath expr="//section" position="attributes">
+        <attribute name="class" add="o_cc o_cc2" separator=" "/>
+    </xpath>
+</template>
+
+</odoo>

--- a/theme_kea/__manifest__.py
+++ b/theme_kea/__manifest__.py
@@ -16,6 +16,7 @@
         'views/snippets/s_cover.xml',
         'views/snippets/s_striped_top.xml',
         'views/snippets/s_card_offset.xml',
+        'views/snippets/s_comparisons_horizontal.xml',
         'views/snippets/s_image_text.xml',
         'views/snippets/s_images_mosaic.xml',
         'views/snippets/s_text_image.xml',

--- a/theme_kea/views/snippets/s_comparisons_horizontal.xml
+++ b/theme_kea/views/snippets/s_comparisons_horizontal.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+
+<template id="s_comparisons_horizontal" inherit_id="website.s_comparisons_horizontal">
+    <!-- Section -->
+    <xpath expr="//section" position="attributes">
+        <attribute name="class" add="o_cc o_cc2" separator=" "/>
+        <attribute name="data-oe-shape-data">{"shape":"web_editor/Floats/04","flip":[]}</attribute>
+    </xpath>
+    <!-- Shape -->
+    <xpath expr="//div[hasclass('container')]" position="before">
+        <div class="o_we_shape o_web_editor_Floats_04"/>
+    </xpath>
+</template>
+
+</odoo>

--- a/theme_loftspace/__manifest__.py
+++ b/theme_loftspace/__manifest__.py
@@ -19,6 +19,7 @@
         'views/snippets/s_title.xml',
         'views/snippets/s_three_columns.xml',
         'views/snippets/s_call_to_action.xml',
+        'views/snippets/s_comparisons_horizontal.xml',
         'views/snippets/s_sidegrid.xml',
         'views/snippets/s_image_gallery.xml',
         'views/snippets/s_freegrid.xml',

--- a/theme_loftspace/views/snippets/s_comparisons_horizontal.xml
+++ b/theme_loftspace/views/snippets/s_comparisons_horizontal.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+
+<template id="s_comparisons_horizontal" inherit_id="website.s_comparisons_horizontal">
+    <!-- Section -->
+    <xpath expr="//section" position="attributes">
+        <attribute name="class" add="o_cc o_cc2" separator=" "/>
+    </xpath>
+</template>
+
+</odoo>

--- a/theme_monglia/views/customizations.xml
+++ b/theme_monglia/views/customizations.xml
@@ -1028,4 +1028,20 @@
     <xpath expr="//p" position="replace"/>
 </template>
 
+<!-- ======== COMPARISONS HORIZONTAL ======== -->
+<template id="s_comparisons_horizontal" inherit_id="website.s_comparisons_horizontal">
+    <!-- Section -->
+    <xpath expr="//section" position="attributes">
+        <attribute name="class" add="o_cc o_cc4" separator=" "/>
+    </xpath>
+    <!-- Card 1 -->
+    <xpath expr="//div[hasclass('s_card')]" position="attributes">
+        <attribute name="class" add="o_cc5" remove="o_cc1" separator=" "/>
+    </xpath>
+    <!-- Card 2 -->
+    <xpath expr="(//div[hasclass('s_card')])[2]" position="attributes">
+        <attribute name="class" add="o_cc5" remove="o_cc1" separator=" "/>
+    </xpath>
+</template>
+
 </odoo>

--- a/theme_nano/__manifest__.py
+++ b/theme_nano/__manifest__.py
@@ -16,6 +16,7 @@
         'views/snippets/s_cta_box.xml',
         'views/snippets/s_banner.xml',
         'views/snippets/s_carousel.xml',
+        'views/snippets/s_comparisons_horizontal.xml',
         'views/snippets/s_cover.xml',
         'views/snippets/s_motto.xml',
         'views/snippets/s_card_offset.xml',

--- a/theme_nano/views/snippets/s_comparisons_horizontal.xml
+++ b/theme_nano/views/snippets/s_comparisons_horizontal.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+
+    <template id="s_comparisons_horizontal" inherit_id="website.s_comparisons_horizontal">
+        <!-- Section -->
+        <xpath expr="//section" position="attributes">
+            <attribute name="class" add="o_cc o_cc5" separator=" "/>
+        </xpath>
+    </template>
+
+</odoo>

--- a/theme_notes/__manifest__.py
+++ b/theme_notes/__manifest__.py
@@ -17,6 +17,7 @@
         'views/snippets/s_striped_top.xml',
         'views/snippets/s_cards_grid.xml',
         'views/snippets/s_carousel_intro.xml',
+        'views/snippets/s_comparisons_horizontal.xml',
         'views/snippets/s_image_text.xml',
         'views/snippets/s_images_mosaic.xml',
         'views/snippets/s_media_list.xml',

--- a/theme_notes/views/snippets/s_comparisons_horizontal.xml
+++ b/theme_notes/views/snippets/s_comparisons_horizontal.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+
+    <template id="s_comparisons_horizontal" inherit_id="website.s_comparisons_horizontal">
+        <!-- Section -->
+        <xpath expr="//section" position="attributes">
+            <attribute name="class" add="o_cc o_cc3" separator=" "/>
+        </xpath>
+    </template>
+
+</odoo>

--- a/theme_orchid/__manifest__.py
+++ b/theme_orchid/__manifest__.py
@@ -28,6 +28,7 @@
         'views/snippets/s_image_text_overlap.xml',
         'views/snippets/s_quotes_carousel.xml',
         'views/snippets/s_carousel_intro.xml',
+        'views/snippets/s_comparisons_horizontal.xml',
         'views/snippets/s_quotes_carousel_minimal.xml',
         'views/snippets/s_features_wall.xml',
         'views/snippets/s_call_to_action.xml',

--- a/theme_orchid/views/snippets/s_comparisons_horizontal.xml
+++ b/theme_orchid/views/snippets/s_comparisons_horizontal.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+
+    <template id="s_comparisons_horizontal" inherit_id="website.s_comparisons_horizontal">
+        <!-- Section -->
+        <xpath expr="//section" position="attributes">
+            <attribute name="class" add="o_cc o_cc5" separator=" "/>
+        </xpath>
+    </template>
+
+</odoo>

--- a/theme_treehouse/__manifest__.py
+++ b/theme_treehouse/__manifest__.py
@@ -19,6 +19,7 @@
         'views/snippets/s_carousel_intro.xml',
         'views/snippets/s_color_blocks_2.xml',
         'views/snippets/s_comparisons.xml',
+        'views/snippets/s_comparisons_horizontal.xml',
         'views/snippets/s_company_team_detail.xml',
         'views/snippets/s_cover.xml',
         'views/snippets/s_card_offset.xml',

--- a/theme_treehouse/views/snippets/s_comparisons_horizontal.xml
+++ b/theme_treehouse/views/snippets/s_comparisons_horizontal.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+
+<template id="s_comparisons_horizontal" inherit_id="website.s_comparisons_horizontal">
+    <!-- Section -->
+    <xpath expr="//section" position="attributes">
+        <attribute name="class" add="o_cc o_cc3" separator=" "/>
+    </xpath>
+</template>
+
+</odoo>

--- a/theme_vehicle/views/customizations.xml
+++ b/theme_vehicle/views/customizations.xml
@@ -929,4 +929,12 @@
     </xpath>
 </template>
 
+<!-- ======== COMPARISONS HORIZONTAL ======== -->
+<template id="s_comparisons_horizontal" inherit_id="website.s_comparisons_horizontal">
+    <!-- Section -->
+    <xpath expr="//section" position="attributes">
+        <attribute name="class" add="o_cc o_cc5" separator=" "/>
+    </xpath>
+</template>
+
 </odoo>

--- a/theme_yes/__manifest__.py
+++ b/theme_yes/__manifest__.py
@@ -22,6 +22,7 @@
         'views/snippets/s_company_team.xml',
         'views/snippets/s_company_team_detail.xml',
         'views/snippets/s_company_team_basic.xml',
+        'views/snippets/s_comparisons_horizontal.xml',
         'views/snippets/s_cover.xml',
         'views/snippets/s_card_offset.xml',
         'views/snippets/s_image_text.xml',

--- a/theme_yes/views/snippets/s_comparisons_horizontal.xml
+++ b/theme_yes/views/snippets/s_comparisons_horizontal.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+
+    <template id="s_comparisons_horizontal" inherit_id="website.s_comparisons_horizontal">
+        <!-- Section -->
+        <xpath expr="//section" position="attributes">
+            <attribute name="class" add="o_cc o_cc2" separator=" "/>
+        </xpath>
+    </template>
+
+</odoo>

--- a/theme_zap/__manifest__.py
+++ b/theme_zap/__manifest__.py
@@ -15,6 +15,7 @@
         'views/snippets/s_banner.xml',
         'views/snippets/s_discovery.xml',
         'views/snippets/s_comparisons.xml',
+        'views/snippets/s_comparisons_horizontal.xml',
         'views/snippets/s_showcase.xml',
         'views/snippets/s_cta_card.xml',
         'views/snippets/s_striped_top.xml',

--- a/theme_zap/views/snippets/s_comparisons_horizontal.xml
+++ b/theme_zap/views/snippets/s_comparisons_horizontal.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+
+<template id="s_comparisons_horizontal" inherit_id="website.s_comparisons_horizontal">
+    <!-- Card 1 -->
+    <xpath expr="//div[hasclass('s_card')]" position="attributes">
+        <attribute name="class" add="o_cc2" remove="o_cc1" separator=" "/>
+    </xpath>
+    <!-- Card 2 -->
+    <xpath expr="(//div[hasclass('s_card')])[2]" position="attributes">
+        <attribute name="class" add="o_cc2" remove="o_cc1" separator=" "/>
+    </xpath>
+</template>
+
+</odoo>


### PR DESCRIPTION
*: theme_anelusia, theme_artists, theme_avantgarde, theme_aviato, theme_beauty, theme_bistro, theme_enark, theme_kea, theme_loftspace, theme_monglia, theme_nano, theme_notes, theme_orchid, theme_treehouse, theme_vehicle, theme_yes, theme_zap

This commit adapts the themes to the new `s_comparisons_horizontal` snippet.

task-4105264
Part of task-4077427

Community PR: https://github.com/odoo/odoo/pull/184281