### PR TITLE
[IMP] theme_*: adapt `s_form_aside` snippet across themes

### DIFF
--- a/theme_artists/__manifest__.py
+++ b/theme_artists/__manifest__.py
@@ -106,6 +106,7 @@
         'views/snippets/s_website_form_cover.xml',
         'views/snippets/s_numbers_boxed.xml',
         'views/snippets/s_split_intro.xml',
+        'views/snippets/s_form_aside.xml',
         'views/new_page_template.xml',
     ],
     'images': [

--- a/theme_artists/views/snippets/s_form_aside.xml
+++ b/theme_artists/views/snippets/s_form_aside.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+
+<template id="s_form_aside" inherit_id="website.s_form_aside">
+    <!-- Section -->
+    <xpath expr="//section" position="attributes">
+        <attribute name="class" add="o_cc o_cc5" separator=" "/>
+    </xpath>
+</template>
+
+</odoo>

--- a/theme_nano/__manifest__.py
+++ b/theme_nano/__manifest__.py
@@ -55,6 +55,7 @@
         'views/snippets/s_numbers_boxed.xml',
         'views/snippets/s_company_team_card.xml',
         'views/snippets/s_split_intro.xml',
+        'views/snippets/s_form_aside.xml',
         'views/new_page_template.xml',
     ],
     'images': [

--- a/theme_nano/views/snippets/s_form_aside.xml
+++ b/theme_nano/views/snippets/s_form_aside.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+
+<template id="s_form_aside" inherit_id="website.s_form_aside">
+    <!-- Section -->
+    <xpath expr="//section" position="attributes">
+        <attribute name="class" add="o_cc o_cc5" separator=" "/>
+    </xpath>
+</template>
+
+</odoo>

--- a/theme_notes/__manifest__.py
+++ b/theme_notes/__manifest__.py
@@ -69,6 +69,7 @@
         'views/snippets/s_website_form_cover.xml',
         'views/snippets/s_numbers_boxed.xml',
         'views/snippets/s_split_intro.xml',
+        'views/snippets/s_form_aside.xml',
         'views/new_page_template.xml',
     ],
     'images': [

--- a/theme_notes/views/snippets/s_form_aside.xml
+++ b/theme_notes/views/snippets/s_form_aside.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+
+<template id="s_form_aside" inherit_id="website.s_form_aside">
+    <!-- Section -->
+    <xpath expr="//section" position="attributes">
+        <attribute name="class" add="o_cc o_cc3" separator=" "/>
+    </xpath>
+</template>
+
+</odoo>

--- a/theme_vehicle/views/customizations.xml
+++ b/theme_vehicle/views/customizations.xml
@@ -967,4 +967,12 @@
     </xpath>
 </template>
 
+<!-- ======== FORM ASIDE ======== -->
+<template id="s_form_aside" inherit_id="website.s_form_aside">
+    <!-- Section -->
+    <xpath expr="//section" position="attributes">
+        <attribute name="class" add="o_cc o_cc5" separator=" "/>
+    </xpath>
+</template>
+
 </odoo>


### PR DESCRIPTION
*: artists, nano, notes, vehicle

This commit adapt the occurrences of the `s_form_aside` snippet across
themes.

task-4135499
part of task-4077427

- requires https://github.com/odoo/odoo/pull/184094