### PR TITLE
[FIX] theme_artists: `s_opening_hours` remove unnecessary xpath

### DIFF
--- a/theme_artists/views/snippets/s_opening_hours.xml
+++ b/theme_artists/views/snippets/s_opening_hours.xml
@@ -11,9 +11,6 @@
     <xpath expr="//div[hasclass('o_grid_item')][4]" position="attributes">
         <attribute name="class" add="o_cc4" remove="o_cc1" separator=" "/>
     </xpath>
-    <xpath expr="//div[hasclass('o_grid_item')][5]" position="attributes">
-        <attribute name="class" add="o_cc4" remove="o_cc1" separator=" "/>
-    </xpath>
 </template>
 
 </odoo>


### PR DESCRIPTION
With recent updates to the `s_opening_hours` snippet, an additional xpath has become redundant in the context of this theme's revamp.

This commit removes the now unused xpath.

task-4207030
Part of task-4077427

requires: https://github.com/odoo/odoo/pull/181170