### PR TITLE
[IMP] theme_*: adapt `s_website_form_cover` snippet

### DIFF
--- a/theme_anelusia/views/images_library.xml
+++ b/theme_anelusia/views/images_library.xml
@@ -432,5 +432,10 @@
     <field name="name">website.s_website_form_overlay_default_image</field>
     <field name="url">/theme_anelusia/static/src/img/snippets/s_carousel_3.jpg</field>
 </record>
+<record id="s_website_form_cover_default_image" model="theme.ir.attachment">
+    <field name="key">website.s_website_form_cover_default_image</field>
+    <field name="name">website.s_website_form_cover_default_image</field>
+    <field name="url">/theme_anelusia/static/src/img/snippets/s_quotes_carousel_2.jpg</field>
+</record>
 
 </odoo>

--- a/theme_artists/__manifest__.py
+++ b/theme_artists/__manifest__.py
@@ -100,6 +100,7 @@
         'views/snippets/s_unveil.xml',
         'views/snippets/s_empowerment.xml',
         'views/snippets/s_cta_mobile.xml',
+        'views/snippets/s_website_form_cover.xml',
         'views/new_page_template.xml',
     ],
     'images': [

--- a/theme_artists/views/images.xml
+++ b/theme_artists/views/images.xml
@@ -425,5 +425,10 @@ Check in theme_monglia's primary_variables.scss, theme.scss and theme_common's m
     <field name="name">website.s_website_form_overlay_default_image</field>
     <field name="url">/theme_artists/static/src/img/snippets/s_cover.jpg</field>
 </record>
+<record id="s_website_form_cover_default_image" model="theme.ir.attachment">
+    <field name="key">website.s_website_form_cover_default_image</field>
+    <field name="name">website.s_website_form_cover_default_image</field>
+    <field name="url">/theme_artists/static/src/img/snippets/s_image_hexagonal_1.jpg</field>
+</record>
 
 </odoo>

--- a/theme_artists/views/snippets/s_website_form_cover.xml
+++ b/theme_artists/views/snippets/s_website_form_cover.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+
+<template id="s_website_form_cover" inherit_id="website.s_website_form_cover">
+    <!-- Section -->
+    <xpath expr="//section" position="attributes">
+        <attribute name="class" add="o_cc o_cc5" separator=" "/>
+    </xpath>
+    <!-- Form -->
+    <xpath expr="(//div[hasclass('col-lg-6')])[2]" position="attributes">
+        <attribute name="class" add="o_cc o_cc5" separator=" "/>
+    </xpath>
+</template>
+
+</odoo>

--- a/theme_avantgarde/views/images_library.xml
+++ b/theme_avantgarde/views/images_library.xml
@@ -482,5 +482,10 @@ Check in images.scss, primary_variables.scss, main.scss and theme_common's mixin
     <field name="name">website.s_website_form_overlay_default_image</field>
     <field name="url">/theme_avantgarde/static/src/img/pictures/s_pricelist_boxed_default_background.jpg</field>
 </record>
+<record id="s_website_form_cover_default_image" model="theme.ir.attachment">
+    <field name="key">website.s_website_form_cover_default_image</field>
+    <field name="name">website.s_website_form_cover_default_image</field>
+    <field name="url">/theme_avantgarde/static/src/img/content/s_cover.jpg</field>
+</record>
 
 </odoo>

--- a/theme_aviato/views/images_library.xml
+++ b/theme_aviato/views/images_library.xml
@@ -389,4 +389,11 @@
     <field name="url">/theme_aviato/static/src/img/content/s_cover.jpg</field>
 </record>
 
+<!-- Website Form Cover -->
+<record id="s_website_form_cover_default_image" model="theme.ir.attachment">
+    <field name="key">website.s_website_form_cover_default_image</field>
+    <field name="name">website.s_website_form_cover_default_image</field>
+    <field name="url">/theme_aviato/static/src/img/content/s_wall_06.jpg</field>
+</record>
+
 </odoo>

--- a/theme_beauty/views/images.xml
+++ b/theme_beauty/views/images.xml
@@ -450,5 +450,10 @@ Check in theme_loftspace's primary_variables.scss and theme.scss -->
     <field name="name">website.s_website_form_overlay_default_image</field>
     <field name="url">/theme_beauty/static/src/img/snippets/s_cover.jpg</field>
 </record>
+<record id="s_website_form_cover_default_image" model="theme.ir.attachment">
+    <field name="key">website.s_website_form_cover_default_image</field>
+    <field name="name">website.s_website_form_cover_default_image</field>
+    <field name="url">/theme_beauty/static/src/img/snippets/library_image_02.jpg</field>
+</record>
 
 </odoo>

--- a/theme_bewise/views/image_content.xml
+++ b/theme_bewise/views/image_content.xml
@@ -407,5 +407,10 @@
     <field name="name">website.s_website_form_overlay_default_image</field>
     <field name="url">/theme_bewise/static/src/img/content/library_image_08.jpg</field>
 </record>
+<record id="s_website_form_cover_default_image" model="theme.ir.attachment">
+    <field name="key">website.s_website_form_cover_default_image</field>
+    <field name="name">website.s_website_form_cover_default_image</field>
+    <field name="url">/theme_bewise/static/src/img/content/library_image_14.jpg</field>
+</record>
 
 </odoo>

--- a/theme_bistro/views/images_library.xml
+++ b/theme_bistro/views/images_library.xml
@@ -598,4 +598,11 @@
     <field name="url">/theme_bistro/static/src/img/backgrounds/17.jpg</field>
 </record>
 
+<!-- Website Form Cover -->
+<record id="s_website_form_cover_default_image" model="theme.ir.attachment">
+    <field name="key">website.s_website_form_cover_default_image</field>
+    <field name="name">website.s_website_form_cover_default_image</field>
+    <field name="url">/theme_bistro/static/src/img/backgrounds/19.jpg</field>
+</record>
+
 </odoo>

--- a/theme_bookstore/views/images.xml
+++ b/theme_bookstore/views/images.xml
@@ -336,6 +336,11 @@ Check in theme_loftspace's primary_variables.scss and theme.scss -->
     <field name="name">website.s_website_form_overlay_default_image</field>
     <field name="url">/theme_bookstore/static/src/img/snippets/s_banner.jpg</field>
 </record>
+<record id="s_website_form_cover_default_image" model="theme.ir.attachment">
+    <field name="key">website.s_website_form_cover_default_image</field>
+    <field name="name">website.s_website_form_cover_default_image</field>
+    <field name="url">/theme_bookstore/static/src/img/snippets/s_unveil_3.jpg</field>
+</record>
 
 <!-- Quadrant -->
 <record id="s_quadrant_default_image_1" model="theme.ir.attachment">

--- a/theme_clean/views/image_content.xml
+++ b/theme_clean/views/image_content.xml
@@ -382,5 +382,10 @@
     <field name="name">website.s_website_form_overlay_default_image</field>
     <field name="url">/theme_clean/static/src/img/backgrounds/bg_snippet_09.jpg</field>
 </record>
+<record id="s_website_form_cover_default_image" model="theme.ir.attachment">
+    <field name="key">website.s_website_form_cover_default_image</field>
+    <field name="name">website.s_website_form_cover_default_image</field>
+    <field name="url">/theme_clean/static/src/img/backgrounds/bg_snippet_05.jpg</field>
+</record>
 
 </odoo>

--- a/theme_cobalt/views/images.xml
+++ b/theme_cobalt/views/images.xml
@@ -454,4 +454,11 @@
     <field name="url">/theme_cobalt/static/src/img/pictures/s_cover.jpg</field>
 </record>
 
+<!-- Website Form Cover -->
+<record id="s_website_form_cover_default_image" model="theme.ir.attachment">
+    <field name="key">website.s_website_form_cover_default_image</field>
+    <field name="name">website.s_website_form_cover_default_image</field>
+    <field name="url">/theme_cobalt/static/src/img/pictures/s_picture.jpg</field>
+</record>
+
 </odoo>

--- a/theme_enark/views/image_library.xml
+++ b/theme_enark/views/image_library.xml
@@ -345,5 +345,10 @@
     <field name="name">website.s_website_form_overlay_default_image</field>
     <field name="url">/theme_enark/static/src/img/snippets/s_cover.jpg</field>
 </record>
+<record id="s_website_form_cover_default_image" model="theme.ir.attachment">
+    <field name="key">website.s_website_form_cover_default_image</field>
+    <field name="name">website.s_website_form_cover_default_image</field>
+    <field name="url">/theme_enark/static/src/img/snippets/library_image_02.jpg</field>
+</record>
 
 </odoo>

--- a/theme_graphene/views/images_library.xml
+++ b/theme_graphene/views/images_library.xml
@@ -542,4 +542,11 @@ Check in images.scss, primary_variables.scss, main.scss and theme_common's mixin
     <field name="url">/theme_graphene/static/src/img/pictures/bg_image_08.jpg</field>
 </record>
 
+<!-- Website Form Cover -->
+<record id="s_website_form_cover_default_image" model="theme.ir.attachment">
+    <field name="key">website.s_website_form_cover_default_image</field>
+    <field name="name">website.s_website_form_cover_default_image</field>
+    <field name="url">/theme_graphene/static/src/img/pictures/bg_image_08.jpg</field>
+</record>
+
 </odoo>

--- a/theme_kea/views/images_content.xml
+++ b/theme_kea/views/images_content.xml
@@ -481,5 +481,10 @@ Check in primary_variables.scss, theme.scss and theme_common's mixins.scss -->
     <field name="name">website.s_website_form_overlay_default_image</field>
     <field name="url">/theme_kea/static/src/img/snippets/s_masonry_block.jpg</field>
 </record>
+<record id="s_website_form_cover_default_image" model="theme.ir.attachment">
+    <field name="key">website.s_website_form_cover_default_image</field>
+    <field name="name">website.s_website_form_cover_default_image</field>
+    <field name="url">/theme_kea/static/src/img/snippets/s_color_blocks_1.jpg</field>
+</record>
 
 </odoo>

--- a/theme_kiddo/views/images_library.xml
+++ b/theme_kiddo/views/images_library.xml
@@ -419,5 +419,10 @@
     <field name="name">website.s_website_form_overlay_default_image</field>
     <field name="url">/theme_kiddo/static/src/img/library/bg12.jpg</field>
 </record>
+<record id="s_website_form_cover_default_image" model="theme.ir.attachment">
+    <field name="key">website.s_website_form_cover_default_image</field>
+    <field name="name">website.s_website_form_cover_default_image</field>
+    <field name="url">/theme_kiddo/static/src/img/snippets/library_image_08.jpg</field>
+</record>
 
 </odoo>

--- a/theme_loftspace/views/images_content.xml
+++ b/theme_loftspace/views/images_content.xml
@@ -416,5 +416,10 @@ Check in primary_variables.scss and theme.scss -->
     <field name="name">website.s_website_form_overlay_default_image</field>
     <field name="url">/theme_loftspace/static/src/img/snippets/s_cover.jpg</field>
 </record>
+<record id="s_website_form_cover_default_image" model="theme.ir.attachment">
+    <field name="key">website.s_website_form_cover_default_image</field>
+    <field name="name">website.s_website_form_cover_default_image</field>
+    <field name="url">/theme_loftspace/static/src/img/snippets/s_images_wall_05.jpg</field>
+</record>
 
 </odoo>

--- a/theme_monglia/views/images_content.xml
+++ b/theme_monglia/views/images_content.xml
@@ -452,5 +452,10 @@ Check in primary_variables.scss, theme.scss and theme_common's mixins.scss -->
     <field name="name">website.s_website_form_overlay_default_image</field>
     <field name="url">/theme_monglia/static/src/img/snippets/s_quotes_carousel_0.jpg</field>
 </record>
+<record id="s_website_form_cover_default_image" model="theme.ir.attachment">
+    <field name="key">website.s_website_form_cover_default_image</field>
+    <field name="name">website.s_website_form_cover_default_image</field>
+    <field name="url">/theme_monglia/static/src/img/content/content_img_11.jpg</field>
+</record>
 
 </odoo>

--- a/theme_nano/__manifest__.py
+++ b/theme_nano/__manifest__.py
@@ -48,6 +48,7 @@
         'views/snippets/s_company_team_basic.xml',
         'views/snippets/s_cta_mobile.xml',
         'views/snippets/s_company_team_spotlight.xml',
+        'views/snippets/s_website_form_cover.xml',
         'views/new_page_template.xml',
     ],
     'images': [

--- a/theme_nano/views/images_library.xml
+++ b/theme_nano/views/images_library.xml
@@ -581,5 +581,10 @@
     <field name="name">website.s_website_form_overlay_default_image</field>
     <field name="url">/theme_nano/static/src/img/snippets/s_cover.jpg</field>
 </record>
+<record id="s_website_form_cover_default_image" model="theme.ir.attachment">
+    <field name="key">website.s_website_form_cover_default_image</field>
+    <field name="name">website.s_website_form_cover_default_image</field>
+    <field name="url">/theme_nano/static/src/img/snippets/s_parallax.jpg</field>
+</record>
 
 </odoo>

--- a/theme_nano/views/snippets/s_website_form_cover.xml
+++ b/theme_nano/views/snippets/s_website_form_cover.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+
+<template id="s_website_form_cover" inherit_id="website.s_website_form_cover">
+    <!-- Section -->
+    <xpath expr="//section" position="attributes">
+        <attribute name="class" add="o_cc o_cc5" separator=" "/>
+    </xpath>
+    <!-- Form -->
+    <xpath expr="(//div[hasclass('col-lg-6')])[2]" position="attributes">
+        <attribute name="class" add="o_cc o_cc5" separator=" "/>
+    </xpath>
+</template>
+
+</odoo>

--- a/theme_notes/__manifest__.py
+++ b/theme_notes/__manifest__.py
@@ -64,6 +64,7 @@
         'views/snippets/s_shape_image.xml',
         'views/snippets/s_text_cover.xml',
         'views/snippets/s_empowerment.xml',
+        'views/snippets/s_website_form_cover.xml',
         'views/new_page_template.xml',
     ],
     'images': [

--- a/theme_notes/views/images_library.xml
+++ b/theme_notes/views/images_library.xml
@@ -437,5 +437,10 @@
     <field name="name">website.s_website_form_overlay_default_image</field>
     <field name="url">/theme_notes/static/src/img/content/content_img_14.jpg</field>
 </record>
+<record id="s_website_form_cover_default_image" model="theme.ir.attachment">
+    <field name="key">website.s_website_form_cover_default_image</field>
+    <field name="name">website.s_website_form_cover_default_image</field>
+    <field name="url">/theme_notes/static/src/img/content/content_img_22.jpg</field>
+</record>
 
 </odoo>

--- a/theme_notes/views/snippets/s_website_form_cover.xml
+++ b/theme_notes/views/snippets/s_website_form_cover.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+
+<template id="s_website_form_cover" inherit_id="website.s_website_form_cover">
+    <!-- Section -->
+    <xpath expr="//section" position="attributes">
+        <attribute name="class" add="o_cc o_cc3" separator=" "/>
+    </xpath>
+    <!-- Form -->
+    <xpath expr="(//div[hasclass('col-lg-6')])[2]" position="attributes">
+        <attribute name="class" add="o_cc o_cc3" separator=" "/>
+    </xpath>
+</template>
+
+</odoo>

--- a/theme_odoo_experts/views/images.xml
+++ b/theme_odoo_experts/views/images.xml
@@ -397,5 +397,10 @@ Check in theme_loftspace's primary_variables.scss and theme.scss -->
     <field name="name">website.s_website_form_overlay_default_image</field>
     <field name="url">/theme_odoo_experts/static/src/img/snippets/s_cover.jpg</field>
 </record>
+<record id="s_website_form_cover_default_image" model="theme.ir.attachment">
+    <field name="key">website.s_website_form_cover_default_image</field>
+    <field name="name">website.s_website_form_cover_default_image</field>
+    <field name="url">/theme_odoo_experts/static/src/img/content/s_cover.jpg</field>
+</record>
 
 </odoo>

--- a/theme_orchid/views/images.xml
+++ b/theme_orchid/views/images.xml
@@ -390,5 +390,10 @@ Check in theme_loftspace's primary_variables.scss and theme.scss -->
     <field name="name">website.s_website_form_overlay_default_image</field>
     <field name="url">/theme_orchid/static/src/img/snippets/s_product_catalog_default_image.jpg</field>
 </record>
+<record id="s_website_form_cover_default_image" model="theme.ir.attachment">
+    <field name="key">website.s_website_form_cover_default_image</field>
+    <field name="name">website.s_website_form_cover_default_image</field>
+    <field name="url">/theme_orchid/static/src/img/snippets/s_product_catalog_default_image.jpg</field>
+</record>
 
 </odoo>

--- a/theme_paptic/views/customizations.xml
+++ b/theme_paptic/views/customizations.xml
@@ -744,6 +744,18 @@
     </xpath>
 </template>
 
+<!-- ==== FORM COVER ===== -->
+<template id="s_website_form_cover" inherit_id="website.s_website_form_cover">
+    <!-- Section -->
+    <xpath expr="//section" position="attributes">
+        <attribute name="class" add="o_cc o_cc3" separator=" "/>
+    </xpath>
+    <!-- Form -->
+    <xpath expr="(//div[hasclass('col-lg-6')])[2]" position="attributes">
+        <attribute name="class" add="o_cc o_cc3" separator=" "/>
+    </xpath>
+</template>
+
 <!-- ==== Masonry Block ===== -->
 <template id="s_masonry_block_images_template" inherit_id="website.s_masonry_block_images_template">
     <xpath expr="//div[hasclass('row')]" position="attributes">

--- a/theme_paptic/views/images.xml
+++ b/theme_paptic/views/images.xml
@@ -381,4 +381,11 @@
     <field name="url">/theme_paptic/static/src/img/pictures/s_quotes_carousel_bg_slide3.jpg</field>
 </record>
 
+<!-- Website Form Cover -->
+<record id="s_website_form_cover_default_image" model="theme.ir.attachment">
+    <field name="key">website.s_website_form_cover_default_image</field>
+    <field name="name">website.s_website_form_cover_default_image</field>
+    <field name="url">/theme_paptic/static/src/img/pictures/s_banner_2.jpg</field>
+</record>
+
 </odoo>

--- a/theme_real_estate/views/images.xml
+++ b/theme_real_estate/views/images.xml
@@ -386,5 +386,10 @@ Check in theme_monglia's primary_variables.scss, theme.scss and theme_common's m
     <field name="name">website.s_website_form_overlay_default_image</field>
     <field name="url">/theme_real_estate/static/src/img/snippets/s_cover.jpg</field>
 </record>
+<record id="s_website_form_cover_default_image" model="theme.ir.attachment">
+    <field name="key">website.s_website_form_cover_default_image</field>
+    <field name="name">website.s_website_form_cover_default_image</field>
+    <field name="url">/theme_real_estate/static/src/img/snippets/library_image_13.jpg</field>
+</record>
 
 </odoo>

--- a/theme_treehouse/views/images_library.xml
+++ b/theme_treehouse/views/images_library.xml
@@ -562,4 +562,11 @@
     <field name="url">/theme_treehouse/static/src/img/content/cover.jpg</field>
 </record>
 
+<!-- Website Form Cover -->
+<record id="s_website_form_cover_default_image" model="theme.ir.attachment">
+    <field name="key">website.s_website_form_cover_default_image</field>
+    <field name="name">website.s_website_form_cover_default_image</field>
+    <field name="url">/theme_treehouse/static/src/img/content/masonry_block.jpg</field>
+</record>
+
 </odoo>

--- a/theme_vehicle/views/images.xml
+++ b/theme_vehicle/views/images.xml
@@ -410,5 +410,10 @@ Check in theme_monglia's primary_variables.scss, theme.scss and theme_common's m
     <field name="name">website.s_website_form_overlay_default_image</field>
     <field name="url">/theme_vehicle/static/src/img/snippets/s_cover.jpg</field>
 </record>
+<record id="s_website_form_cover_default_image" model="theme.ir.attachment">
+    <field name="key">website.s_website_form_cover_default_image</field>
+    <field name="name">website.s_website_form_cover_default_image</field>
+    <field name="url">/theme_vehicle/static/src/img/snippets/s_banner_2.jpg</field>
+</record>
 
 </odoo>

--- a/theme_yes/views/images.xml
+++ b/theme_yes/views/images.xml
@@ -490,4 +490,11 @@ Check in theme_kea's primary_variables.scss, theme.scss and theme_common's mixin
     <field name="url">/theme_yes/static/src/img/snippets/s_cover.jpg</field>
 </record>
 
+<!-- // Website Form Cover // -->
+<record id="s_website_form_cover_default_image" model="theme.ir.attachment">
+    <field name="key">website.s_website_form_cover_default_image</field>
+    <field name="name">website.s_website_form_cover_default_image</field>
+    <field name="url">/theme_yes/static/src/img/snippets/library_image_10.webp</field>
+</record>
+
 </odoo>

--- a/theme_zap/views/images_library.xml
+++ b/theme_zap/views/images_library.xml
@@ -489,4 +489,11 @@
     <field name="url">/theme_zap/static/src/img/backgrounds/09.jpg</field>
 </record>
 
+<!-- Website Form Cover -->
+<record id="s_website_form_cover_default_image" model="theme.ir.attachment">
+    <field name="key">website.s_website_form_cover_default_image</field>
+    <field name="name">website.s_website_form_cover_default_image</field>
+    <field name="url">/theme_zap/static/src/img/backgrounds/04.jpg</field>
+</record>
+
 </odoo>


### PR DESCRIPTION
*: theme_anelusia, theme_artists, theme_avantgarde, theme_aviato, theme_beauty, theme_bewise, theme_bistro, theme_bookstore, theme_buzzy, theme_clean, theme_cobalt, theme_enark, theme_graphene, theme_kea, theme_kiddo, theme_monglia, theme_nano, theme_notes, theme_odoo_experts, theme_orchid, theme_paptic, theme_real_estate, theme_treehouse, theme_vehicle, theme_yes, theme_zap

This PR reviews the occurrences of `s_website_form_cover` across design themes.
 
- requires https://github.com/odoo/odoo/pull/178102

task-4138250
Part-of: task-4077427