### PR TITLE
[FIX] test_themes: allow proper patch website_swit

### DIFF
--- a/test_themes/static/src/systray_items/website_switcher.js
+++ b/test_themes/static/src/systray_items/website_switcher.js
@@ -27,5 +27,18 @@ patch(WebsiteSwitcherSystray.prototype, 'test_themes_website_switcher_systray', 
             }
         });
     },
+
+    getElements() {
+        // Add tooltip information
+        const elements = this._super();
+        return elements.map((elem) => {
+            elem.dataset = {
+                ...elem.dataset,
+                ...this.tooltips[elem.id]
+            };
+            return elem
+        });
+    },
+
     template: 'test_themes.WebsiteSwitcherSystray',
 });

--- a/test_themes/static/src/systray_items/website_switcher.xml
+++ b/test_themes/static/src/systray_items/website_switcher.xml
@@ -5,9 +5,6 @@
 </t>
 
 <t t-name="test_themes.WebsiteSwitcherSystray" t-inherit="website.WebsiteSwitcherSystray" t-inherit-mode="extension">
-    <xpath expr="//DropdownItem" position="attributes">
-        <attribute name="dataset">this.tooltips[element.id]</attribute>
-    </xpath>
     <!-- With this module installed, disable the warning -->
     <xpath expr="//DropdownItem/t[@t-if='!element.domain']" position="replace">
     </xpath>


### PR DESCRIPTION
..cher

Defines dataset directly on website elements such that it can be overridden by other modules if necessary.
This was done due to the override in the `test_themes` module completely overriding all attributes of the website_switcher's dropdown items.

Runbot Error 106501