### PR TITLE
[FIX] theme_test_custo: Update menu search to match URL changes

### DIFF
--- a/theme_test_custo/data/menu.xml
+++ b/theme_test_custo/data/menu.xml
@@ -62,7 +62,6 @@
 <record id="main_menu_animals" model="theme.website.menu">
     <field name="name">Main Menu Animals</field>
     <field name="use_main_menu_as_parent" eval="False"/>
-    <field name="url">/main-menu-animals</field>
 </record>
 <record id="menu_dogs" model="theme.website.menu">
     <field name="name">Dogs</field>

--- a/theme_test_custo/views/footer.xml
+++ b/theme_test_custo/views/footer.xml
@@ -24,7 +24,8 @@
                         <div class="col-lg-6 pt24 pb24 text-center">
                             <h5 class="mb-4">Useful Links</h5>
                             <ul class="list-unstyled">
-                                <li t-foreach="request.env['website.menu'].search([('url', '=', '/main-menu-animals'), ('website_id', '=', request.website.id)]).child_id" t-as="menu">
+                                <t t-set="animal_menu" t-value="request.env.ref('theme_test_custo.main_menu_animals')"/>
+                                <li t-foreach="request.env['website.menu'].search([('theme_template_id', '=', animal_menu.id), ('website_id', '=', request.website.id)]).child_id" t-as="menu">
                                     <a t-att-href="menu.url" t-esc="menu.name"/>
                                 </li>
                             </ul>


### PR DESCRIPTION
With [PR](https://github.com/odoo/odoo/pull/160950), the url field for menus has been made required, with a default value of #. This change ensures that parent menus or megamenus can now have a URL.

In the theme_test_custo module, theme menus were previously defined with a parent menu having a specific URL. Due to the above improvement, the url field defaults to #, making it impossible to search menus by URL. This caused the theme_menu_hierarchies tour to fail.

This commit modifies the search mechanism for menus to align with the updated behavior, ensuring the tour passes successfully.

Related PR: https://github.com/odoo/odoo/pull/160950

Task: 3851453