### PR TITLE
[FIX] test_themes: prepare restoring the website switcher

### DIFF
--- a/test_themes/static/src/systray_items/website_switcher.js
+++ b/test_themes/static/src/systray_items/website_switcher.js
@@ -36,7 +36,7 @@ patch(WebsiteSwitcherSystray.prototype, 'test_themes_website_switcher_systray', 
                 ...elem.dataset,
                 ...this.tooltips[elem.id]
             };
-            return elem
+            return elem;
         });
     },
 


### PR DESCRIPTION
The forward-port of [1] made no adaptation to the code, and it now simply crashes when trying to use the website switcher when test_themes is installed.

This commit, joined to another related fix in community, will be adapted in the forward-ported version to actually fix the issue. Meanwhile, it fixes a linter error introduced by that same [1] commit.

[1]: https://github.com/odoo/design-themes/commit/c3af5d9796929025c9503ab639afc8c60a262b3f