### PR TITLE
[FIX] *: remove automatic text selection on click

### DIFF
--- a/theme_buzzy/views/snippets/s_banner.xml
+++ b/theme_buzzy/views/snippets/s_banner.xml
@@ -18,7 +18,7 @@
       <attribute name="style"/>
    </xpath>
    <xpath expr="//h1" position="replace" mode="inner">
-      Unleash your <strong class="o_default_snippet_text"><span class="o_text_highlight o_translate_inline o_text_highlight_scribble_3 o_text_highlight_fill">potential</span>.</strong>
+      Unleash your <strong><span class="o_text_highlight o_translate_inline o_text_highlight_scribble_3 o_text_highlight_fill">potential</span>.</strong>
    </xpath>
    <xpath expr="//div[hasclass('row')]//div[2]//img" position="attributes">
       <attribute name="src">/web_editor/shape/theme_buzzy/s_banner_2.svg?c1=o-color-2</attribute>

--- a/theme_clean/views/snippets/s_banner.xml
+++ b/theme_clean/views/snippets/s_banner.xml
@@ -4,7 +4,7 @@
 <template id="s_banner" inherit_id="website.s_banner">
     <!-- Text -->
     <xpath expr="//h1" position="replace">
-        <h1 class="display-3 o_default_snippet_text">Unleash your <strong class="o_default_snippet_text"><span class="o_text_highlight o_translate_inline o_text_highlight_circle_2 o_text_highlight_fill">potential</span>.</strong></h1>
+        <h1 class="display-3">Unleash your <strong><span class="o_text_highlight o_translate_inline o_text_highlight_circle_2 o_text_highlight_fill">potential</span>.</strong></h1>
     </xpath>
     <!-- Remove panels -->
     <xpath expr="(//div[hasclass('o_grid_item_image')])[2]" position="replace"/>

--- a/theme_common/static/src/old_snippets/s_big_icons/000_variables.scss
+++ b/theme_common/static/src/old_snippets/s_big_icons/000_variables.scss
@@ -11,10 +11,6 @@ $s-big-icon-circle-icon-size: 120px;
             .fa {
                 color: o-color('alpha') !important;
             }
-            h5.o_default_snippet_text {
-                color: $font-color;
-                margin-top: 20px;
-            }
         }
         &:hover .s_big_icons_icon {
             @include o-theme-chd-big-icons-styles($h5-color: o-color('alpha'));

--- a/theme_common/static/src/scss/mixins.scss
+++ b/theme_common/static/src/scss/mixins.scss
@@ -790,9 +790,6 @@
     .fa {
         color: $fa-color !important;
     }
-    h5.o_default_snippet_text {
-        color: $h5-color !important;
-    }
 }
 
 @mixin o-theme-sri-bg-effects-styles(

--- a/theme_graphene/views/customizations.xml
+++ b/theme_graphene/views/customizations.xml
@@ -18,11 +18,11 @@
                 <h1>
                     Making the difference.
                 </h1>
-                <p class="lead o_default_snippet_text">
+                <p class="lead">
                     Our mission is to give customers the best experience.<br/>Extensive documentation &amp; guides, an active community,<br/>24/7 support make it a pleasure to work with us.
                 </p>
                 <p>
-                    <a t-att-href="cta_btn_href" class="btn btn-primary btn-lg o_default_snippet_text"><t t-esc="cta_btn_text">Contact us</t></a>
+                    <a t-att-href="cta_btn_href" class="btn btn-primary btn-lg"><t t-esc="cta_btn_text">Contact us</t></a>
                 </p>
             </div>
         </div>

--- a/theme_kiddo/views/snippets/s_cover.xml
+++ b/theme_kiddo/views/snippets/s_cover.xml
@@ -38,7 +38,7 @@
 
     <!-- Paragraph -->
     <xpath expr="//p[last()]" position="before">
-        <p class="lead o_default_snippet_text" style="text-align: center;">
+        <p class="lead" style="text-align: center;">
             <br/>
         </p>
     </xpath>

--- a/theme_odoo_experts/views/snippets/s_mockup_image.xml
+++ b/theme_odoo_experts/views/snippets/s_mockup_image.xml
@@ -11,14 +11,14 @@
     <xpath expr="//div[hasclass('o_we_shape')]" position="replace"/>
     <xpath expr="//div[hasclass('col-lg-4')]" position="replace">
         <div class="col-lg-5 pt16 pb16">
-            <h1 class="o_default_snippet_text">
+            <h1>
                 Unlock the
                 <span class="o_text_highlight o_translate_inline o_text_highlight_circle_1" style="--text-highlight-color: var(--o-color-1); --text-highlight-width: 6px;"><span class="o_text_highlight_item">growth</span></span>
                 of your business
             </h1>
             <p>With over 15 years of proven success, we deliver expert guidance and strategic insights for your business’s future.</p>
             <p><br/></p>
-            <a t-att-href="cta_btn_href" class="btn btn-primary btn-lg o_default_snippet_text"><t t-esc="cta_btn_text">Learn more</t></a>
+            <a t-att-href="cta_btn_href" class="btn btn-primary btn-lg"><t t-esc="cta_btn_text">Learn more</t></a>
         </div>
     </xpath>
     <xpath expr="//div[hasclass('col-lg-8')]" position="attributes">

--- a/theme_test_custo/data/pages.xml
+++ b/theme_test_custo/data/pages.xml
@@ -27,7 +27,7 @@
             <section class="s_text_block pt80 pb200" data-name="Text" data-oe-shape-data="{'shape': 'theme_test_custo/curves/01','flip':[]}">
                 <div class="o_we_shape o_theme_test_custo_curves_01"/>
                 <div class="s_allow_columns container">
-                    <p class="o_default_snippet_text">Great stories have a <b class="o_default_snippet_text">personality</b>. Consider telling a great story that provides personality. Writing a story with personality for potential clients will assist with making a relationship connection. This shows up in small quirks like word choices or phrases. Write from your point of view, not from someone else's experience.</p>
+                    <p>Great stories have a <b>personality</b>. Consider telling a great story that provides personality. Writing a story with personality for potential clients will assist with making a relationship connection. This shows up in small quirks like word choices or phrases. Write from your point of view, not from someone else's experience.</p>
                 </div>
             </section>
 


### PR DESCRIPTION
*: theme_buzzy, theme_clean, theme_common, theme_graphene, theme_kiddo, theme_odoo_experts, theme_test_custo

This commit removes the default behavior of automatically selecting text when clicking on an element that contains pre-defined text originating from templates. Previously, when interacting with such elements, the default template text would be highlighted upon click, which could lead to unintended user experiences, especially in scenarios where the user does not expect or desire the selection of content by default. By eliminating this automatic selection, we ensure a more intuitive and streamlined interaction, giving users greater control over their text editing process when working with elements populated from templates.

task-4147162