### PR TITLE
[IMP] theme_*: adapt `s_timeline_images` to themes

### DIFF
--- a/theme_anelusia/__manifest__.py
+++ b/theme_anelusia/__manifest__.py
@@ -54,6 +54,7 @@
         'views/snippets/s_accordion_image.xml',
         'views/snippets/s_pricelist_boxed.xml',
         'views/snippets/s_striped_center_top.xml',
+        'views/snippets/s_timeline_images.xml',
         'views/snippets/s_key_images.xml',
         'views/snippets/s_big_number.xml',
         'views/snippets/s_image_frame.xml',

--- a/theme_anelusia/views/snippets/s_timeline_images.xml
+++ b/theme_anelusia/views/snippets/s_timeline_images.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+
+<template id="s_timeline_images" inherit_id="website.s_timeline_images">
+    <!-- Title -->
+    <xpath expr="//h2" position="replace" mode="inner">
+        <font style="background-image: linear-gradient(135deg, var(--o-color-1) 0%, var(--o-color-2) 100%);" class="text-gradient">Our journey</font>
+    </xpath>
+</template>
+
+</odoo>

--- a/theme_artists/__manifest__.py
+++ b/theme_artists/__manifest__.py
@@ -97,6 +97,7 @@
         'views/snippets/s_table_of_content.xml',
         'views/snippets/s_tabs.xml',
         'views/snippets/s_timeline.xml',
+        'views/snippets/s_timeline_images.xml',
         'views/snippets/s_timeline_list.xml',
         'views/snippets/s_title_form.xml',
         'views/snippets/s_unveil.xml',

--- a/theme_artists/views/snippets/s_timeline_images.xml
+++ b/theme_artists/views/snippets/s_timeline_images.xml
@@ -1,0 +1,31 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+
+<template id="s_timeline_images" inherit_id="website.s_timeline_images">
+    <!-- Section -->
+    <xpath expr="//section" position="attributes">
+        <attribute name="class" add="o_cc o_cc5" separator=" "/>
+    </xpath>
+    <!-- Milestone #1-->
+    <xpath expr="//img" position="attributes">
+        <attribute name="class" remove="rounded" separator=" "/>
+    </xpath>
+    <xpath expr="//span[hasclass('o_dot')]" position="attributes">
+        <attribute name="class" add="text-o-color-4" remove="text-o-color-1" separator=" "/>
+    </xpath>
+    <xpath expr="//div[hasclass('o_dot_line')]" position="attributes">
+        <attribute name="style">border-color: var(--o-color-1) !important;</attribute>
+    </xpath>
+    <!-- Milestone #2 -->
+    <xpath expr="(//img)[2]" position="attributes">
+        <attribute name="class" remove="rounded" separator=" "/>
+    </xpath>
+    <xpath expr="(//span[hasclass('o_dot')])[2]" position="attributes">
+        <attribute name="class" add="text-o-color-4" remove="text-o-color-1" separator=" "/>
+    </xpath>
+    <xpath expr="(//div[hasclass('o_dot_line')])[2]" position="attributes">
+        <attribute name="style">border-color: var(--o-color-1) !important;</attribute>
+    </xpath>
+</template>
+
+</odoo>

--- a/theme_buzzy/__manifest__.py
+++ b/theme_buzzy/__manifest__.py
@@ -59,6 +59,7 @@
         'views/snippets/s_image_punchy.xml',
         'views/snippets/s_striped_center_top.xml',
         'views/snippets/s_company_team_card.xml',
+        'views/snippets/s_timeline_images.xml',
         'views/snippets/s_image_title.xml',
         'views/snippets/s_key_images.xml',
         'views/snippets/s_big_number.xml',

--- a/theme_buzzy/views/snippets/s_timeline_images.xml
+++ b/theme_buzzy/views/snippets/s_timeline_images.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+
+<template id="s_timeline_images" inherit_id="website.s_timeline_images">
+   <!-- Milestone #1-->
+   <xpath expr="//span[hasclass('o_dot')]" position="attributes">
+      <attribute name="class" add="text-o-color-2" remove="text-o-color-1" separator=" "/>
+   </xpath>
+   <!-- Milestone #2 -->
+   <xpath expr="(//span[hasclass('o_dot')])[2]" position="attributes">
+      <attribute name="class" add="text-o-color-2" remove="text-o-color-1" separator=" "/>
+   </xpath>
+</template>
+
+</odoo>

--- a/theme_nano/__manifest__.py
+++ b/theme_nano/__manifest__.py
@@ -43,6 +43,7 @@
         'views/snippets/s_image_frame.xml',
         'views/snippets/s_shape_image.xml',
         'views/snippets/s_text_cover.xml',
+        'views/snippets/s_timeline_images.xml',
         'views/snippets/s_empowerment.xml',
         'views/snippets/s_discovery.xml',
         'views/snippets/s_numbers.xml',

--- a/theme_nano/views/snippets/s_timeline_images.xml
+++ b/theme_nano/views/snippets/s_timeline_images.xml
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+
+<template id="s_timeline_images" inherit_id="website.s_timeline_images">
+    <!-- Section -->
+    <xpath expr="//section" position="attributes">
+        <attribute name="class" add="o_cc o_cc5" separator=" "/>
+    </xpath>
+    <!-- Milestone #1-->
+    <xpath expr="//span[hasclass('o_dot')]" position="attributes">
+        <attribute name="class" add="text-o-color-4" remove="text-o-color-1" separator=" "/>
+    </xpath>
+    <xpath expr="//div[hasclass('o_dot_line')]" position="attributes">
+        <attribute name="style">border-color: var(--o-color-1) !important;</attribute>
+    </xpath>
+    <!-- Milestone #2 -->
+    <xpath expr="(//span[hasclass('o_dot')])[2]" position="attributes">
+        <attribute name="class" add="text-o-color-4" remove="text-o-color-1" separator=" "/>
+    </xpath>
+    <xpath expr="(//div[hasclass('o_dot_line')])[2]" position="attributes">
+        <attribute name="style">border-color: var(--o-color-1) !important;</attribute>
+    </xpath>
+</template>
+
+</odoo>

--- a/theme_yes/views/images.xml
+++ b/theme_yes/views/images.xml
@@ -497,4 +497,16 @@ Check in theme_kea's primary_variables.scss, theme.scss and theme_common's mixin
     <field name="url">/theme_yes/static/src/img/snippets/library_image_10.webp</field>
 </record>
 
+<!-- // Timeline Images // -->
+<record id="s_timeline_images_default_image_1" model="theme.ir.attachment">
+    <field name="key">website.s_timeline_images_default_image_1</field>
+    <field name="name">website.s_timeline_images_default_image_1</field>
+    <field name="url">/theme_yes/static/src/img/snippets/s_pricelist_boxed_default_background.jpg</field>
+</record>
+<record id="s_timeline_images_default_image_2" model="theme.ir.attachment">
+    <field name="key">website.s_timeline_images_default_image_2</field>
+    <field name="name">website.s_timeline_images_default_image_2</field>
+    <field name="url">/theme_yes/static/src/img/snippets/s_kickoff_default_image.jpg</field>
+</record>
+
 </odoo>


### PR DESCRIPTION
This commit adapt the `s_timeline_images` snippet to the themes.

task-4105285
Part of task-4077427

Community PR: https://github.com/odoo/odoo/pull/184760