### PR TITLE
[IMP] orm/all: Make _name or _inherit mandatory

### DIFF
--- a/test_themes/models/ir_http.py
+++ b/test_themes/models/ir_http.py
@@ -5,7 +5,7 @@ from odoo.http import request
 
 
 class IrHttp(models.AbstractModel):
-    _inherit = ['ir.http']
+    _inherit = 'ir.http'
 
     @classmethod
     def _pre_dispatch(cls, rule, args):

--- a/test_themes/models/website.py
+++ b/test_themes/models/website.py
@@ -4,7 +4,7 @@ from odoo import api, models
 
 
 class Website(models.Model):
-    _inherit = ['website']
+    _inherit = 'website'
 
     @api.model
     def get_test_themes_websites_theme_preview(self):

--- a/theme_anelusia/models/theme_anelusia.py
+++ b/theme_anelusia/models/theme_anelusia.py
@@ -2,7 +2,7 @@ from odoo import models
 
 
 class ThemeUtils(models.AbstractModel):
-    _inherit = ['theme.utils']
+    _inherit = 'theme.utils'
 
     def _theme_anelusia_post_copy(self, mod):
         self.enable_view('website.template_footer_headline')

--- a/theme_artists/models/theme_artists.py
+++ b/theme_artists/models/theme_artists.py
@@ -2,7 +2,7 @@ from odoo import models
 
 
 class ThemeUtils(models.AbstractModel):
-    _inherit = ['theme.utils']
+    _inherit = 'theme.utils'
 
     def _theme_artists_post_copy(self, mod):
         self.enable_view('website.template_header_vertical')

--- a/theme_avantgarde/models/theme_avantgarde.py
+++ b/theme_avantgarde/models/theme_avantgarde.py
@@ -2,7 +2,7 @@ from odoo import models
 
 
 class ThemeUtils(models.AbstractModel):
-    _inherit = ['theme.utils']
+    _inherit = 'theme.utils'
 
     def _theme_avantgarde_post_copy(self, mod):
         self.enable_view('website.template_header_hamburger')

--- a/theme_aviato/models/theme_aviato.py
+++ b/theme_aviato/models/theme_aviato.py
@@ -2,7 +2,7 @@ from odoo import models
 
 
 class ThemeUtils(models.AbstractModel):
-    _inherit = ['theme.utils']
+    _inherit = 'theme.utils'
 
     def _theme_aviato_post_copy(self, mod):
         self.enable_view('website.template_footer_contact')

--- a/theme_beauty/models/theme_beauty.py
+++ b/theme_beauty/models/theme_beauty.py
@@ -2,7 +2,7 @@ from odoo import models
 
 
 class ThemeUtils(models.AbstractModel):
-    _inherit = ['theme.utils']
+    _inherit = 'theme.utils'
 
     def _theme_beauty_post_copy(self, mod):
         self.enable_view('website.footer_custom')

--- a/theme_bewise/models/theme_bewise.py
+++ b/theme_bewise/models/theme_bewise.py
@@ -2,7 +2,7 @@ from odoo import models
 
 
 class ThemeUtils(models.AbstractModel):
-    _inherit = ['theme.utils']
+    _inherit = 'theme.utils'
 
     def _theme_bewise_post_copy(self, mod):
         self.enable_view('website.template_footer_headline')

--- a/theme_bistro/models/theme_bistro.py
+++ b/theme_bistro/models/theme_bistro.py
@@ -2,7 +2,7 @@ from odoo import models
 
 
 class ThemeUtils(models.AbstractModel):
-    _inherit = ['theme.utils']
+    _inherit = 'theme.utils'
 
     def _theme_bistro_post_copy(self, mod):
         self.enable_view('website.template_header_vertical')

--- a/theme_bookstore/models/theme_bookstore.py
+++ b/theme_bookstore/models/theme_bookstore.py
@@ -2,7 +2,7 @@ from odoo import models
 
 
 class ThemeUtils(models.AbstractModel):
-    _inherit = ['theme.utils']
+    _inherit = 'theme.utils'
 
     def _theme_bookstore_post_copy(self, mod):
         self.enable_view('website.template_header_search')

--- a/theme_buzzy/models/theme_buzzy.py
+++ b/theme_buzzy/models/theme_buzzy.py
@@ -2,7 +2,7 @@ from odoo import models
 
 
 class ThemeUtils(models.AbstractModel):
-    _inherit = ['theme.utils']
+    _inherit = 'theme.utils'
 
     def _theme_buzzy_post_copy(self, mod):
         self.enable_view('website.template_footer_headline')

--- a/theme_clean/models/theme_clean.py
+++ b/theme_clean/models/theme_clean.py
@@ -2,7 +2,7 @@ from odoo import models
 
 
 class ThemeUtils(models.AbstractModel):
-    _inherit = ['theme.utils']
+    _inherit = 'theme.utils'
 
     def _theme_clean_post_copy(self, mod):
         self.enable_view('website.template_header_default')

--- a/theme_cobalt/models/theme_cobalt.py
+++ b/theme_cobalt/models/theme_cobalt.py
@@ -2,7 +2,7 @@ from odoo import models
 
 
 class ThemeUtils(models.AbstractModel):
-    _inherit = ['theme.utils']
+    _inherit = 'theme.utils'
 
     def _theme_cobalt_post_copy(self, mod):
         self.enable_asset("website.ripple_effect_scss")

--- a/theme_common/models/theme_common.py
+++ b/theme_common/models/theme_common.py
@@ -2,7 +2,7 @@ from odoo import models
 
 
 class ThemeUtils(models.AbstractModel):
-    _inherit = ['theme.utils']
+    _inherit = 'theme.utils'
 
     def _theme_common_post_copy(self, mod):
         # Reset all default color when switching themes

--- a/theme_enark/models/theme_enark.py
+++ b/theme_enark/models/theme_enark.py
@@ -2,7 +2,7 @@ from odoo import models
 
 
 class ThemeUtils(models.AbstractModel):
-    _inherit = ['theme.utils']
+    _inherit = 'theme.utils'
 
     def _theme_enark_post_copy(self, mod):
         self.enable_view('website.template_footer_descriptive')

--- a/theme_graphene/models/theme_graphene.py
+++ b/theme_graphene/models/theme_graphene.py
@@ -2,7 +2,7 @@ from odoo import models
 
 
 class ThemeUtils(models.AbstractModel):
-    _inherit = ['theme.utils']
+    _inherit = 'theme.utils'
 
     def _theme_graphene_post_copy(self, mod):
         self.enable_view('website.template_header_stretch')

--- a/theme_kea/models/theme_kea.py
+++ b/theme_kea/models/theme_kea.py
@@ -2,7 +2,7 @@ from odoo import models
 
 
 class ThemeUtils(models.AbstractModel):
-    _inherit = ['theme.utils']
+    _inherit = 'theme.utils'
 
     def _theme_kea_post_copy(self, mod):
         self.enable_view('website.template_footer_minimalist')

--- a/theme_kiddo/models/theme_kiddo.py
+++ b/theme_kiddo/models/theme_kiddo.py
@@ -2,7 +2,7 @@ from odoo import models
 
 
 class ThemeUtils(models.AbstractModel):
-    _inherit = ['theme.utils']
+    _inherit = 'theme.utils'
 
     def _theme_kiddo_post_copy(self, mod):
         self.enable_view('website.template_header_default_align_right')

--- a/theme_loftspace/models/theme_loftspace.py
+++ b/theme_loftspace/models/theme_loftspace.py
@@ -2,7 +2,7 @@ from odoo import models
 
 
 class ThemeUtils(models.AbstractModel):
-    _inherit = ['theme.utils']
+    _inherit = 'theme.utils'
 
     def _theme_loftspace_post_copy(self, mod):
         self.enable_view('website.template_header_search')

--- a/theme_monglia/models/theme_monglia.py
+++ b/theme_monglia/models/theme_monglia.py
@@ -2,7 +2,7 @@ from odoo import models
 
 
 class ThemeUtils(models.AbstractModel):
-    _inherit = ['theme.utils']
+    _inherit = 'theme.utils'
 
     def _theme_monglia_post_copy(self, mod):
         self.enable_view('website.template_footer_minimalist')

--- a/theme_nano/models/theme_nano.py
+++ b/theme_nano/models/theme_nano.py
@@ -2,7 +2,7 @@ from odoo import models
 
 
 class ThemeUtils(models.AbstractModel):
-    _inherit = ['theme.utils']
+    _inherit = 'theme.utils'
 
     def _theme_nano_post_copy(self, mod):
 

--- a/theme_notes/models/theme_notes.py
+++ b/theme_notes/models/theme_notes.py
@@ -2,7 +2,7 @@ from odoo import models
 
 
 class ThemeUtils(models.AbstractModel):
-    _inherit = ['theme.utils']
+    _inherit = 'theme.utils'
 
     def _theme_notes_post_copy(self, mod):
         self.enable_view('website.template_footer_descriptive')

--- a/theme_odoo_experts/models/theme_odoo_experts.py
+++ b/theme_odoo_experts/models/theme_odoo_experts.py
@@ -2,7 +2,7 @@ from odoo import models
 
 
 class ThemeUtils(models.AbstractModel):
-    _inherit = ['theme.utils']
+    _inherit = 'theme.utils'
 
     def _theme_odoo_experts_post_copy(self, mod):
         self.enable_view('website.template_footer_contact')

--- a/theme_orchid/models/theme_orchid.py
+++ b/theme_orchid/models/theme_orchid.py
@@ -2,7 +2,7 @@ from odoo import models
 
 
 class ThemeUtils(models.AbstractModel):
-    _inherit = ['theme.utils']
+    _inherit = 'theme.utils'
 
     def _theme_orchid_post_copy(self, mod):
         self.enable_view('website.template_header_default')

--- a/theme_paptic/models/theme_paptic.py
+++ b/theme_paptic/models/theme_paptic.py
@@ -2,7 +2,7 @@ from odoo import models
 
 
 class ThemeUtils(models.AbstractModel):
-    _inherit = ['theme.utils']
+    _inherit = 'theme.utils'
 
     def _theme_paptic_post_copy(self, mod):
         self.enable_asset("website.ripple_effect_scss")

--- a/theme_real_estate/models/theme_real_estate.py
+++ b/theme_real_estate/models/theme_real_estate.py
@@ -2,7 +2,7 @@ from odoo import models
 
 
 class ThemeUtils(models.AbstractModel):
-    _inherit = ['theme.utils']
+    _inherit = 'theme.utils'
 
     def _theme_real_estate_post_copy(self, mod):
         self.enable_asset("website.ripple_effect_scss")

--- a/theme_test_custo/models/theme_models.py
+++ b/theme_test_custo/models/theme_models.py
@@ -4,7 +4,7 @@ from odoo import models
 
 
 class ThemeUtils(models.AbstractModel):
-    _inherit = ['theme.utils']
+    _inherit = 'theme.utils'
 
     @property
     def _header_templates(self):

--- a/theme_treehouse/models/theme_treehouse.py
+++ b/theme_treehouse/models/theme_treehouse.py
@@ -2,7 +2,7 @@ from odoo import models
 
 
 class ThemeUtils(models.AbstractModel):
-    _inherit = ['theme.utils']
+    _inherit = 'theme.utils'
 
     def _theme_treehouse_post_copy(self, mod):
         self.disable_view('website.header_visibility_standard')

--- a/theme_vehicle/models/theme_vehicle.py
+++ b/theme_vehicle/models/theme_vehicle.py
@@ -2,7 +2,7 @@ from odoo import models
 
 
 class ThemeUtils(models.AbstractModel):
-    _inherit = ['theme.utils']
+    _inherit = 'theme.utils'
 
     def _theme_vehicle_post_copy(self, mod):
         self.enable_view('website.template_footer_minimalist')

--- a/theme_yes/models/theme_yes.py
+++ b/theme_yes/models/theme_yes.py
@@ -2,7 +2,7 @@ from odoo import models
 
 
 class ThemeUtils(models.AbstractModel):
-    _inherit = ['theme.utils']
+    _inherit = 'theme.utils'
 
     def _theme_yes_post_copy(self, mod):
         self.enable_view('website.template_footer_descriptive')

--- a/theme_zap/models/theme_zap.py
+++ b/theme_zap/models/theme_zap.py
@@ -2,7 +2,7 @@ from odoo import models
 
 
 class ThemeUtils(models.AbstractModel):
-    _inherit = ['theme.utils']
+    _inherit = 'theme.utils'
 
     def _theme_zap_post_copy(self, mod):
         self.enable_view('website.template_header_sales_four')


### PR DESCRIPTION
This is a request following the revert of the use of class names (concerning the python inheritance and typing project)