### PR TITLE
[IMP] test_themes: fix test for `s_rating` inner snippet

### DIFF
--- a/test_themes/tests/test_new_page_templates.py
+++ b/test_themes/tests/test_new_page_templates.py
@@ -97,6 +97,7 @@ CONFLICTUAL_CLASSES_RE = {
         's_process_steps_connector_line',
         's_product_catalog_dish_name', 's_product_catalog_dish_dot_leaders',
         's_progress_bar_label_hidden', 's_progress_bar_label_inline',
+        's_rating_no_title',
         's_table_of_content_vertical_navbar', 's_table_of_content_navbar_sticky', 's_table_of_content_navbar_wrap',
         's_timeline_card',
         's_website_form_custom', 's_website_form_dnone', 's_website_form_field', 's_website_form_input', 's_website_form_mark', 's_website_form_submit', 's_website_form_no_submit_label',


### PR DESCRIPTION
This PR adds a line within the `new_page_templates` test in order to allow the snippet `s_rating` to be used with `s_rating_no_title`.

- requires https://github.com/odoo/odoo/pull/186130

task-4306631