### PR TITLE
[IMP] theme_*: improve SEO by correcting heading tag hierarchy

### DIFF
--- a/theme_anelusia/views/snippets/s_call_to_action.xml
+++ b/theme_anelusia/views/snippets/s_call_to_action.xml
@@ -15,10 +15,10 @@
     <xpath expr="//div[hasclass('col-lg-9')]" position="attributes">
         <attribute name="class" add="col-lg-12" remove="col-lg-9" separator=" "/>
     </xpath>
-    <xpath expr="//h3" position="replace" mode="inner">
+    <xpath expr="//h2" position="replace" mode="inner">
         Be yourself, create your own style
     </xpath>
-    <xpath expr="//h3" position="attributes">
+    <xpath expr="//h2" position="attributes">
         <attribute name="style">text-align: center;</attribute>
     </xpath>
     <xpath expr="//p" position="replace" mode="inner">

--- a/theme_anelusia/views/snippets/s_card_offset.xml
+++ b/theme_anelusia/views/snippets/s_card_offset.xml
@@ -11,7 +11,7 @@
         <attribute name="src">/web/image/website.s_carousel_default_image_3</attribute>
     </xpath>
     <!-- Title -->
-    <xpath expr="//h3" position="replace" mode="inner">
+    <xpath expr="//h2" position="replace" mode="inner">
         Redefining Style with Every Step
     </xpath>
     <!-- Paragraph 1 -->

--- a/theme_anelusia/views/snippets/s_cards_grid.xml
+++ b/theme_anelusia/views/snippets/s_cards_grid.xml
@@ -7,14 +7,14 @@
         <attribute name="class" add="o_cc5" remove="o_cc2" separator=" "/>
     </xpath>
     <!-- Main Title -->
-    <xpath expr="//h3" position="replace" mode="inner">
+    <xpath expr="//h2" position="replace" mode="inner">
         Redefining Fashion
     </xpath>
     <!-- Card 1 -->
     <xpath expr="(//div[hasclass('card')])[1]" position="attributes">
         <attribute name="class" add="o_cc4" remove="o_cc1" separator=" "/>
     </xpath>
-    <xpath expr="(//h5)[1]" position="replace" mode="inner">
+    <xpath expr="(//h3)[1]" position="replace" mode="inner">
         Timeless Elegance
     </xpath>
     <xpath expr="(//p)[1]" position="replace" mode="inner">
@@ -24,7 +24,7 @@
     <xpath expr="(//div[hasclass('card')])[2]" position="attributes">
         <attribute name="class" add="o_cc3" remove="o_cc1" separator=" "/>
     </xpath>
-    <xpath expr="(//h5)[2]" position="replace" mode="inner">
+    <xpath expr="(//h3)[2]" position="replace" mode="inner">
         Sustainable Craftsmanship
     </xpath>
     <xpath expr="(//p)[2]" position="replace" mode="inner">
@@ -34,7 +34,7 @@
     <xpath expr="(//div[hasclass('card')])[3]" position="attributes">
         <attribute name="class" add="o_cc4" remove="o_cc1" separator=" "/>
     </xpath>
-    <xpath expr="(//h5)[3]" position="replace" mode="inner">
+    <xpath expr="(//h3)[3]" position="replace" mode="inner">
         Versatile Style
     </xpath>
     <xpath expr="(//p)[3]" position="replace" mode="inner">
@@ -44,7 +44,7 @@
     <xpath expr="(//div[hasclass('card')])[4]" position="attributes">
         <attribute name="class" add="o_cc3" remove="o_cc1" separator=" "/>
     </xpath>
-    <xpath expr="(//h5)[4]" position="replace" mode="inner">
+    <xpath expr="(//h3)[4]" position="replace" mode="inner">
         Innovative Design
     </xpath>
     <xpath expr="(//p)[4]" position="replace" mode="inner">

--- a/theme_anelusia/views/snippets/s_company_team.xml
+++ b/theme_anelusia/views/snippets/s_company_team.xml
@@ -12,7 +12,7 @@
         <attribute name="class" remove="rounded-circle" separator=" "/>
     </xpath>
     <!-- Team #01 - Title -->
-    <xpath expr="//div[hasclass('col-lg-6')]//h4" position="replace" mode="inner">
+    <xpath expr="//div[hasclass('col-lg-6')]//h3" position="replace" mode="inner">
         <font style="background-image: linear-gradient(135deg, var(--o-color-1) 0%, var(--o-color-5) 100%);" class="text-gradient">Tony Fred</font>
     </xpath>
     <!-- Team #01 - Work Description -->
@@ -37,7 +37,7 @@
         <attribute name="class" remove="rounded-circle" separator=" "/>
     </xpath>
     <!-- Team #02 - Title -->
-    <xpath expr="//div[hasclass('col-lg-6')][2]//h4" position="replace" mode="inner">
+    <xpath expr="//div[hasclass('col-lg-6')][2]//h3" position="replace" mode="inner">
         <font style="background-image: linear-gradient(135deg, var(--o-color-1) 0%, var(--o-color-5) 100%);" class="text-gradient">Mich Stark</font>
         <br/>
     </xpath>
@@ -63,7 +63,7 @@
         <attribute name="class" remove="rounded-circle" separator=" "/>
     </xpath>
     <!-- Team #03 - Title -->
-    <xpath expr="//div[hasclass('col-lg-6')][3]//h4" position="replace" mode="inner">
+    <xpath expr="//div[hasclass('col-lg-6')][3]//h3" position="replace" mode="inner">
         <font style="background-image: linear-gradient(135deg, var(--o-color-2) 0%, var(--o-color-5) 100%);" class="text-gradient">Aline Turner</font>
     </xpath>
     <!-- Team #03 - Work Description -->
@@ -88,7 +88,7 @@
         <attribute name="class" remove="rounded-circle" separator=" "/>
     </xpath>
     <!-- Team #04 - Title -->
-    <xpath expr="//div[hasclass('col-lg-6')][4]//h4" position="replace" mode="inner">
+    <xpath expr="//div[hasclass('col-lg-6')][4]//h3" position="replace" mode="inner">
         <font style="background-image: linear-gradient(135deg, var(--o-color-2) 0%, var(--o-color-5) 100%);" class="text-gradient">Iris Joe</font>
     </xpath>
     <!-- Team #04 - Work Description -->

--- a/theme_anelusia/views/snippets/s_company_team_basic.xml
+++ b/theme_anelusia/views/snippets/s_company_team_basic.xml
@@ -3,7 +3,7 @@
 
 <template id="s_company_team_basic" inherit_id="website.s_company_team_basic">
     <!-- Team #01 - Title -->
-    <xpath expr="//h4" position="replace" mode="inner">
+    <xpath expr="//h3" position="replace" mode="inner">
         Tony Fred
     </xpath>
     <!-- Team #01 - Work Description -->
@@ -21,7 +21,7 @@
     </xpath>
 
     <!-- Team #02 - Title -->
-    <xpath expr="(//h4)[2]" position="replace" mode="inner">
+    <xpath expr="(//h3)[2]" position="replace" mode="inner">
         Mich Stark
     </xpath>
     <!-- Team #02 - Work Description -->
@@ -39,7 +39,7 @@
     </xpath>
 
     <!-- Team #03 - Title -->
-    <xpath expr="(//h4)[3]" position="replace" mode="inner">
+    <xpath expr="(//h3)[3]" position="replace" mode="inner">
         Aline Turner
     </xpath>
     <!-- Team #03 - Work Description -->
@@ -57,7 +57,7 @@
     </xpath>
 
     <!-- Team #04 - Title -->
-    <xpath expr="(//h4)[4]" position="replace" mode="inner">
+    <xpath expr="(//h3)[4]" position="replace" mode="inner">
         Iris Joe
     </xpath>
     <!-- Team #04 - Work Description -->

--- a/theme_artists/views/snippets/s_call_to_action.xml
+++ b/theme_artists/views/snippets/s_call_to_action.xml
@@ -7,7 +7,7 @@
         <attribute name="class" add="pb208 o_cc4" remove="pb64 o_cc5" separator=" "/>
     </xpath>
     <!-- Title & Paragraph -->
-    <xpath expr="//h3" position="replace" mode="inner">
+    <xpath expr="//h2" position="replace" mode="inner">
         Want to discover more?
     </xpath>
     <xpath expr="//p" position="replace" mode="inner">

--- a/theme_artists/views/snippets/s_card_offset.xml
+++ b/theme_artists/views/snippets/s_card_offset.xml
@@ -11,7 +11,7 @@
         <attribute name="src">/web/image/website.s_carousel_default_image_3</attribute>
     </xpath>
     <!-- Title -->
-    <xpath expr="//h3" position="replace" mode="inner">
+    <xpath expr="//h2" position="replace" mode="inner">
         Discover Art that Inspires Your Soul
     </xpath>
     <!-- Paragraph 1 -->

--- a/theme_artists/views/snippets/s_cards_grid.xml
+++ b/theme_artists/views/snippets/s_cards_grid.xml
@@ -8,7 +8,7 @@
     </xpath>
 
     <!-- Title -->
-    <xpath expr="//h3" position="replace" mode="inner">
+    <xpath expr="//h2" position="replace" mode="inner">
         Distinctive Creations: Art That Speaks
     </xpath>
     <!-- Card 1 -->
@@ -16,7 +16,7 @@
         <attribute name="class" add="border" separator=" "/>
         <attribute name="style" add="border-width: 0px !important;" separator=";"/>
     </xpath>
-    <xpath expr="(//h5)[1]" position="replace" mode="inner">
+    <xpath expr="(//h3)[1]" position="replace" mode="inner">
         Unique Creative Vision
     </xpath>
     <xpath expr="(//p)[1]" position="replace" mode="inner">
@@ -27,7 +27,7 @@
         <attribute name="class" add="border" separator=" "/>
         <attribute name="style" add="border-width: 0px !important;" separator=";"/>
     </xpath>
-    <xpath expr="(//h5)[2]" position="replace" mode="inner">
+    <xpath expr="(//h3)[2]" position="replace" mode="inner">
         Original and Handcrafted Works
     </xpath>
     <xpath expr="(//p)[2]" position="replace" mode="inner">
@@ -38,7 +38,7 @@
         <attribute name="class" add="border" separator=" "/>
         <attribute name="style" add="border-width: 0px !important;" separator=";"/>
     </xpath>
-    <xpath expr="(//h5)[3]" position="replace" mode="inner">
+    <xpath expr="(//h3)[3]" position="replace" mode="inner">
         Bold Use of Color and Texture
     </xpath>
     <xpath expr="(//p)[3]" position="replace" mode="inner">
@@ -49,7 +49,7 @@
         <attribute name="class" add="border" separator=" "/>
         <attribute name="style" add="border-width: 0px !important;" separator=";"/>
     </xpath>
-    <xpath expr="(//h5)[4]" position="replace" mode="inner">
+    <xpath expr="(//h3)[4]" position="replace" mode="inner">
         Personalized Art Commissions
     </xpath>
     <xpath expr="(//p)[4]" position="replace" mode="inner">

--- a/theme_artists/views/snippets/s_three_columns.xml
+++ b/theme_artists/views/snippets/s_three_columns.xml
@@ -15,7 +15,7 @@
         <attribute name="class" add="o_cc5" remove="o_cc1" separator=" "/>
     </xpath>
     <!-- Column #1 - Title -->
-    <xpath expr="//div[hasclass('card-body')]//h5" position="replace" mode="inner">
+    <xpath expr="//div[hasclass('card-body')]//h2" position="replace" mode="inner">
         My artistic process
     </xpath>
     <!-- Column #1 - Paragraph -->
@@ -35,7 +35,7 @@
         <attribute name="class" add="o_cc5" remove="o_cc1" separator=" "/>
     </xpath>
     <!-- Column #2 - Title -->
-    <xpath expr="(//div[hasclass('card-body')])[2]//h5" position="replace" mode="inner">
+    <xpath expr="(//div[hasclass('card-body')])[2]//h2" position="replace" mode="inner">
         My work
     </xpath>
     <!-- Column #2 - Paragraph -->
@@ -55,7 +55,7 @@
         <attribute name="class" add="o_cc5" remove="o_cc1" separator=" "/>
     </xpath>
     <!-- Column #3 - Title -->
-    <xpath expr="(//div[hasclass('card-body')])[3]//h5" position="replace" mode="inner">
+    <xpath expr="(//div[hasclass('card-body')])[3]//h2" position="replace" mode="inner">
         About me
     </xpath>
     <!-- Column #3 - Paragraph -->

--- a/theme_avantgarde/views/customizations.xml
+++ b/theme_avantgarde/views/customizations.xml
@@ -146,7 +146,7 @@
         <attribute name="class" add="shadow border" separator=" "/>
         <attribute name="style">border-color: var(--o-color-2) !important; box-shadow: var(--o-color-2) -25px -25px 0px 0px !important; border-width: 8px !important;</attribute>
     </xpath>
-    <xpath expr="//h5" position="replace" mode="inner">
+    <xpath expr="//h2" position="replace" mode="inner">
         <span style="font-weight: bolder;">Excellence</span>
     </xpath>
     <xpath expr="(//p[hasclass('card-text')])[1]" position="replace" mode="inner">
@@ -155,7 +155,7 @@
         <attribute name="class" add="shadow border" separator=" "/>
         <attribute name="style">border-color: var(--o-color-4) !important; border-width: 8px !important; box-shadow: var(--o-color-5) 0px 0px 100px -40px !important;</attribute>
     </xpath>
-    <xpath expr="(//h5)[2]" position="replace" mode="inner">
+    <xpath expr="(//h2)[2]" position="replace" mode="inner">
         <span style="font-weight: bolder;">Collaboration</span>
     </xpath>
     <xpath expr="(//p[hasclass('card-text')])[2]" position="replace" mode="inner">
@@ -165,7 +165,7 @@
         <attribute name="class" add="shadow border" separator=" "/>
         <attribute name="style">box-shadow: var(--o-color-1) 25px 25px 0px 0px !important; border-color: var(--o-color-1) !important; border-width: 8px !important;</attribute>
     </xpath>
-    <xpath expr="(//h5)[3]" position="replace" mode="inner">
+    <xpath expr="(//h2)[3]" position="replace" mode="inner">
         <span style="font-weight: bolder;">Sustainability</span>
     </xpath>
     <xpath expr="(//p[hasclass('card-text')])[3]" position="replace" mode="inner">
@@ -231,8 +231,8 @@
 
 <!-- ======== CALL TO ACTION ======== -->
 <template id="s_call_to_action" inherit_id="website.s_call_to_action" name="Avantgarde s_call_to_action">
-    <xpath expr="//h3" position="replace">
-        <h3 style="text-align: right;"><b>Since 1992</b> creating around the world.</h3>
+    <xpath expr="//h2" position="replace">
+        <h2 style="text-align: right;"><b>Since 1992</b> creating around the world.</h2>
     </xpath>
     <xpath expr="//p" position="replace" mode="inner">
         We partner with ambitious clients. We’d love to hear from you.
@@ -570,7 +570,7 @@
         <attribute name="src">/web/image/website.s_carousel_default_image_3</attribute>
     </xpath>
     <!-- Title -->
-    <xpath expr="//h3" position="replace" mode="inner">
+    <xpath expr="//h2" position="replace" mode="inner">
         Innovative Design Meets Fine Art
     </xpath>
     <!-- Paragraph 1 -->

--- a/theme_aviato/views/snippets/s_card_offset.xml
+++ b/theme_aviato/views/snippets/s_card_offset.xml
@@ -11,7 +11,7 @@
         <attribute name="src">/web/image/website.s_carousel_default_image_3</attribute>
     </xpath>
     <!-- Title -->
-    <xpath expr="//h3" position="replace" mode="inner">
+    <xpath expr="//h2" position="replace" mode="inner">
         Your Gateway to Unforgettable Journeys
     </xpath>
     <!-- Paragraph 1 -->

--- a/theme_aviato/views/snippets/s_cards_grid.xml
+++ b/theme_aviato/views/snippets/s_cards_grid.xml
@@ -3,32 +3,32 @@
 
 <template id="s_cards_grid" inherit_id="website.s_cards_grid">
     <!-- Main Title -->
-    <xpath expr="//h3" position="replace" mode="inner">
+    <xpath expr="//h2" position="replace" mode="inner">
         Unravel your next adventure
     </xpath>
     <!-- Card 1 -->
-    <xpath expr="(//h5)[1]" position="replace" mode="inner">
+    <xpath expr="(//h3)[1]" position="replace" mode="inner">
         Relax in Marbella
     </xpath>
     <xpath expr="(//p)[1]" position="replace" mode="inner">
         Marbella is a city on the southern coast of Spain known for its luxurious lifestyle, beautiful beaches, and vibrant nightlife.
     </xpath>
     <!-- Card 2 -->
-    <xpath expr="(//h5)[2]" position="replace" mode="inner">
+    <xpath expr="(//h3)[2]" position="replace" mode="inner">
         Rest in Finland
     </xpath>
     <xpath expr="(//p)[2]" position="replace" mode="inner">
         Enjoy the peace and quiet of Finland's forests and lakes. Rest and relax in one of our best partnered resorts.
     </xpath>
     <!-- Card 3 -->
-    <xpath expr="(//h5)[3]" position="replace" mode="inner">
+    <xpath expr="(//h3)[3]" position="replace" mode="inner">
         Tan in Thailand
     </xpath>
     <xpath expr="(//p)[3]" position="replace" mode="inner">
         Known for its stunning beaches Thailand is a Southeast Asian country, enjoy its lush forests and vibrant culture.
     </xpath>
     <!-- Card 4 -->
-    <xpath expr="(//h5)[4]" position="replace" mode="inner">
+    <xpath expr="(//h3)[4]" position="replace" mode="inner">
         Hike in Switzerland
     </xpath>
     <xpath expr="(//p)[4]" position="replace" mode="inner">

--- a/theme_aviato/views/snippets/s_company_team.xml
+++ b/theme_aviato/views/snippets/s_company_team.xml
@@ -7,8 +7,8 @@
         <attribute name="class" add="pt72 pb0" remove="pt48 pb48" separator=" "/>
     </xpath>
     <!-- Title -->
-    <xpath expr="//h3" position="replace">
-        <h2>Meet our travel agents</h2>
+    <xpath expr="//h2" position="replace" mode="inner">
+        Meet our travel agents
     </xpath>
 
     <xpath expr="//div[hasclass('col-lg-9')]//p" position="replace"/>

--- a/theme_aviato/views/snippets/s_masonry_block.xml
+++ b/theme_aviato/views/snippets/s_masonry_block.xml
@@ -22,7 +22,7 @@
     <!-- Add Text -->
     <xpath expr="//div[hasclass('o_grid_item')]" position="inside">
         <div class="o_we_bg_filter bg-black-50"></div>
-        <h3 style="text-align: left;">Brazil</h3>
+        <h2 class="h3-fs" style="text-align: left;">Brazil</h2>
         <p style="text-align: left;">From $699</p>
     </xpath>
 
@@ -32,11 +32,11 @@
         <attribute name="class" add="oe_img_bg o_bg_img_center o_cc o_cc5 overflow-hidden rounded" remove="o_cc o_cc2 rounded-4" separator=" "/>
         <attribute name="style" add="--grid-item-padding-y: 0px; background-image: url('/web/image/website.s_carousel_default_image_1');" remove="--grid-item-padding-y: 20px" separator=";"/>
     </xpath>
-    <xpath expr="(//div[hasclass('o_grid_item')])[2]/h3" position="before">
+    <xpath expr="(//div[hasclass('o_grid_item')])[2]/h2" position="before">
         <div class="o_we_bg_filter bg-black-50"></div>
     </xpath>
     <!-- Title -->
-    <xpath expr="(//div[hasclass('o_grid_item')])[2]/h3" position="replace" mode="inner">
+    <xpath expr="(//div[hasclass('o_grid_item')])[2]/h2" position="replace" mode="inner">
         Greece
     </xpath>
     <!-- Paragraph -->
@@ -50,11 +50,11 @@
         <attribute name="class" add="oe_img_bg o_bg_img_center o_cc o_cc5 overflow-hidden rounded" remove="o_cc o_cc3 rounded-4" separator=" "/>
         <attribute name="style" remove="--grid-item-padding-y: 20px; background-image: linear-gradient(135deg, var(--o-color-4) -400%, var(--o-color-2) 100%);" add="--grid-item-padding-y: 0px; background-image: url('/web/image/website.s_quotes_carousel_demo_image_2');" separator=";"/>
     </xpath>
-    <xpath expr="(//div[hasclass('o_grid_item')])[3]/h3" position="before">
+    <xpath expr="(//div[hasclass('o_grid_item')])[3]/h2" position="before">
         <div class="o_we_bg_filter bg-black-50"></div>
     </xpath>
     <!-- Title -->
-    <xpath expr="(//div[hasclass('o_grid_item')])[3]/h3" position="replace" mode="inner">
+    <xpath expr="(//div[hasclass('o_grid_item')])[3]/h2" position="replace" mode="inner">
         Italy
     </xpath>
     <!-- Paragraph -->
@@ -68,11 +68,11 @@
         <attribute name="class" add="oe_img_bg o_bg_img_center o_cc o_cc5 overflow-hidden rounded" remove="o_cc o_cc4 rounded-4" separator=" "/>
         <attribute name="style" remove="--grid-item-padding-y: 20px; background-image: linear-gradient(135deg, var(--o-color-4) -400%, var(--o-color-1) 100%);" add="--grid-item-padding-y: 0px; background-image: url('/web/image/website.s_key_images_default_image_4');" separator=";"/>
     </xpath>
-    <xpath expr="(//div[hasclass('o_grid_item')])[4]/h3" position="before">
+    <xpath expr="(//div[hasclass('o_grid_item')])[4]/h2" position="before">
         <div class="o_we_bg_filter bg-black-50"></div>
     </xpath>
     <!-- Title -->
-    <xpath expr="(//div[hasclass('o_grid_item')])[4]/h3" position="replace" mode="inner">
+    <xpath expr="(//div[hasclass('o_grid_item')])[4]/h2" position="replace" mode="inner">
         Romania
     </xpath>
     <!-- Paragraph -->
@@ -86,11 +86,11 @@
         <attribute name="class" add="oe_img_bg o_bg_img_center o_cc o_cc5 overflow-hidden rounded" remove="o_cc o_cc2 rounded-4" separator=" "/>
         <attribute name="style" add="--grid-item-padding-y: 0px; background-image: url('/web/image/website.s_three_columns_default_image_1');" remove="--grid-item-padding-y: 20px" separator=";"/>
     </xpath>
-    <xpath expr="(//div[hasclass('o_grid_item')])[5]/h3" position="before">
+    <xpath expr="(//div[hasclass('o_grid_item')])[5]/h2" position="before">
         <div class="o_we_bg_filter bg-black-50"></div>
     </xpath>
     <!-- Title -->
-    <xpath expr="(//div[hasclass('o_grid_item')])[5]/h3" position="replace" mode="inner">
+    <xpath expr="(//div[hasclass('o_grid_item')])[5]/h2" position="replace" mode="inner">
         France
     </xpath>
     <!-- Paragraph -->

--- a/theme_aviato/views/snippets/s_showcase.xml
+++ b/theme_aviato/views/snippets/s_showcase.xml
@@ -11,23 +11,23 @@
         <attribute name="class" add="align-items-center" separator=" "/>
     </xpath>
     <!-- Title -->
-    <xpath expr="//h3" position="replace">
-        <h2>Why Choose Us</h2>
+    <xpath expr="//h2" position="replace" mode="inner">
+        Why Choose Us
     </xpath>
     <!-- Content -->
-    <xpath expr="//h5" position="replace" mode="inner">
+    <xpath expr="//h3" position="replace" mode="inner">
         Expertly Curated Trips
     </xpath>
     <xpath expr="//div[hasclass('col-12')][2]//p" position="replace" mode="inner">
         We select only the best destinations, ensuring your travel experience is nothing short of extraordinary.
     </xpath>
-    <xpath expr="(//h5)[2]" position="replace" mode="inner">
+    <xpath expr="(//h3)[2]" position="replace" mode="inner">
         Personalized Itineraries
     </xpath>
     <xpath expr="//div[hasclass('col-12')][3]//p" position="replace" mode="inner">
         Your journey is tailored to match your preferences, making every trip uniquely yours.
     </xpath>
-    <xpath expr="(//h5)[3]" position="replace" mode="inner">
+    <xpath expr="(//h3)[3]" position="replace" mode="inner">
         Seamless Travel Experience
     </xpath>
     <xpath expr="//div[hasclass('col-12')][4]//p" position="replace" mode="inner">

--- a/theme_aviato/views/snippets/s_three_columns.xml
+++ b/theme_aviato/views/snippets/s_three_columns.xml
@@ -13,7 +13,7 @@
     <xpath expr="//figure" position="attributes">
         <attribute name="class" remove="ratio-16x9" add="o_card_img_ratio_custom" separator=" "/>
     </xpath>
-    <xpath expr="//h5" position="replace" mode="inner">
+    <xpath expr="//h2" position="replace" mode="inner">
         Paris
     </xpath>
     <xpath expr="//p" position="replace" mode="inner">
@@ -29,7 +29,7 @@
     <xpath expr="(//figure)[2]"  position="attributes">
         <attribute name="class" remove="ratio-16x9" add="o_card_img_ratio_custom" separator=" "/>
     </xpath>
-    <xpath expr="(//h5)[2]" position="replace" mode="inner">
+    <xpath expr="(//h2)[2]" position="replace" mode="inner">
         Rome
     </xpath>
     <xpath expr="(//p)[2]" position="replace" mode="inner">
@@ -45,7 +45,7 @@
     <xpath expr="(//figure)[3]"  position="attributes">
         <attribute name="class" remove="ratio-16x9" add="o_card_img_ratio_custom" separator=" "/>
     </xpath>
-    <xpath expr="(//h5)[3]" position="replace" mode="inner">
+    <xpath expr="(//h2)[3]" position="replace" mode="inner">
         Prague
     </xpath>
     <xpath expr="(//p)[3]" position="replace" mode="inner">

--- a/theme_beauty/views/snippets/s_call_to_action.xml
+++ b/theme_beauty/views/snippets/s_call_to_action.xml
@@ -14,7 +14,7 @@
         <attribute name="class" add="col-lg-12" remove="col-lg-3" separator=" "/>
     </xpath>
     <!-- Paragraphs -->
-    <xpath expr="//h3" position="replace">
+    <xpath expr="//h2" position="replace">
         <h2>Beauty without <br/>expression is boring</h2>
     </xpath>
     <xpath expr="//p" position="replace" mode="inner">

--- a/theme_beauty/views/snippets/s_card_offset.xml
+++ b/theme_beauty/views/snippets/s_card_offset.xml
@@ -15,7 +15,7 @@
         <attribute name="src">/web/image/website.s_carousel_default_image_3</attribute>
     </xpath>
     <!-- Title -->
-    <xpath expr="//h3" position="replace" mode="inner">
+    <xpath expr="//h2" position="replace" mode="inner">
         Unveil Your Natural Beauty
     </xpath>
     <!-- Paragraph 1 -->

--- a/theme_beauty/views/snippets/s_cards_grid.xml
+++ b/theme_beauty/views/snippets/s_cards_grid.xml
@@ -3,32 +3,32 @@
 
 <template id="s_cards_grid" inherit_id="website.s_cards_grid">
     <!-- Title -->
-    <xpath expr="//h3" position="replace" mode="inner">
+    <xpath expr="//h2" position="replace" mode="inner">
         Innovative Beauty Treatments for Radiant Results
     </xpath>
     <!-- Card 1 -->
-    <xpath expr="(//h5)[1]" position="replace" mode="inner">
+    <xpath expr="(//h3)[1]" position="replace" mode="inner">
         Premium Beauty Products
     </xpath>
     <xpath expr="(//p)[1]" position="replace" mode="inner">
         Discover our exclusive range of high-quality beauty products, crafted with natural ingredients to enhance your skin's radiance and health.
     </xpath>
     <!-- Card 2 -->
-    <xpath expr="(//h5)[2]" position="replace" mode="inner">
+    <xpath expr="(//h3)[2]" position="replace" mode="inner">
         Personalized Skincare Solutions
     </xpath>
     <xpath expr="(//p)[2]" position="replace" mode="inner">
         Our experts provide tailored skincare consultations, recommending products and treatments designed specifically for your skin type and concerns.
     </xpath>
     <!-- Card 3 -->
-    <xpath expr="(//h5)[3]" position="replace" mode="inner">
+    <xpath expr="(//h3)[3]" position="replace" mode="inner">
         Advanced Beauty Treatments
     </xpath>
     <xpath expr="(//p)[3]" position="replace" mode="inner">
         Experience cutting-edge beauty treatments, from innovative facial therapies to advanced body treatments, designed to enhance your natural beauty.
     </xpath>
     <!-- Card 4 -->
-    <xpath expr="(//h5)[4]" position="replace" mode="inner">
+    <xpath expr="(//h3)[4]" position="replace" mode="inner">
         Expert Beauty Consultations
     </xpath>
     <xpath expr="(//p)[4]" position="replace" mode="inner">

--- a/theme_beauty/views/snippets/s_company_team.xml
+++ b/theme_beauty/views/snippets/s_company_team.xml
@@ -7,16 +7,16 @@
         <attribute name="class" add="o_cc o_cc4 pt80 pb80" remove="pb48 pt48" separator=" "/>
     </xpath>
     <!-- Titles -->
-    <xpath expr="(//div[hasclass('col-lg-9')])[1]/h4" position="replace" mode="inner">
+    <xpath expr="(//div[hasclass('col-lg-9')])[1]/h3" position="replace" mode="inner">
         Tony
     </xpath>
-    <xpath expr="(//div[hasclass('col-lg-9')])[2]/h4" position="replace" mode="inner">
+    <xpath expr="(//div[hasclass('col-lg-9')])[2]/h3" position="replace" mode="inner">
         Mich
     </xpath>
-    <xpath expr="(//div[hasclass('col-lg-9')])[3]/h4" position="replace" mode="inner">
+    <xpath expr="(//div[hasclass('col-lg-9')])[3]/h3" position="replace" mode="inner">
         Aline
     </xpath>
-    <xpath expr="(//div[hasclass('col-lg-9')])[4]/h4" position="replace" mode="inner">
+    <xpath expr="(//div[hasclass('col-lg-9')])[4]/h3" position="replace" mode="inner">
         Iris
     </xpath>
     <!-- Images -->

--- a/theme_bewise/views/customizations.xml
+++ b/theme_bewise/views/customizations.xml
@@ -250,8 +250,8 @@
         <div class="o_we_shape o_web_editor_Blobs_05_001" style="background-image: url('/web_editor/shape/web_editor/Blobs/05_001.svg?c1=rgba(0,0,0,0.25)&amp;flip=xy'); background-position: 50% 0%;"/>
     </xpath>
     <!-- Title -->
-    <xpath expr="//h3" position="replace">
-        <h4>3,000 students graduate each year and find a job within 2 months</h4>
+    <xpath expr="//h2" position="replace">
+        <h2 class="h4-fs">3,000 students graduate each year and find a job within 2 months</h2>
     </xpath>
     <!-- Subtitle -->
     <xpath expr="//div[hasclass('col-lg-9')]/p" position="replace" mode="inner">
@@ -282,7 +282,7 @@
 <!-- ======== TEAM ======== -->
 <template id="s_company_team" inherit_id="website.s_company_team" name="Be Wise s_company_team">
     <!-- Profile #1 -->
-    <xpath expr="//div[hasclass('row')]/div//h4" position="replace" mode="inner">
+    <xpath expr="//div[hasclass('row')]/div//h3" position="replace" mode="inner">
         <b>Tony Fred</b>
     </xpath>
     <xpath expr="//div[hasclass('row')]/div//p" position="replace" mode="inner">
@@ -292,7 +292,7 @@
         Tony received a degree in Electrical and Mechanical Engineering and a Ph D. degree in 1998 and 2004. After a post-doctoral experience  he joined the school as professor of mechatronics in 2006. In 2010, he became Head of IT.
     </xpath>
     <!-- Profile #2 -->
-    <xpath expr="//div[hasclass('row')]/div[2]//h4" position="replace" mode="inner">
+    <xpath expr="//div[hasclass('row')]/div[2]//h3" position="replace" mode="inner">
         <b>Mich Stark</b>
     </xpath>
     <xpath expr="//div[hasclass('row')]/div[2]//p" position="replace" mode="inner">
@@ -302,7 +302,7 @@
         He is professor in the Institute of Mechanics, Materials and Civil Engineering since 2000. He lectures in mechanical drawing and mechanical design for undergraduate and graduate students. He is active in Problem and Project based learning. He is the promoter of 8 doctoral theses.
     </xpath>
     <!-- Profile #3 -->
-    <xpath expr="//div[hasclass('row')]/div[3]//h4" position="replace" mode="inner">
+    <xpath expr="//div[hasclass('row')]/div[3]//h3" position="replace" mode="inner">
         <b>Aline Turner</b>
     </xpath>
     <xpath expr="//div[hasclass('row')]/div[3]//p" position="replace" mode="inner">
@@ -312,7 +312,7 @@
         She has been practicing law at the French-speaking Brussels Bar since 2006. She has worked in various major law firms based in Brussels, as member and then head of their litigation/arbitration practice groups.
     </xpath>
     <!-- Profile #4 -->
-    <xpath expr="//div[hasclass('row')]/div[4]//h4" position="replace" mode="inner">
+    <xpath expr="//div[hasclass('row')]/div[4]//h3" position="replace" mode="inner">
         <b>Iris Joe</b>
     </xpath>
     <xpath expr="//div[hasclass('row')]/div[4]//p" position="replace" mode="inner">
@@ -322,18 +322,18 @@
 
 <!-- ======== TEAM BASIC ======== -->
 <template id="s_company_team_basic" inherit_id="website.s_company_team_basic">
-    <xpath expr="//h3" position="replace" mode="inner">
+    <xpath expr="//h2" position="replace" mode="inner">
         Discover our dedicated staff
     </xpath>
     <!-- Profile #1 -->
-    <xpath expr="(//h4)[1]" position="replace" mode="inner">
+    <xpath expr="(//h3)[1]" position="replace" mode="inner">
         Tony Fred
     </xpath>
     <xpath expr="(//p[hasclass('o_small-fs')])[1]" position="replace" mode="inner">
         Faculty Head of IT
     </xpath>
     <!-- Profile #2 -->
-    <xpath expr="(//h4)[2]" position="replace" mode="inner">
+    <xpath expr="(//h3)[2]" position="replace" mode="inner">
         Mich Stark
     </xpath>
     <xpath expr="(//p[hasclass('o_small-fs')])[2]" position="replace" mode="inner">
@@ -806,32 +806,32 @@
 
 <template id="s_cards_grid" inherit_id="website.s_cards_grid">
     <!-- Title -->
-    <xpath expr="//h3" position="replace" mode="inner">
+    <xpath expr="//h2" position="replace" mode="inner">
         Elevate Your Academic Journey
     </xpath>
     <!-- Card 1 -->
-    <xpath expr="(//h5)[1]" position="replace" mode="inner">
+    <xpath expr="(//h3)[1]" position="replace" mode="inner">
         Cutting-Edge Research Facilities
     </xpath>
     <xpath expr="(//p)[1]" position="replace" mode="inner">
         Explore our state-of-the-art research facilities, equipped with the latest technology to support groundbreaking research and innovative projects.
     </xpath>
     <!-- Card 2 -->
-    <xpath expr="(//h5)[2]" position="replace" mode="inner">
+    <xpath expr="(//h3)[2]" position="replace" mode="inner">
         Personalized Academic Support
     </xpath>
     <xpath expr="(//p)[2]" position="replace" mode="inner">
         Benefit from tailored academic advising and support services, designed to guide you through your educational journey.
     </xpath>
     <!-- Card 3 -->
-    <xpath expr="(//h5)[3]" position="replace" mode="inner">
+    <xpath expr="(//h3)[3]" position="replace" mode="inner">
         Advanced Learning Programs
     </xpath>
     <xpath expr="(//p)[3]" position="replace" mode="inner">
         Engage in our cutting-edge learning programs that offer specialized courses, hands-on experiences for in-depth exploration in your field of interest.
     </xpath>
     <!-- Card 4 -->
-    <xpath expr="(//h5)[4]" position="replace" mode="inner">
+    <xpath expr="(//h3)[4]" position="replace" mode="inner">
         Expert Faculty and Mentorship
     </xpath>
     <xpath expr="(//p)[4]" position="replace" mode="inner">
@@ -961,7 +961,7 @@
         <attribute name="src">/web/image/website.s_carousel_default_image_2</attribute>
     </xpath>
     <!-- Title -->
-    <xpath expr="//h3" position="replace" mode="inner">
+    <xpath expr="//h2" position="replace" mode="inner">
         Shaping Tomorrow's Leaders
     </xpath>
     <!-- Paragraph 1 -->

--- a/theme_bistro/views/snippets/s_card_offset.xml
+++ b/theme_bistro/views/snippets/s_card_offset.xml
@@ -15,7 +15,7 @@
         <attribute name="src">/web/image/website.s_carousel_default_image_3</attribute>
     </xpath>
     <!-- Title -->
-    <xpath expr="//h3" position="replace" mode="inner">
+    <xpath expr="//h2" position="replace" mode="inner">
         A Culinary Journey Awaits You
     </xpath>
     <!-- Paragraph 1 -->

--- a/theme_bistro/views/snippets/s_cards_grid.xml
+++ b/theme_bistro/views/snippets/s_cards_grid.xml
@@ -3,32 +3,32 @@
 
 <template id="s_cards_grid" inherit_id="website.s_cards_grid">
     <!-- Title -->
-    <xpath expr="//h3" position="replace" mode="inner">
+    <xpath expr="//h2" position="replace" mode="inner">
         Experience the Pinnacle of Fine Dining and Innovation
     </xpath>
     <!-- Card 1 -->
-    <xpath expr="(//h5)[1]" position="replace" mode="inner">
+    <xpath expr="(//h3)[1]" position="replace" mode="inner">
         Gourmet Dining Experiences
     </xpath>
     <xpath expr="(//p)[1]" position="replace" mode="inner">
         Savor exquisite culinary creations crafted by top chefs. Our gourmet dining experiences feature innovative dishes and premium ingredients, promising an unforgettable meal.
     </xpath>
     <!-- Card 2 -->
-    <xpath expr="(//h5)[2]" position="replace" mode="inner">
+    <xpath expr="(//h3)[2]" position="replace" mode="inner">
         Personalized Culinary Consultations
     </xpath>
     <xpath expr="(//p)[2]" position="replace" mode="inner">
         Enjoy tailored culinary advice with bespoke menus designed to suit your taste preferences and dietary needs. Our personalized consultations ensure a dining experience just for you.
     </xpath>
     <!-- Card 3 -->
-    <xpath expr="(//h5)[3]" position="replace" mode="inner">
+    <xpath expr="(//h3)[3]" position="replace" mode="inner">
         Cutting-Edge Culinary Techniques
     </xpath>
     <xpath expr="(//p)[3]" position="replace" mode="inner">
         Experience the latest in gastronomic innovation with advanced cooking techniques. Our unique flavor combinations and modern methods elevate the art of dining to new heights.
     </xpath>
     <!-- Card 4 -->
-    <xpath expr="(//h5)[4]" position="replace" mode="inner">
+    <xpath expr="(//h3)[4]" position="replace" mode="inner">
         Expert Chef Workshops
     </xpath>
     <xpath expr="(//p)[4]" position="replace" mode="inner">

--- a/theme_bookstore/views/snippets/s_card_offset.xml
+++ b/theme_bookstore/views/snippets/s_card_offset.xml
@@ -11,7 +11,7 @@
         <attribute name="src">/web/image/website.s_carousel_default_image_3</attribute>
     </xpath>
     <!-- Title -->
-    <xpath expr="//h3" position="replace" mode="inner">
+    <xpath expr="//h2" position="replace" mode="inner">
         Discover a World of Knowledge
     </xpath>
     <!-- Paragraph 1 -->

--- a/theme_bookstore/views/snippets/s_cards_grid.xml
+++ b/theme_bookstore/views/snippets/s_cards_grid.xml
@@ -3,7 +3,7 @@
 
 <template id="s_cards_grid" inherit_id="website.s_cards_grid">
     <!-- Title -->
-    <xpath expr="//h3" position="replace" mode="inner">
+    <xpath expr="//h2" position="replace" mode="inner">
         Discover Your Next Great Read
     </xpath>
     <!-- Card 1 -->
@@ -13,7 +13,7 @@
     <xpath expr="(//div[hasclass('s_card')])[1]//img" position="attributes">
         <attribute name="class" add="rounded-end" remove="rounded-start" separator=" "/>
     </xpath>
-    <xpath expr="(//h5)[1]" position="replace" mode="inner">
+    <xpath expr="(//h3)[1]" position="replace" mode="inner">
         Boundless
     </xpath>
     <xpath expr="(//p)[1]" position="replace" mode="inner">
@@ -26,7 +26,7 @@
     <xpath expr="(//div[hasclass('s_card')])[2]//img" position="attributes">
         <attribute name="class" add="rounded-end" remove="rounded-start" separator=" "/>
     </xpath>
-    <xpath expr="(//h5)[2]" position="replace" mode="inner">
+    <xpath expr="(//h3)[2]" position="replace" mode="inner">
         Romans
     </xpath>
     <xpath expr="(//p)[2]" position="replace" mode="inner">
@@ -39,7 +39,7 @@
     <xpath expr="(//div[hasclass('s_card')])[3]//img" position="attributes">
         <attribute name="class" add="rounded-end" remove="rounded-start" separator=" "/>
     </xpath>
-    <xpath expr="(//h5)[3]" position="replace" mode="inner">
+    <xpath expr="(//h3)[3]" position="replace" mode="inner">
         Change the Way You Think
     </xpath>
     <xpath expr="(//p)[3]" position="replace" mode="inner">
@@ -52,7 +52,7 @@
     <xpath expr="(//div[hasclass('s_card')])[4]//img" position="attributes">
         <attribute name="class" add="rounded-end" remove="rounded-start" separator=" "/>
     </xpath>
-    <xpath expr="(//h5)[4]" position="replace" mode="inner">
+    <xpath expr="(//h3)[4]" position="replace" mode="inner">
         What I Didn't Post on Social Media
     </xpath>
     <xpath expr="(//p)[4]" position="replace" mode="inner">

--- a/theme_bookstore/views/snippets/s_masonry_block.xml
+++ b/theme_bookstore/views/snippets/s_masonry_block.xml
@@ -13,7 +13,7 @@
         <attribute name="style" remove="background-image: linear-gradient(135deg, var(--o-color-4) -400%, var(--o-color-2) 100%);" separator=";"/>
     </xpath>
     <!-- Title -->
-    <xpath expr="//div[hasclass('col-lg-4')]/h3" position="replace" mode="inner">
+    <xpath expr="//div[hasclass('col-lg-4')]/h2" position="replace" mode="inner">
         Science fiction
     </xpath>
     <!-- Paragraph -->
@@ -28,7 +28,7 @@
         <attribute name="style" remove="background-image: linear-gradient(135deg, var(--o-color-4) -400%, var(--o-color-1) 100%);" separator=";"/>
     </xpath>
     <!-- Title -->
-    <xpath expr="//div[hasclass('col-lg-4')][2]/h3" position="replace" mode="inner">
+    <xpath expr="//div[hasclass('col-lg-4')][2]/h2" position="replace" mode="inner">
         Biographies
     </xpath>
     <!-- Paragraph -->
@@ -42,7 +42,7 @@
         <attribute name="class" add="rounded" remove="rounded-4" separator=" "/>
     </xpath>
     <!-- Title -->
-    <xpath expr="//div[hasclass('col-lg-3')]/h3" position="replace" mode="inner">
+    <xpath expr="//div[hasclass('col-lg-3')]/h2" position="replace" mode="inner">
         Horror
     </xpath>
     <!-- Paragraph -->
@@ -56,7 +56,7 @@
         <attribute name="class" add="rounded" remove="rounded-4" separator=" "/>
     </xpath>
     <!-- Title -->
-    <xpath expr="//div[hasclass('col-lg-3')][2]/h3" position="replace" mode="inner">
+    <xpath expr="//div[hasclass('col-lg-3')][2]/h2" position="replace" mode="inner">
         Romance
     </xpath>
     <!-- Paragraph -->

--- a/theme_bookstore/views/snippets/s_showcase.xml
+++ b/theme_bookstore/views/snippets/s_showcase.xml
@@ -7,7 +7,7 @@
         <attribute name="class" add="pt128 pb128 o_cc o_cc5" remove="pt48 pb48" separator=" "/>
     </xpath>
     <!-- Title -->
-    <xpath expr="//h3" position="replace" mode="inner">
+    <xpath expr="//h2" position="replace" mode="inner">
         We also sell prime quality second hand books
     </xpath>
     <!-- Lead -->
@@ -15,19 +15,19 @@
         Prime quality second-hand books, carefully selected for value and charm. Timeless stories at great prices.
     </xpath>
     <!-- Features -->
-    <xpath expr="//h5" position="replace" mode="inner">
+    <xpath expr="//h3" position="replace" mode="inner">
         Timeless Reads
     </xpath>
     <xpath expr="//div[hasclass('col-12')][2]//p" position="replace" mode="inner">
         Explore beloved stories from every era. Find cherished classics to enjoy again and again.
     </xpath>
-    <xpath expr="(//h5)[2]" position="replace" mode="inner">
+    <xpath expr="(//h3)[2]" position="replace" mode="inner">
         Affordable Classics
     </xpath>
     <xpath expr="//div[hasclass('col-12')][3]//p" position="replace" mode="inner">
         Own literary masterpieces without breaking the bank. Your favorite classic books at budget-friendly prices.
     </xpath>
-    <xpath expr="(//h5)[3]" position="replace" mode="inner">
+    <xpath expr="(//h3)[3]" position="replace" mode="inner">
         Hidden Treasures
     </xpath>
     <xpath expr="//div[hasclass('col-12')][4]//p" position="replace" mode="inner">

--- a/theme_bookstore/views/snippets/s_three_columns.xml
+++ b/theme_bookstore/views/snippets/s_three_columns.xml
@@ -7,21 +7,21 @@
         <attribute name="class" add="o_cc1" remove="o_cc2" separator=" "/>
     </xpath>
     <!-- Column #1 -->
-    <xpath expr="//h5" position="replace" mode="inner">
+    <xpath expr="//h2" position="replace" mode="inner">
         A Belgian Story
     </xpath>
     <xpath expr="//p[hasclass('card-text')]" position="replace" mode="inner">
         Discover the history of Belgium in this well-documented book with many illustrations and testimonials.
     </xpath>
     <!-- Column #2 -->
-    <xpath expr="(//h5)[2]" position="replace" mode="inner">
+    <xpath expr="(//h2)[2]" position="replace" mode="inner">
         At the Mars conquest
     </xpath>
     <xpath expr="(//p[hasclass('card-text')])[2]" position="replace" mode="inner">
         Learn about the difficulties encountered by NASA engineers in sending the first men to Mars.
     </xpath>
     <!-- Column #3 -->
-    <xpath expr="(//h5)[3]" position="replace" mode="inner">
+    <xpath expr="(//h2)[3]" position="replace" mode="inner">
         Re-edition
     </xpath>
     <xpath expr="(//p[hasclass('card-text')])[3]" position="replace" mode="inner">

--- a/theme_buzzy/views/snippets/s_call_to_action.xml
+++ b/theme_buzzy/views/snippets/s_call_to_action.xml
@@ -11,7 +11,7 @@
         <attribute name="class" add="col-lg-8" remove="col-lg-9" separator=" "/>
     </xpath>
     <!-- Title -->
-    <xpath expr="//h3" position="replace" mode="inner">
+    <xpath expr="//h2" position="replace" mode="inner">
         Start to build your robust activity with these powerful tools
     </xpath>
     <!-- Paragraph -->

--- a/theme_buzzy/views/snippets/s_card_offset.xml
+++ b/theme_buzzy/views/snippets/s_card_offset.xml
@@ -11,7 +11,7 @@
         <attribute name="src">/web/image/website.s_carousel_default_image_3</attribute>
     </xpath>
     <!-- Title -->
-    <xpath expr="//h3" position="replace" mode="inner">
+    <xpath expr="//h2" position="replace" mode="inner">
         Innovation at the Heart of Business
     </xpath>
     <!-- Paragraph 1 -->

--- a/theme_buzzy/views/snippets/s_showcase.xml
+++ b/theme_buzzy/views/snippets/s_showcase.xml
@@ -5,7 +5,7 @@
     <xpath expr="//img" position="attributes">
         <attribute name="src">/web_editor/shape/theme_buzzy/s_showcase.svg?c1=o-color-2</attribute>
     </xpath>
-    <xpath expr="//h3" position="replace" mode="inner">
+    <xpath expr="//h2" position="replace" mode="inner">
         Features <span class="o_text_highlight o_translate_inline o_text_highlight_scribble_3 o_text_highlight_fill">showcase</span>
     </xpath>
     <xpath expr="(//div[hasclass('col-lg-6')])[2]" position="attributes">

--- a/theme_buzzy/views/snippets/s_three_columns.xml
+++ b/theme_buzzy/views/snippets/s_three_columns.xml
@@ -13,7 +13,7 @@
         <attribute name="src">/web_editor/shape/theme_buzzy/s_three_columns-01.svg?c1=o-color-1</attribute>
     </xpath>
     <!-- Title -->
-    <xpath expr="//div[hasclass('card')]//h5" position="replace" mode="inner">
+    <xpath expr="//div[hasclass('card')]//h2" position="replace" mode="inner">
         Built to <br/>your effigy
     </xpath>
     <!-- Paragraph -->
@@ -32,7 +32,7 @@
         <attribute name="src">/web_editor/shape/theme_buzzy/s_three_columns-02.svg?c1=o-color-1</attribute>
     </xpath>
     <!-- Title -->
-    <xpath expr="(//div[hasclass('card')])[2]//h5" position="replace" mode="inner">
+    <xpath expr="(//div[hasclass('card')])[2]//h2" position="replace" mode="inner">
         Editable from <br/>A to Z
     </xpath>
     <!-- Paragraph -->
@@ -51,7 +51,7 @@
         <attribute name="src">/web_editor/shape/theme_buzzy/s_three_columns-03.svg?c1=o-color-1</attribute>
     </xpath>
     <!-- Title -->
-    <xpath expr="(//div[hasclass('card')])[3]//h5" position="replace" mode="inner">
+    <xpath expr="(//div[hasclass('card')])[3]//h2" position="replace" mode="inner">
         All data <br/>in your hands
     </xpath>
     <!-- Paragraph -->

--- a/theme_clean/views/snippets/s_call_to_action.xml
+++ b/theme_clean/views/snippets/s_call_to_action.xml
@@ -10,7 +10,7 @@
     <xpath expr="//div[hasclass('col-lg-9')]" position="attributes">
         <attribute name="class" add="pt16" separator=" "/>
     </xpath>
-    <xpath expr="//h3" position="replace" mode="inner">
+    <xpath expr="//h2" position="replace" mode="inner">
         <b>50,000 people</b>, run Clean to grow their financial wealth.
     </xpath>
     <xpath expr="//p" position="replace" mode="inner">

--- a/theme_clean/views/snippets/s_card_offset.xml
+++ b/theme_clean/views/snippets/s_card_offset.xml
@@ -11,7 +11,7 @@
         <attribute name="src">/web/image/website.s_quotes_carousel_demo_image_1</attribute>
     </xpath>
     <!-- Title -->
-    <xpath expr="//h3" position="replace" mode="inner">
+    <xpath expr="//h2" position="replace" mode="inner">
         Expert Legal Solutions for Business
     </xpath>
     <!-- Paragraph 1 -->

--- a/theme_clean/views/snippets/s_carousel.xml
+++ b/theme_clean/views/snippets/s_carousel.xml
@@ -9,10 +9,10 @@
     <xpath expr="(//h2)[2]" position="replace" mode="inner">
         Simplify things
     </xpath>
-    <xpath expr="//h3" position="replace" mode="inner">
+    <xpath expr="(//h2)[3]" position="replace" mode="inner">
         Efficient team processes
     </xpath>
-    <xpath expr="//h6" position="replace"/>
+    <xpath expr="//div[hasclass('carousel-item')][3]//p" position="replace"/>
 
     <!-- Paragraphs -->
     <xpath expr="//p[hasclass('lead')]" position="replace" mode="inner">

--- a/theme_clean/views/snippets/s_three_columns.xml
+++ b/theme_clean/views/snippets/s_three_columns.xml
@@ -10,7 +10,7 @@
     <xpath expr="//div[hasclass('card')]" position="attributes">
         <attribute name="style">border-width: 0px !important;</attribute>
     </xpath>
-    <xpath expr="//h5[hasclass('card-title')]" position="replace" mode="inner">
+    <xpath expr="//h2[hasclass('card-title')]" position="replace" mode="inner">
         Our mission
     </xpath>
     <xpath expr="//p[hasclass('card-text')]" position="replace" mode="inner">
@@ -20,7 +20,7 @@
     <xpath expr="(//div[hasclass('card')])[2]" position="attributes">
         <attribute name="style">border-width: 0px !important;</attribute>
     </xpath>
-    <xpath expr="(//h5[hasclass('card-title')])[2]" position="replace" mode="inner">
+    <xpath expr="(//h2[hasclass('card-title')])[2]" position="replace" mode="inner">
         Our values
     </xpath>
     <xpath expr="(//p[hasclass('card-text')])[2]" position="replace" mode="inner">
@@ -30,7 +30,7 @@
     <xpath expr="(//div[hasclass('card')])[3]" position="attributes">
         <attribute name="style">border-width: 0px !important;</attribute>
     </xpath>
-    <xpath expr="(//h5[hasclass('card-title')])[3]" position="replace" mode="inner">
+    <xpath expr="(//h2[hasclass('card-title')])[3]" position="replace" mode="inner">
         Our team
     </xpath>
     <xpath expr="(//p[hasclass('card-text')])[3]" position="replace" mode="inner">

--- a/theme_cobalt/views/customizations.xml
+++ b/theme_cobalt/views/customizations.xml
@@ -598,7 +598,7 @@
         <attribute name="src">/web/image/website.s_carousel_default_image_3</attribute>
     </xpath>
     <!-- Title -->
-    <xpath expr="//h3" position="replace" mode="inner">
+    <xpath expr="//h2" position="replace" mode="inner">
         Pioneering IT Solutions &amp; Development
     </xpath>
     <!-- Paragraph 1 -->

--- a/theme_enark/views/snippets/s_call_to_action.xml
+++ b/theme_enark/views/snippets/s_call_to_action.xml
@@ -3,7 +3,7 @@
 
 <template id="s_call_to_action" inherit_id="website.s_call_to_action">
     <!-- Paragraph -->
-    <xpath expr="//h3" position="replace" mode="inner">
+    <xpath expr="//h2" position="replace" mode="inner">
         As 436 clients before you, let’s work together
     </xpath>
     <xpath expr="//p" position="replace"/>

--- a/theme_enark/views/snippets/s_card_offset.xml
+++ b/theme_enark/views/snippets/s_card_offset.xml
@@ -15,7 +15,7 @@
         <attribute name="src">/web/image/website.library_image_13</attribute>
     </xpath>
     <!-- Title -->
-    <xpath expr="//h3" position="replace" mode="inner">
+    <xpath expr="//h2" position="replace" mode="inner">
         Building the Future of Business
     </xpath>
     <!-- Paragraph 1 -->

--- a/theme_enark/views/snippets/s_cards_grid.xml
+++ b/theme_enark/views/snippets/s_cards_grid.xml
@@ -3,32 +3,32 @@
 
 <template id="s_cards_grid" inherit_id="website.s_cards_grid">
     <!-- Title -->
-    <xpath expr="//h3" position="replace" mode="inner">
+    <xpath expr="//h2" position="replace" mode="inner">
         Crafting Tomorrow's Architectural Icons
     </xpath>
     <!-- Card 1 -->
-    <xpath expr="(//h5)[1]" position="replace" mode="inner">
+    <xpath expr="(//h3)[1]" position="replace" mode="inner">
         Innovative Building Design
     </xpath>
     <xpath expr="(//p)[1]" position="replace" mode="inner">
         We create visionary designs that transform spaces into functional works of art. Our approach blends creativity with cutting-edge technology to craft buildings that stand out.
     </xpath>
     <!-- Card 2 -->
-    <xpath expr="(//h5)[2]" position="replace" mode="inner">
+    <xpath expr="(//h3)[2]" position="replace" mode="inner">
         Modern Architecture Solutions
     </xpath>
     <xpath expr="(//p)[2]" position="replace" mode="inner">
         Our modern architectural solutions are tailored to meet the needs of today’s urban environments. We specialize in sleek, contemporary designs that optimize space and enhance livability.
     </xpath>
     <!-- Card 3 -->
-    <xpath expr="(//h5)[3]" position="replace" mode="inner">
+    <xpath expr="(//h3)[3]" position="replace" mode="inner">
         Sustainable Design Practices
     </xpath>
     <xpath expr="(//p)[3]" position="replace" mode="inner">
         We incorporate sustainable practices into every project, creating eco-friendly buildings that minimize environmental impact while maintaining aesthetic appeal and functionality.
     </xpath>
     <!-- Card 4 -->
-    <xpath expr="(//h5)[4]" position="replace" mode="inner">
+    <xpath expr="(//h3)[4]" position="replace" mode="inner">
         Comprehensive Project Management
     </xpath>
     <xpath expr="(//p)[4]" position="replace" mode="inner">

--- a/theme_graphene/views/customizations.xml
+++ b/theme_graphene/views/customizations.xml
@@ -175,8 +175,8 @@
 
 <!-- ======== 3 COLUMNS ======== -->
 <template id="s_three_columns" inherit_id="website.s_three_columns" name="Graphene s_three_columns">
-    <xpath expr="//div[hasclass('row')]/div//h5[1]" position="replace">
-        <h5>Powerful API</h5>
+    <xpath expr="//div[hasclass('row')]/div//h2[1]" position="replace">
+        <h2 class="h5-fs">Powerful API</h2>
         <div class="s_hr pt8 pb16" data-snippet="s_hr" data-name="Separator">
             <hr class="w-100 mx-auto" style="border-top-color: var(--o-color-3) !important;"/>
         </div>
@@ -184,8 +184,8 @@
     <xpath expr="//div[hasclass('row')]/div//p[1]" position="replace" mode="inner">
         Thanks to our API, Developers report building their solutions 4x faster. Discover why and how.
     </xpath>
-    <xpath expr="//div[hasclass('row')]/div[2]//h5[1]" position="replace">
-        <h5>Mobile Experience</h5>
+    <xpath expr="//div[hasclass('row')]/div[2]//h2[1]" position="replace">
+        <h2 class="h5-fs">Mobile Experience</h2>
         <div class="s_hr pt8 pb16" data-snippet="s_hr" data-name="Separator">
             <hr class="w-100 mx-auto" style="border-top-color: var(--o-color-3) !important;"/>
         </div>
@@ -193,8 +193,8 @@
     <xpath expr="//div[hasclass('row')]/div[2]//p[1]" position="replace" mode="inner">
         Probably the only CRM with a full mobile experience. Never wondered how it works? That's because it just works
     </xpath>
-    <xpath expr="//div[hasclass('row')]/div[3]//h5[1]" position="replace">
-        <h5>Support Team</h5>
+    <xpath expr="//div[hasclass('row')]/div[3]//h2[1]" position="replace">
+        <h2 class="h5-fs">Support Team</h2>
         <div class="s_hr pt8 pb16" data-snippet="s_hr" data-name="Separator">
             <hr class="w-100 mx-auto" style="border-top-color: var(--o-color-3) !important;"/>
         </div>
@@ -206,8 +206,8 @@
 
 <!-- ======== CALL TO ACTION ======== -->
 <template id="s_call_to_action" inherit_id="website.s_call_to_action" name="Graphene s_call_to_action">
-    <xpath expr="//h3" position="replace">
-        <h3 style="text-align: right;">50,000+ companies run our software.</h3>
+    <xpath expr="//h2" position="replace">
+        <h2 class="h3-fs" style="text-align: right;">50,000+ companies run our software.</h2>
     </xpath>
     <xpath expr="//div[hasclass('col-lg-9')]" position="attributes">
         <attribute name="class" add="col-lg-8" remove="col-lg-9" separator=" "/>
@@ -609,7 +609,7 @@
         <attribute name="src">/web/image/website.s_numbers_default_image</attribute>
     </xpath>
     <!-- Title -->
-    <xpath expr="//h3" position="replace" mode="inner">
+    <xpath expr="//h2" position="replace" mode="inner">
         Robotics &amp; Technology for Tomorrow
     </xpath>
     <!-- Paragraph 1 -->

--- a/theme_kea/views/snippets/s_card_offset.xml
+++ b/theme_kea/views/snippets/s_card_offset.xml
@@ -11,7 +11,7 @@
         <attribute name="src">/web/image/website.s_carousel_default_image_3</attribute>
     </xpath>
     <!-- Title -->
-    <xpath expr="//h3" position="replace" mode="inner">
+    <xpath expr="//h2" position="replace" mode="inner">
         Virtual Reality: Redefining Experience
     </xpath>
     <!-- Paragraph 1 -->

--- a/theme_kea/views/snippets/s_cards_grid.xml
+++ b/theme_kea/views/snippets/s_cards_grid.xml
@@ -10,32 +10,32 @@
         <div class="o_we_shape o_web_editor_Bold_01_001" style="background-image: url('/web_editor/shape/web_editor/Bold/01_001.svg?c5=o-color-2');"/>
     </xpath>
     <!-- Title -->
-    <xpath expr="//h3" position="replace" mode="inner">
+    <xpath expr="//h2" position="replace" mode="inner">
         Unlock a World of Possibilities
     </xpath>
     <!-- Card 1 -->
-    <xpath expr="(//h5)[1]" position="replace" mode="inner">
+    <xpath expr="(//h3)[1]" position="replace" mode="inner">
         Virtual Collaboration and Meetings
     </xpath>
     <xpath expr="(//p)[1]" position="replace" mode="inner">
         Redefine your remote work experience with our VR headsets. Conduct meetings, collaborate in virtual environments, and connect with colleagues from around the globe in a more engaging way.
     </xpath>
     <!-- Card 2 -->
-    <xpath expr="(//h5)[2]" position="replace" mode="inner">
+    <xpath expr="(//h3)[2]" position="replace" mode="inner">
         Elevate Your Gaming Experience
     </xpath>
     <xpath expr="(//p)[2]" position="replace" mode="inner">
         Transform your gameplay with our high-performance VR headsets. Feel the action, engage with realistic environments, and take your gaming to the next level with our state-of-the-art technology.
     </xpath>
     <!-- Card 3 -->
-    <xpath expr="(//h5)[3]" position="replace" mode="inner">
+    <xpath expr="(//h3)[3]" position="replace" mode="inner">
         Ultimate Comfort and Design
     </xpath>
     <xpath expr="(//p)[3]" position="replace" mode="inner">
         Enjoy extended VR sessions with headsets designed for maximum comfort. Lightweight, adjustable, and crafted to fit perfectly, our VR headsets let you stay immersed for longer.
     </xpath>
     <!-- Card 4 -->
-    <xpath expr="(//h5)[4]" position="replace" mode="inner">
+    <xpath expr="(//h3)[4]" position="replace" mode="inner">
         Explore Virtual Worlds
     </xpath>
     <xpath expr="(//p)[4]" position="replace" mode="inner">

--- a/theme_kea/views/snippets/s_three_columns.xml
+++ b/theme_kea/views/snippets/s_three_columns.xml
@@ -10,7 +10,7 @@
     <xpath expr="//figure" position="attributes">
         <attribute name="class" remove="ratio-16x9" add="ratio-1x1" separator=" "/>
     </xpath>
-    <xpath expr="//h5" position="replace" mode="inner">
+    <xpath expr="//h2" position="replace" mode="inner">
         Gaming
     </xpath>
     <xpath expr="//p" position="replace" mode="inner">
@@ -20,7 +20,7 @@
     <xpath expr="(//figure)[2]"  position="attributes">
         <attribute name="class" remove="ratio-16x9" add="ratio-1x1" separator=" "/>
     </xpath>
-    <xpath expr="(//h5)[2]" position="replace" mode="inner">
+    <xpath expr="(//h2)[2]" position="replace" mode="inner">
         Design
     </xpath>
     <xpath expr="(//p)[2]" position="replace" mode="inner">
@@ -30,7 +30,7 @@
     <xpath expr="(//figure)[3]"  position="attributes">
         <attribute name="class" remove="ratio-16x9" add="ratio-1x1" separator=" "/>
     </xpath>
-    <xpath expr="(//h5)[3]" position="replace" mode="inner">
+    <xpath expr="(//h2)[3]" position="replace" mode="inner">
         Training
     </xpath>
     <xpath expr="(//p)[3]" position="replace" mode="inner">

--- a/theme_kiddo/views/snippets/s_call_to_action.xml
+++ b/theme_kiddo/views/snippets/s_call_to_action.xml
@@ -16,7 +16,7 @@
     <!-- Paragraph -->
     <xpath expr="//div[hasclass('col-lg-9')]" position="replace">
         <div class="col-lg-10 offset-lg-1 pt48 pb24">
-            <h3 style="text-align: center;">2,000 parents<br/> brought their kid to our nursery.</h3>
+            <h2 class="h3-fs" style="text-align: center;">2,000 parents<br/> brought their kid to our nursery.</h2>
             <p style="text-align: center;">Entrust us with your children and go to work with peace of mind</p>
             <p><br/></p>
             <p style="text-align: center;"><a t-att-href="cta_btn_href" class="btn btn-primary btn-lg o_translate_inline"><t t-out="cta_btn_text">Contact us</t></a></p>

--- a/theme_kiddo/views/snippets/s_card_offset.xml
+++ b/theme_kiddo/views/snippets/s_card_offset.xml
@@ -11,7 +11,7 @@
         <attribute name="src">/web/image/website.s_carousel_default_image_3</attribute>
     </xpath>
     <!-- Title -->
-    <xpath expr="//h3" position="replace" mode="inner">
+    <xpath expr="//h2" position="replace" mode="inner">
         Toys That Spark Imagination
     </xpath>
     <!-- Paragraph 1 -->

--- a/theme_kiddo/views/snippets/s_cards_grid.xml
+++ b/theme_kiddo/views/snippets/s_cards_grid.xml
@@ -10,32 +10,32 @@
         <div class="o_we_shape o_web_editor_Floats_05 o_we_animated"/>
     </xpath>
     <!-- Title -->
-    <xpath expr="//h3" position="replace" mode="inner">
+    <xpath expr="//h2" position="replace" mode="inner">
         Caring for Your Child's Growth and Happiness
     </xpath>
     <!-- Card 1 -->
-    <xpath expr="(//h5)[1]" position="replace" mode="inner">
+    <xpath expr="(//h3)[1]" position="replace" mode="inner">
         Nurturing Early Learning
     </xpath>
     <xpath expr="(//p)[1]" position="replace" mode="inner">
         We provide a safe and engaging environment where children can explore, learn, and grow. Our programs are designed to foster creativity, curiosity, and a love for learning from an early age.
     </xpath>
     <!-- Card 2 -->
-    <xpath expr="(//h5)[2]" position="replace" mode="inner">
+    <xpath expr="(//h3)[2]" position="replace" mode="inner">
         Professional and Caring Staff
     </xpath>
     <xpath expr="(//p)[2]" position="replace" mode="inner">
         Our team of trained caregivers and educators is dedicated to providing personalized attention and care. We focus on creating a warm and supportive atmosphere where every child feels valued and understood.
     </xpath>
     <!-- Card 3 -->
-    <xpath expr="(//h5)[3]" position="replace" mode="inner">
+    <xpath expr="(//h3)[3]" position="replace" mode="inner">
         Fun and Educational Activities
     </xpath>
     <xpath expr="(//p)[3]" position="replace" mode="inner">
         We offer a range of activities that combine fun with learning, from creative arts and crafts to outdoor play and interactive storytelling, ensuring every child enjoys a balanced and enriching day.
     </xpath>
     <!-- Card 4 -->
-    <xpath expr="(//h5)[4]" position="replace" mode="inner">
+    <xpath expr="(//h3)[4]" position="replace" mode="inner">
         Safe and Secure Environment
     </xpath>
     <xpath expr="(//p)[4]" position="replace" mode="inner">

--- a/theme_kiddo/views/snippets/s_three_columns.xml
+++ b/theme_kiddo/views/snippets/s_three_columns.xml
@@ -19,15 +19,15 @@
         <attribute name="data-shape-colors">;o-color-1;;;</attribute>
     </xpath>
     <!-- Column n°1 - Title -->
-    <xpath expr="//h5" position="attributes">
+    <xpath expr="//h2" position="attributes">
         <attribute name="style">text-align: center;</attribute>
     </xpath>
-    <xpath expr="//h5" position="replace" mode="inner">
+    <xpath expr="//h2" position="replace" mode="inner">
         <br/>
         Our mission
     </xpath>
     <!-- Column n°1 - Add separator -->
-    <xpath expr="//h5" position="after">
+    <xpath expr="//h2" position="after">
         <div class="s_hr pb32 pt8" data-snippet="s_hr" data-name="Separator">
             <hr class="w-25 mx-auto" style="border-top: 5px dotted var(--o-color-2) !important;"/>
         </div>
@@ -56,15 +56,15 @@
         <attribute name="data-shape-colors">;o-color-3;;;</attribute>
     </xpath>
     <!-- Column n°2 - Title -->
-    <xpath expr="(//h5)[2]" position="attributes">
+    <xpath expr="(//h2)[2]" position="attributes">
         <attribute name="style">text-align: center;</attribute>
     </xpath>
-    <xpath expr="(//h5)[2]" position="replace" mode="inner">
+    <xpath expr="(//h2)[2]" position="replace" mode="inner">
         <br/>
         For every kid
     </xpath>
     <!-- Column n°2 - Add separator -->
-    <xpath expr="(//h5)[2]" position="after">
+    <xpath expr="(//h2)[2]" position="after">
         <div class="s_hr pb32 pt8" data-snippet="s_hr" data-name="Separator">
             <hr class="w-25 mx-auto" style="border-top: 5px dotted var(--o-color-1) !important;"/>
         </div>
@@ -93,15 +93,15 @@
         <attribute name="data-shape-colors">;;;;o-color-2</attribute>
     </xpath>
     <!-- Column n°3 - Title -->
-    <xpath expr="(//h5)[3]" position="attributes">
+    <xpath expr="(//h2)[3]" position="attributes">
         <attribute name="style">text-align: center;</attribute>
     </xpath>
-    <xpath expr="(//h5)[3]" position="replace" mode="inner">
+    <xpath expr="(//h2)[3]" position="replace" mode="inner">
         <br/>
         Open-door policy
     </xpath>
     <!-- Column n°3 - Add separator -->
-    <xpath expr="(//h5)[3]" position="after">
+    <xpath expr="(//h2)[3]" position="after">
         <div class="s_hr pb32 pt8" data-snippet="s_hr" data-name="Separator">
             <hr class="w-25 mx-auto" style="border-top: 5px dotted var(--o-color-2) !important;"/>
         </div>

--- a/theme_loftspace/views/snippets/s_call_to_action.xml
+++ b/theme_loftspace/views/snippets/s_call_to_action.xml
@@ -14,7 +14,7 @@
         <attribute name="class" add="col-lg-12" remove="col-lg-3" separator=" "/>
     </xpath>
     <!-- Title & paragraph -->
-    <xpath expr="//h3" position="replace" mode="inner">
+    <xpath expr="//h2" position="replace" mode="inner">
         Would you like more information <br/>about a product?
     </xpath>
     <xpath expr="//p" position="replace"/>

--- a/theme_loftspace/views/snippets/s_card_offset.xml
+++ b/theme_loftspace/views/snippets/s_card_offset.xml
@@ -15,7 +15,7 @@
         <attribute name="src">/web/image/website.s_carousel_default_image_3</attribute>
     </xpath>
     <!-- Title -->
-    <xpath expr="//h3" position="replace" mode="inner">
+    <xpath expr="//h2" position="replace" mode="inner">
         Elegant Furniture for Modern Living
     </xpath>
     <!-- Paragraph 1 -->

--- a/theme_loftspace/views/snippets/s_cards_grid.xml
+++ b/theme_loftspace/views/snippets/s_cards_grid.xml
@@ -3,32 +3,32 @@
 
 <template id="s_cards_grid" inherit_id="website.s_cards_grid">
     <!-- Title -->
-    <xpath expr="//h3" position="replace" mode="inner">
+    <xpath expr="//h2" position="replace" mode="inner">
         Tailored Furniture
     </xpath>
     <!-- Card 1 -->
-    <xpath expr="(//h5)[1]" position="replace" mode="inner">
+    <xpath expr="(//h3)[1]" position="replace" mode="inner">
         Custom-Designed Furniture
     </xpath>
     <xpath expr="(//p)[1]" position="replace" mode="inner">
         Transform your living space with bespoke furniture pieces, crafted to reflect your unique style and fit perfectly in any room.
     </xpath>
     <!-- Card 2 -->
-    <xpath expr="(//h5)[2]" position="replace" mode="inner">
+    <xpath expr="(//h3)[2]" position="replace" mode="inner">
         Personalized Interior Solutions
     </xpath>
     <xpath expr="(//p)[2]" position="replace" mode="inner">
         Our expert designers collaborate with you to create furniture that meets your exact needs, ensuring every piece complements your home's aesthetic.
     </xpath>
     <!-- Card 3 -->
-    <xpath expr="(//h5)[3]" position="replace" mode="inner">
+    <xpath expr="(//h3)[3]" position="replace" mode="inner">
         Handcrafted Quality and Comfort
     </xpath>
     <xpath expr="(//p)[3]" position="replace" mode="inner">
         Experience the ultimate in comfort and durability with our handmade furniture, meticulously crafted from premium materials for a timeless appeal.
     </xpath>
     <!-- Card 4 -->
-    <xpath expr="(//h5)[4]" position="replace" mode="inner">
+    <xpath expr="(//h3)[4]" position="replace" mode="inner">
         Exclusive Collections
     </xpath>
     <xpath expr="(//p)[4]" position="replace" mode="inner">

--- a/theme_loftspace/views/snippets/s_faq_collapse.xml
+++ b/theme_loftspace/views/snippets/s_faq_collapse.xml
@@ -7,8 +7,8 @@
         <attribute name="class" add="o_cc o_cc2" separator=" "/>
     </xpath>
     <!-- Title -->
-    <xpath expr="//h3" position="replace">
-        <h2>Frequently asked question</h2>
+    <xpath expr="//h2" position="replace" mode="inner">
+        Frequently asked question
     </xpath>
     <xpath expr="//p" position="replace"/>
 </template>

--- a/theme_loftspace/views/snippets/s_features.xml
+++ b/theme_loftspace/views/snippets/s_features.xml
@@ -6,7 +6,7 @@
     <xpath expr="//section" position="attributes">
         <attribute name="class" add="pt72 pb128" remove="pt64 pb64" separator=" "/>
     </xpath>
-    <xpath expr="//div[hasclass('container')]/h3" position="replace" mode="inner">
+    <xpath expr="//div[hasclass('container')]/h2" position="replace" mode="inner">
         Customer benefits
     </xpath>
     <xpath expr="//div[hasclass('container')]/p" position="replace" mode="inner">

--- a/theme_loftspace/views/snippets/s_three_columns.xml
+++ b/theme_loftspace/views/snippets/s_three_columns.xml
@@ -11,7 +11,7 @@
         <attribute name="style">box-shadow: 0px 2px 10px 0px rgba(0, 0, 0, 0.05) !important;</attribute>
     </xpath>
     <!-- Column #1 - Title -->
-    <xpath expr="//div[hasclass('card-body')]//h5" position="replace" mode="inner">
+    <xpath expr="//div[hasclass('card-body')]//h2" position="replace" mode="inner">
         Unique Items
     </xpath>
     <!-- Column #1 - Paragraph -->
@@ -23,7 +23,7 @@
         <attribute name="style">box-shadow: 0px 2px 10px 0px rgba(0, 0, 0, 0.05) !important;</attribute>
     </xpath>
     <!-- Column #2 - Title -->
-    <xpath expr="(//div[hasclass('card-body')])[2]//h5" position="replace" mode="inner">
+    <xpath expr="(//div[hasclass('card-body')])[2]//h2" position="replace" mode="inner">
         Tailored advice
     </xpath>
     <!-- Column #2 - Paragraph -->
@@ -35,7 +35,7 @@
         <attribute name="style">box-shadow: 0px 2px 10px 0px rgba(0, 0, 0, 0.05) !important;</attribute>
     </xpath>
     <!-- Column #3 - Title -->
-    <xpath expr="(//div[hasclass('card-body')])[3]//h5" position="replace" mode="inner">
+    <xpath expr="(//div[hasclass('card-body')])[3]//h2" position="replace" mode="inner">
         For the whole Family
     </xpath>
     <!-- Column #3 - Paragraph -->

--- a/theme_monglia/views/customizations.xml
+++ b/theme_monglia/views/customizations.xml
@@ -327,8 +327,8 @@
     <xpath expr="//section" position="attributes">
         <attribute name="class" add="o_cc4" remove="o_cc5" separator=" "/>
     </xpath>
-    <xpath expr="//h3" position="replace">
-        <h3 style="text-align: left;"><b>APPLY FOR OUR V.I.P. CARD</b></h3>
+    <xpath expr="//h2" position="replace">
+        <h2 class="h3-fs" style="text-align: left;"><b>APPLY FOR OUR V.I.P. CARD</b></h2>
     </xpath>
     <xpath expr="//p" position="replace">
         <p style="text-align: left;">The vip card allows you to benefit from tickets before everyone else.</p>
@@ -377,13 +377,13 @@
     <xpath expr="//section" position="attributes">
         <attribute name="class" add="pb0 o_cc5" remove="pb32 o_cc2" separator=" "/>
     </xpath>
-    <xpath expr="//h5" position="replace" mode="inner">
+    <xpath expr="//h2" position="replace" mode="inner">
         Wilson Holt
     </xpath>
-    <xpath expr="(//h5)[2]" position="replace" mode="inner">
+    <xpath expr="(//h2)[2]" position="replace" mode="inner">
         Theia Hayward
     </xpath>
-    <xpath expr="(//h5)[3]" position="replace" mode="inner">
+    <xpath expr="(//h2)[3]" position="replace" mode="inner">
         Bruce Porter
     </xpath>
 </template>
@@ -816,7 +816,7 @@
         <attribute name="src">/web/image/website.s_carousel_default_image_3</attribute>
     </xpath>
     <!-- Title -->
-    <xpath expr="//h3" position="replace" mode="inner">
+    <xpath expr="//h2" position="replace" mode="inner">
         Unforgettable Events &amp; Entertainment
     </xpath>
     <!-- Paragraph 1 -->
@@ -832,32 +832,32 @@
 <!-- ======== CARDS GRID ======== -->
 <template id="s_cards_grid" inherit_id="website.s_cards_grid">
     <!-- Title -->
-    <xpath expr="//h3" position="replace" mode="inner">
+    <xpath expr="//h2" position="replace" mode="inner">
         Exquisite Cocktails to Elevate Your Experience
     </xpath>
     <!-- Card 1 -->
-    <xpath expr="(//h5)[1]" position="replace" mode="inner">
+    <xpath expr="(//h3)[1]" position="replace" mode="inner">
         Berry Bliss Sangria
     </xpath>
     <xpath expr="(//p)[1]" position="replace" mode="inner">
         A delightful mix of red wine, fresh berries, orange juice, and a hint of brandy, served chilled for a refreshing, fruity experience with every sip.
     </xpath>
     <!-- Card 2 -->
-    <xpath expr="(//h5)[2]" position="replace" mode="inner">
+    <xpath expr="(//h3)[2]" position="replace" mode="inner">
         Tropical Mojito
     </xpath>
     <xpath expr="(//p)[2]" position="replace" mode="inner">
         A refreshing mix of white rum, fresh mint, lime juice, and a splash of soda, perfect for a vibrant, tropical flavor that dances on the palate.
     </xpath>
     <!-- Card 3 -->
-    <xpath expr="(//h5)[3]" position="replace" mode="inner">
+    <xpath expr="(//h3)[3]" position="replace" mode="inner">
         Spicy Margarita
     </xpath>
     <xpath expr="(//p)[3]" position="replace" mode="inner">
         A zesty blend of tequila, lime juice, and a hint of jalapeño, balanced with a touch of agave syrup for a fiery twist on a classic favorite.
     </xpath>
     <!-- Card 4 -->
-    <xpath expr="(//h5)[4]" position="replace" mode="inner">
+    <xpath expr="(//h3)[4]" position="replace" mode="inner">
         Smoky Old Fashioned
     </xpath>
     <xpath expr="(//p)[4]" position="replace" mode="inner">
@@ -1022,11 +1022,11 @@
     <xpath expr="//div[hasclass('col-lg-7')]" position="attributes">
         <attribute name="class" add="col-lg-8 offset-lg-2" remove="col-lg-7 offset-lg-1" separator=" "/>
     </xpath>
-    <xpath expr="//h3" position="attributes">
+    <xpath expr="//h2" position="attributes">
         <attribute name="style" add="text-align: center;" separator=";"/>
     </xpath>
-    <xpath expr="//h3" position="replace">
-        <h2 style="text-align: center;">Frequently Asked Questions</h2>
+    <xpath expr="//h2" position="replace" mode="inner">
+        Frequently Asked Questions
     </xpath>
     <xpath expr="//p" position="attributes">
         <attribute name="style" add="text-align: center;" separator=";"/>

--- a/theme_nano/views/snippets/s_card_offset.xml
+++ b/theme_nano/views/snippets/s_card_offset.xml
@@ -15,7 +15,7 @@
         <attribute name="src">/web/image/website.library_image_03</attribute>
     </xpath>
     <!-- Title -->
-    <xpath expr="//h3" position="replace" mode="inner">
+    <xpath expr="//h2" position="replace" mode="inner">
         Creativity Meets Cutting-Edge Technology
     </xpath>
     <!-- Paragraph 1 -->

--- a/theme_nano/views/snippets/s_company_team_basic.xml
+++ b/theme_nano/views/snippets/s_company_team_basic.xml
@@ -6,8 +6,8 @@
     <xpath expr="//section" position="attributes">
         <attribute name="class" add="o_cc5" remove="o_cc1" separator=" "/>
     </xpath>
-    <xpath expr="//h3" position="replace">
-        <h2 style="text-align: center;">Our talented crew</h2>
+    <xpath expr="//h2" position="replace" mode="inner">
+        Our talented crew
     </xpath>
     <xpath expr="//h2" position="after">
         <p class="lead" style="text-align: center;">Meet the masterminds behind our agency. With them, your project is in good hands for sure.</p>
@@ -20,7 +20,7 @@
     <xpath expr="(//img)[1]" position="attributes">
         <attribute name="class" add="rounded" remove="rounded-circle" separator=" "/>
     </xpath>
-    <xpath expr="(//h4)[1]" position="replace" mode="inner">
+    <xpath expr="(//h3)[1]" position="replace" mode="inner">
         Evan Ray
     </xpath>
     <xpath expr="(//p[hasclass('o_small-fs')])[1]" position="replace" mode="inner">
@@ -33,7 +33,7 @@
     <xpath expr="(//img)[2]" position="attributes">
         <attribute name="class" add="rounded" remove="rounded-circle" separator=" "/>
     </xpath>
-    <xpath expr="(//h4)[2]" position="replace" mode="inner">
+    <xpath expr="(//h3)[2]" position="replace" mode="inner">
         Ben Cole
     </xpath>
     <xpath expr="(//p[hasclass('o_small-fs')])[2]" position="replace" mode="inner">
@@ -46,7 +46,7 @@
     <xpath expr="(//img)[3]" position="attributes">
         <attribute name="class" add="rounded" remove="rounded-circle" separator=" "/>
     </xpath>
-    <xpath expr="(//h4)[3]" position="replace" mode="inner">
+    <xpath expr="(//h3)[3]" position="replace" mode="inner">
         Jane Ford
     </xpath>
     <xpath expr="(//p[hasclass('o_small-fs')])[3]" position="replace" mode="inner">
@@ -59,7 +59,7 @@
     <xpath expr="(//img)[4]" position="attributes">
         <attribute name="class" add="rounded" remove="rounded-circle" separator=" "/>
     </xpath>
-    <xpath expr="(//h4)[4]" position="replace" mode="inner">
+    <xpath expr="(//h3)[4]" position="replace" mode="inner">
         Mia Lee
     </xpath>
     <xpath expr="(//p[hasclass('o_small-fs')])[4]" position="replace" mode="inner">

--- a/theme_notes/views/snippets/s_call_to_action.xml
+++ b/theme_notes/views/snippets/s_call_to_action.xml
@@ -12,8 +12,8 @@
         <div class="o_we_bg_filter bg-black-50"/>
     </xpath>
     <!-- Title -->
-    <xpath expr="//h3" position="replace">
-        <h2>Live the Miraillet <br/>Festival experience</h2>
+    <xpath expr="//h2" position="replace" mode="inner">
+        Live the Miraillet <br/>Festival experience
     </xpath>
     <!-- Paragraph -->
     <xpath expr="//p" position="replace" mode="inner">

--- a/theme_notes/views/snippets/s_card_offset.xml
+++ b/theme_notes/views/snippets/s_card_offset.xml
@@ -11,7 +11,7 @@
         <attribute name="src">/web/image/website.s_carousel_default_image_3</attribute>
     </xpath>
     <!-- Title -->
-    <xpath expr="//h3" position="replace" mode="inner">
+    <xpath expr="//h2" position="replace" mode="inner">
         Music That Moves You
     </xpath>
     <!-- Paragraph 1 -->

--- a/theme_notes/views/snippets/s_cards_grid.xml
+++ b/theme_notes/views/snippets/s_cards_grid.xml
@@ -7,7 +7,7 @@
             <attribute name="class" add="o_cc5" remove="o_cc2" separator=" "/>
         </xpath>
         <!-- Title -->
-        <xpath expr="//h3" position="replace" mode="inner">
+        <xpath expr="//h2" position="replace" mode="inner">
             Experience the Best of Our Festival
         </xpath>
         <!-- Card 1 -->
@@ -15,7 +15,7 @@
             <attribute name="class" add="border" separator=" "/>
             <attribute name="style" add="border-width: 0px !important;" separator=";"/>
         </xpath>
-        <xpath expr="(//h5)[1]" position="replace" mode="inner">
+        <xpath expr="(//h3)[1]" position="replace" mode="inner">
             Engaging Social Activities
         </xpath>
         <xpath expr="(//p)[1]" position="replace" mode="inner">
@@ -26,7 +26,7 @@
             <attribute name="class" add="border" separator=" "/>
             <attribute name="style" add="border-width: 0px !important;" separator=";"/>
         </xpath>
-        <xpath expr="(//h5)[2]" position="replace" mode="inner">
+        <xpath expr="(//h3)[2]" position="replace" mode="inner">
             Incredible Lineup of Artists
         </xpath>
         <xpath expr="(//p)[2]" position="replace" mode="inner">
@@ -37,7 +37,7 @@
             <attribute name="class" add="border" separator=" "/>
             <attribute name="style" add="border-width: 0px !important;" separator=";"/>
         </xpath>
-        <xpath expr="(//h5)[3]" position="replace" mode="inner">
+        <xpath expr="(//h3)[3]" position="replace" mode="inner">
             Exclusive Festival Merchandise
         </xpath>
         <xpath expr="(//p)[3]" position="replace" mode="inner">
@@ -48,7 +48,7 @@
             <attribute name="class" add="border" separator=" "/>
             <attribute name="style" add="border-width: 0px !important;" separator=";"/>
         </xpath>
-        <xpath expr="(//h5)[4]" position="replace" mode="inner">
+        <xpath expr="(//h3)[4]" position="replace" mode="inner">
             High-Quality Music Experience
         </xpath>
         <xpath expr="(//p)[4]" position="replace" mode="inner">

--- a/theme_notes/views/snippets/s_company_team.xml
+++ b/theme_notes/views/snippets/s_company_team.xml
@@ -7,7 +7,7 @@
         <attribute name="class" add="o_cc o_cc2 pb128" remove="pb48" separator=" "/>
     </xpath>
     <!-- Member #1 -->
-    <xpath expr="//div[hasclass('col-lg-9')]//h4" position="replace" mode="inner">
+    <xpath expr="//div[hasclass('col-lg-9')]//h3" position="replace" mode="inner">
         Tony
     </xpath>
     <xpath expr="//div[hasclass('col-lg-9')]//p" position="replace" mode="inner"/>
@@ -15,7 +15,7 @@
         Tony is praised for the quality of his flow and beats but often criticised because of the controversial nature of his lyrics. He has also established a label, and developed a line of jewellery.
     </xpath>
     <!-- Member #2 -->
-    <xpath expr="(//div[hasclass('col-lg-9')])[2]//h4" position="replace" mode="inner">
+    <xpath expr="(//div[hasclass('col-lg-9')])[2]//h3" position="replace" mode="inner">
         Aline
     </xpath>
     <xpath expr="(//div[hasclass('col-lg-9')])[2]//p" position="replace" mode="inner"/>
@@ -23,7 +23,7 @@
         Aline is a French singer, songwriter and producer. In 2016, she was ranked as the most powerful and influential French person by Vanity Fair, who noticed her radiance of French genius.
     </xpath>
     <!-- Member #3 -->
-    <xpath expr="(//div[hasclass('col-lg-9')])[3]//h4" position="replace" mode="inner">
+    <xpath expr="(//div[hasclass('col-lg-9')])[3]//h3" position="replace" mode="inner">
         Mich Starck
     </xpath>
     <xpath expr="(//div[hasclass('col-lg-9')])[3]//p" position="replace" mode="inner"/>
@@ -31,7 +31,7 @@
         Mich Starck is a French DJ, record producer and songwriter. He has sold over nine million albums and thirty million singles worldwide. In 2011, he was voted as the number one DJ in the DJ Mag Top 100 DJs poll.
     </xpath>
     <!-- Member #4 -->
-    <xpath expr="(//div[hasclass('col-lg-9')])[4]//h4" position="replace" mode="inner">
+    <xpath expr="(//div[hasclass('col-lg-9')])[4]//h3" position="replace" mode="inner">
         Joseris
     </xpath>
     <xpath expr="(//div[hasclass('col-lg-9')])[4]//p" position="replace" mode="inner"/>

--- a/theme_notes/views/snippets/s_company_team_basic.xml
+++ b/theme_notes/views/snippets/s_company_team_basic.xml
@@ -2,11 +2,11 @@
 <odoo>
 
 <template id="s_company_team_basic" inherit_id="website.s_company_team_basic">
-    <xpath expr="//h3" position="replace" mode="inner">
+    <xpath expr="//h2" position="replace" mode="inner">
         Discover our talented artists
     </xpath>
     <!-- Team #01 - Title -->
-    <xpath expr="//h4" position="replace" mode="inner">
+    <xpath expr="//h3" position="replace" mode="inner">
         Tony
     </xpath>
     <!-- Team #01 - Work Description -->
@@ -15,7 +15,7 @@
     </xpath>
 
     <!-- Team #02 - Title -->
-    <xpath expr="(//h4)[2]" position="replace" mode="inner">
+    <xpath expr="(//h3)[2]" position="replace" mode="inner">
         Mich
     </xpath>
     <!-- Team #02 - Work Description -->
@@ -24,7 +24,7 @@
     </xpath>
 
     <!-- Team #03 - Title -->
-    <xpath expr="(//h4)[3]" position="replace" mode="inner">
+    <xpath expr="(//h3)[3]" position="replace" mode="inner">
         Aline
     </xpath>
     <!-- Team #03 - Work Description -->
@@ -33,7 +33,7 @@
     </xpath>
 
     <!-- Team #04 - Title -->
-    <xpath expr="(//h4)[4]" position="replace" mode="inner">
+    <xpath expr="(//h3)[4]" position="replace" mode="inner">
         Iris
     </xpath>
     <!-- Team #04 - Work Description -->

--- a/theme_notes/views/snippets/s_masonry_block.xml
+++ b/theme_notes/views/snippets/s_masonry_block.xml
@@ -4,7 +4,7 @@
 <template id="s_masonry_block_default_template" inherit_id="website.s_masonry_block_default_template">
     <!-- Little block #01 -->
     <!-- Title -->
-    <xpath expr="//div[hasclass('col-lg-4')]/h3" position="replace" mode="inner">
+    <xpath expr="//div[hasclass('col-lg-4')]/h2" position="replace" mode="inner">
         Brussels
     </xpath>
     <!-- Paragraph -->
@@ -14,7 +14,7 @@
 
     <!-- Little block #02 -->
     <!-- Title -->
-    <xpath expr="//div[hasclass('col-lg-4')][2]/h3" position="replace" mode="inner">
+    <xpath expr="//div[hasclass('col-lg-4')][2]/h2" position="replace" mode="inner">
         Paris
     </xpath>
     <!-- Paragraph -->
@@ -24,7 +24,7 @@
 
     <!-- Little block #03 -->
     <!-- Title -->
-    <xpath expr="//div[hasclass('col-lg-3')]/h3" position="replace" mode="inner">
+    <xpath expr="//div[hasclass('col-lg-3')]/h2" position="replace" mode="inner">
         Barcelona
     </xpath>
     <!-- Paragraph -->
@@ -34,7 +34,7 @@
 
     <!-- Little block #04 -->
     <!-- Title -->
-    <xpath expr="//div[hasclass('col-lg-3')][2]/h3" position="replace" mode="inner">
+    <xpath expr="//div[hasclass('col-lg-3')][2]/h2" position="replace" mode="inner">
         Amsterdam
     </xpath>
     <!-- Paragraph -->

--- a/theme_notes/views/snippets/s_three_columns.xml
+++ b/theme_notes/views/snippets/s_three_columns.xml
@@ -21,8 +21,8 @@
     <xpath expr="//div[hasclass('s_card')]" position="attributes">
         <attribute name="style" add="border-width: 0px !important;" separator=";"/>
     </xpath>
-    <xpath expr="//div[hasclass('s_card')]//h5" position="replace">
-        <h4 class="card-title">Belgium Tour</h4>
+    <xpath expr="//div[hasclass('s_card')]//h2" position="replace">
+        <h2 class="card-title h4-fs">Belgium Tour</h2>
     </xpath>
     <xpath expr="//div[hasclass('s_card')]//p" position="replace">
         <p class="o_small_fs">24th AUGUST</p>
@@ -41,8 +41,8 @@
     <xpath expr="(//div[hasclass('s_card')])[2]//img" position="attributes">
         <attribute name="src">/web/image/website.s_carousel_default_image_2</attribute>
     </xpath>
-    <xpath expr="(//div[hasclass('s_card')])[2]//h5" position="replace">
-        <h4 class="card-title">Barcelona Night</h4>
+    <xpath expr="(//div[hasclass('s_card')])[2]//h2" position="replace">
+        <h2 class="card-title h4-fs">Barcelona Night</h2>
     </xpath>
     <xpath expr="(//div[hasclass('s_card')])[2]//p" position="replace">
         <p class="o_small_fs">27th AUGUST</p>
@@ -58,8 +58,8 @@
     <xpath expr="(//div[hasclass('s_card')])[3]" position="attributes">
         <attribute name="style" add="border-width: 0px !important;" separator=";"/>
     </xpath>
-    <xpath expr="(//div[hasclass('s_card')])[3]//h5" position="replace">
-        <h4 class="card-title">Amsterdam Tour</h4>
+    <xpath expr="(//div[hasclass('s_card')])[3]//h2" position="replace">
+        <h2 class="card-title h4-fs">Amsterdam Tour</h2>
     </xpath>
     <xpath expr="(//div[hasclass('s_card')])[3]//p" position="replace">
         <p class="o_small_fs">9th SEPTEMBER</p>

--- a/theme_odoo_experts/views/snippets/s_call_to_action.xml
+++ b/theme_odoo_experts/views/snippets/s_call_to_action.xml
@@ -18,8 +18,8 @@
         <attribute name="class" add="col-lg-12" remove="col-lg-3" separator=" "/>
     </xpath>
     <!-- Title & Paragraph -->
-    <xpath expr="//h3" position="replace">
-        <h3 style="text-align: center;">50,000+ clients trust us <br/>to protect their assets</h3>
+    <xpath expr="//h2" position="replace" mode="inner">
+        <h2 class="h3-fs" style="text-align: center;">50,000+ clients trust us <br/>to protect their assets</h2>
     </xpath>
     <xpath expr="//p" position="replace">
         <p style="text-align: center;">Contact us for a personalized meeting</p>

--- a/theme_odoo_experts/views/snippets/s_card_offset.xml
+++ b/theme_odoo_experts/views/snippets/s_card_offset.xml
@@ -11,7 +11,7 @@
         <attribute name="src">/web/image/website.s_carousel_default_image_3</attribute>
     </xpath>
     <!-- Title -->
-    <xpath expr="//h3" position="replace" mode="inner">
+    <xpath expr="//h2" position="replace" mode="inner">
         Strategic Business &amp; IT Advisory
     </xpath>
     <!-- Paragraph 1 -->

--- a/theme_odoo_experts/views/snippets/s_numbers_list.xml
+++ b/theme_odoo_experts/views/snippets/s_numbers_list.xml
@@ -6,12 +6,12 @@
         <attribute name="class" add="col-lg-6" remove="col-lg-5" separator=" "/>
     </xpath>
     <!-- Title -->
-    <xpath expr="//h3" position="replace">
+    <xpath expr="//h2" position="replace">
         <p class="o_small">SOME NUMBERS</p>
     </xpath>
     <!-- Paragraph -->
     <xpath expr="//p" position="replace">
-        <h3>Over the last decade, we've help many businesses to grow.</h3>
+        <h2 class="h3-fs">Over the last decade, we've help many businesses to grow.</h2>
     </xpath>
     <!-- KPI's -->
     <xpath expr="//div[hasclass('col-lg-3')]" position="replace">

--- a/theme_odoo_experts/views/snippets/s_showcase.xml
+++ b/theme_odoo_experts/views/snippets/s_showcase.xml
@@ -18,7 +18,7 @@
         <div class="col-12 pt8 pb8" data-name="Feature">
             <i class="s_showcase_icon fa fa-check me-auto rounded-circle float-start bg-o-color-3" role="img"/>
             <div class="d-flex flex-column">
-                <h5 class="s_showcase_title">Strategic Planning</h5>
+                <h3 class="s_showcase_title h5-fs">Strategic Planning</h3>
                 <p>Aligning your business objectives with forward-thinking strategies for long-term success.</p>
             </div>
         </div>
@@ -27,7 +27,7 @@
         <div class="col-12 pt8 pb8" data-name="Feature">
             <i class="s_showcase_icon fa fa-check me-auto rounded-circle float-start bg-o-color-3" role="img"/>
             <div class="d-flex flex-column">
-                <h5 class="s_showcase_title">Financial Consulting</h5>
+                <h3 class="s_showcase_title h5-fs">Financial Consulting</h3>
                 <p>Providing expert guidance to optimize your financial resources and maximize profitability.</p>
             </div>
         </div>
@@ -36,7 +36,7 @@
         <div class="col-12 pt8 pb8" data-name="Feature">
             <i class="s_showcase_icon fa fa-check me-auto rounded-circle float-start bg-o-color-3" role="img"/>
             <div class="d-flex flex-column">
-                <h5 class="s_showcase_title">Market Analysis</h5>
+                <h3 class="s_showcase_title h5-fs">Market Analysis</h3>
                 <p>Delivering in-depth insights and market trends to keep you ahead of the competition.</p>
             </div>
         </div>

--- a/theme_orchid/views/snippets/s_call_to_action.xml
+++ b/theme_orchid/views/snippets/s_call_to_action.xml
@@ -7,7 +7,7 @@
         <attribute name="class" add="pb88 pt88" remove="pb64 pt64" separator=" "/>
     </xpath>
     <!-- Title & paragraph -->
-    <xpath expr="//h3" position="replace" mode="inner">
+    <xpath expr="//h2" position="replace" mode="inner">
         There are always flowers <br/>for those who want to see them.
     </xpath>
     <xpath expr="//p" position="replace"/>

--- a/theme_orchid/views/snippets/s_card_offset.xml
+++ b/theme_orchid/views/snippets/s_card_offset.xml
@@ -11,7 +11,7 @@
         <attribute name="src">/web/image/website.s_carousel_default_image_3</attribute>
     </xpath>
     <!-- Title -->
-    <xpath expr="//h3" position="replace" mode="inner">
+    <xpath expr="//h2" position="replace" mode="inner">
         Bringing Nature to Your Doorstep
     </xpath>
     <!-- Paragraph 1 -->

--- a/theme_orchid/views/snippets/s_cards_grid.xml
+++ b/theme_orchid/views/snippets/s_cards_grid.xml
@@ -3,32 +3,32 @@
 
     <template id="s_cards_grid" inherit_id="website.s_cards_grid">
         <!-- Title -->
-        <xpath expr="//h3" position="replace" mode="inner">
+        <xpath expr="//h2" position="replace" mode="inner">
             Blooming with Quality and Care
         </xpath>
         <!-- Card 1 -->
-        <xpath expr="(//h5)[1]" position="replace" mode="inner">
+        <xpath expr="(//h3)[1]" position="replace" mode="inner">
             Freshness Like a Rose
         </xpath>
         <xpath expr="(//p)[1]" position="replace" mode="inner">
             Just like a rose stands out for its timeless beauty, our commitment to freshness ensures that every arrangement leaves a lasting impression.
         </xpath>
         <!-- Card 2 -->
-        <xpath expr="(//h5)[2]" position="replace" mode="inner">
+        <xpath expr="(//h3)[2]" position="replace" mode="inner">
             Creativity Like a Wildflower
         </xpath>
         <xpath expr="(//p)[2]" position="replace" mode="inner">
             Our designs are as unique and diverse as a field of wildflowers, bringing creativity and flair to every bouquet we create.
         </xpath>
         <!-- Card 3 -->
-        <xpath expr="(//h5)[3]" position="replace" mode="inner">
+        <xpath expr="(//h3)[3]" position="replace" mode="inner">
             Reliability Like a Sunflower
         </xpath>
         <xpath expr="(//p)[3]" position="replace" mode="inner">
             Just as sunflowers always turn towards the sun, we are dedicated to providing reliable service that meets your floral needs, every time.
         </xpath>
         <!-- Card 4 -->
-        <xpath expr="(//h5)[4]" position="replace" mode="inner">
+        <xpath expr="(//h3)[4]" position="replace" mode="inner">
             Elegance Like an Orchid
         </xpath>
         <xpath expr="(//p)[4]" position="replace" mode="inner">

--- a/theme_orchid/views/snippets/s_company_team_basic.xml
+++ b/theme_orchid/views/snippets/s_company_team_basic.xml
@@ -5,33 +5,33 @@
     <xpath expr="//section" position="attributes">
         <attribute name="class" add="o_cc2" remove="o_cc1" separator=" "/>
     </xpath>
-    <xpath expr="//h3" position="replace">
-        <h2 style="text-align: center">Meet the Team</h2>
+    <xpath expr="//h2" position="replace" mode="inner">
+        Meet the Team
     </xpath>
 
     <!-- Person 1 -->
-    <xpath expr="//h4" position="replace" mode="inner">
+    <xpath expr="//h3" position="replace" mode="inner">
         Tony Fred, Floral Director
     </xpath>
     <xpath expr="//p[2]" position="replace" mode="inner">
         Tony leads the creative vision for the shop.
     </xpath>
     <!-- Person 2 -->
-    <xpath expr="(//h4)[2]" position="replace" mode="inner">
+    <xpath expr="(//h3)[2]" position="replace" mode="inner">
         Mich Stark, Operations Manager
     </xpath>
     <xpath expr="(//p[hasclass('o_small-fs')])[2]" position="replace" mode="inner">
         Mich makes sure everything runs smoothly.
     </xpath>
     <!-- Person 3 -->
-    <xpath expr="(//h4)[3]" position="replace" mode="inner">
+    <xpath expr="(//h3)[3]" position="replace" mode="inner">
         Aline Turner, Bouquet Designer
     </xpath>
     <xpath expr="(//p[hasclass('o_small-fs')])[3]" position="replace" mode="inner">
         Aline is the mastermind behind our bespoke floral arrangements.
     </xpath>
     <!-- Person 4 -->
-    <xpath expr="(//h4)[4]" position="replace" mode="inner">
+    <xpath expr="(//h3)[4]" position="replace" mode="inner">
         Iris Joe, Customer Relations
     </xpath>
     <xpath expr="(//p[hasclass('o_small-fs')])[4]" position="replace" mode="inner">

--- a/theme_orchid/views/snippets/s_three_columns.xml
+++ b/theme_orchid/views/snippets/s_three_columns.xml
@@ -12,7 +12,7 @@
         <attribute name="style" add="--card-img-ratio-align: 20%;" separator=";"/>
     </xpath>
     <!-- Column 1 - Title -->
-    <xpath expr="//h5" position="replace" mode="inner">
+    <xpath expr="//h2" position="replace" mode="inner">
         Local Producers
     </xpath>
     <!-- Column 1 - Paragraph -->
@@ -29,7 +29,7 @@
         <attribute name="style" add="--card-img-ratio-align: 20%;" separator=";"/>
     </xpath>
     <!-- Column 2 - Title -->
-    <xpath expr="(//h5)[2]" position="replace" mode="inner">
+    <xpath expr="(//h2)[2]" position="replace" mode="inner">
         Bio Flowers
     </xpath>
     <!-- Column 2 - Paragraph -->
@@ -46,7 +46,7 @@
         <attribute name="style" add="--card-img-ratio-align: 20%;" separator=";"/>
     </xpath>
     <!-- Column 3 - Title -->
-    <xpath expr="(//h5)[3]" position="replace" mode="inner">
+    <xpath expr="(//h2)[3]" position="replace" mode="inner">
         Eco-Friendly Packaging
     </xpath>
     <!-- Column 3 - Paragraph -->

--- a/theme_paptic/views/customizations.xml
+++ b/theme_paptic/views/customizations.xml
@@ -206,7 +206,7 @@
         <attribute name="style" add="border-width: 0px !important;" separator=";"/>
     </xpath>
     <!-- Card #1 - Title & text -->
-    <xpath expr="//h5[hasclass('card-title')]" position="replace" mode="inner">
+    <xpath expr="//h2[hasclass('card-title')]" position="replace" mode="inner">
         HeyNosf Inc. Digital Transformation
     </xpath>
     <xpath expr="//p[hasclass('card-text')]" position="replace" mode="inner">
@@ -225,7 +225,7 @@
         <attribute name="style" add="border-width: 0px !important;" separator=";"/>
     </xpath>
     <!-- Card #2 - Title & text -->
-    <xpath expr="(//h5[hasclass('card-title')])[2]" position="replace" mode="inner">
+    <xpath expr="(//h2[hasclass('card-title')])[2]" position="replace" mode="inner">
         Fallanzy Integration Explained
     </xpath>
     <xpath expr="(//p[hasclass('card-text')])[2]" position="replace" mode="inner">
@@ -244,7 +244,7 @@
         <attribute name="style" add="border-width: 0px !important;" separator=";"/>
     </xpath>
     <!-- Card #3 - Title & text -->
-    <xpath expr="(//h5[hasclass('card-title')])[3]" position="replace" mode="inner">
+    <xpath expr="(//h2[hasclass('card-title')])[3]" position="replace" mode="inner">
         Hotels Improvement Study
     </xpath>
     <xpath expr="(//p[hasclass('card-text')])[3]" position="replace" mode="inner">
@@ -287,7 +287,7 @@
         <attribute name="class" add="pt120 pb120 o_cc1" remove="pt64 pb64 o_cc5" separator=" "/>
     </xpath>
     <!-- Title -->
-    <xpath expr="//h3" position="replace" mode="inner">
+    <xpath expr="//h2" position="replace" mode="inner">
         50,000+ companies run Paptic to grow their businesses.
     </xpath>
 </template>
@@ -650,7 +650,7 @@
         <attribute name="src">/web/image/website.s_carousel_default_image_3</attribute>
     </xpath>
     <!-- Title -->
-    <xpath expr="//h3" position="replace" mode="inner">
+    <xpath expr="//h2" position="replace" mode="inner">
         Expert Consultancy in Tech &amp; Design
     </xpath>
     <!-- Paragraph 1 -->

--- a/theme_real_estate/views/snippets/s_call_to_action.xml
+++ b/theme_real_estate/views/snippets/s_call_to_action.xml
@@ -5,7 +5,7 @@
     <xpath expr="//section" position="attributes">
         <attribute name="class" remove="o_cc5" add="o_cc3" separator=" "/>
     </xpath>
-    <xpath expr="//h3" position="replace" mode="inner">
+    <xpath expr="//h2" position="replace" mode="inner">
         Want To Become A Real Estate Agent?
     </xpath>
     <xpath expr="//p" position="replace" mode="inner">

--- a/theme_real_estate/views/snippets/s_card_offset.xml
+++ b/theme_real_estate/views/snippets/s_card_offset.xml
@@ -15,7 +15,7 @@
         <attribute name="src">/web/image/website.library_image_16</attribute>
     </xpath>
     <!-- Title -->
-    <xpath expr="//h3" position="replace" mode="inner">
+    <xpath expr="//h2" position="replace" mode="inner">
         Real Estate Solutions for You
     </xpath>
     <!-- Paragraph 1 -->

--- a/theme_real_estate/views/snippets/s_cards_grid.xml
+++ b/theme_real_estate/views/snippets/s_cards_grid.xml
@@ -3,32 +3,32 @@
 
     <template id="s_cards_grid" inherit_id="website.s_cards_grid">
         <!-- Title -->
-        <xpath expr="//h3" position="replace" mode="inner">
+        <xpath expr="//h2" position="replace" mode="inner">
             Explore Our Featured Properties
         </xpath>
         <!-- Card 1 -->
-        <xpath expr="(//h5)[1]" position="replace" mode="inner">
+        <xpath expr="(//h3)[1]" position="replace" mode="inner">
             Spacious Urban Loft
         </xpath>
         <xpath expr="(//p)[1]" position="replace" mode="inner">
             Experience city living at its finest in this expansive urban loft, featuring high ceilings, open-plan living spaces, and modern finishes, all in a prime location.
         </xpath>
         <!-- Card 2 -->
-        <xpath expr="(//h5)[2]" position="replace" mode="inner">
+        <xpath expr="(//h3)[2]" position="replace" mode="inner">
             Charming Suburban Home
         </xpath>
         <xpath expr="(//p)[2]" position="replace" mode="inner">
             Enjoy the comfort of this delightful suburban home with a spacious yard, cozy interior, and family-friendly neighborhood, perfect for making lasting memories.
         </xpath>
         <!-- Card 3 -->
-        <xpath expr="(//h5)[3]" position="replace" mode="inner">
+        <xpath expr="(//h3)[3]" position="replace" mode="inner">
             Luxurious Waterfront Villa
         </xpath>
         <xpath expr="(//p)[3]" position="replace" mode="inner">
             Indulge in opulence with this stunning waterfront villa, boasting panoramic views, a private pool, and exquisite design elements that offer a serene and exclusive living experience.
         </xpath>
         <!-- Card 4 -->
-        <xpath expr="(//h5)[4]" position="replace" mode="inner">
+        <xpath expr="(//h3)[4]" position="replace" mode="inner">
             Contemporary Penthouse
         </xpath>
         <xpath expr="(//p)[4]" position="replace" mode="inner">

--- a/theme_real_estate/views/snippets/s_three_columns.xml
+++ b/theme_real_estate/views/snippets/s_three_columns.xml
@@ -17,10 +17,10 @@
     <xpath expr="//div[hasclass('card')]" position="attributes">
         <attribute name="style">border-radius: 0px !important;</attribute>
     </xpath>
-    <xpath expr="//h5" position="before">
+    <xpath expr="//h2" position="before">
         <p class="h4-fs">$295,000</p>
     </xpath>
-    <xpath expr="//h5" position="replace" mode="inner">
+    <xpath expr="//h2" position="replace" mode="inner">
         House On The Hill
     </xpath>
     <xpath expr="//p[hasclass('card-text')]" position="replace" mode="inner">
@@ -34,10 +34,10 @@
     <xpath expr="(//div[hasclass('card')])[2]" position="attributes">
         <attribute name="style">border-radius: 0px !important;</attribute>
     </xpath>
-    <xpath expr="(//h5)[2]" position="before">
+    <xpath expr="(//h2)[2]" position="before">
         <p class="h4-fs">$1,295,000,000</p>
     </xpath>
-    <xpath expr="(//h5)[2]" position="replace" mode="inner">
+    <xpath expr="(//h2)[2]" position="replace" mode="inner">
         Moutain View
     </xpath>
     <xpath expr="(//p[hasclass('card-text')])[2]" position="replace" mode="inner">
@@ -51,10 +51,10 @@
     <xpath expr="(//div[hasclass('card')])[3]" position="attributes">
         <attribute name="style">border-radius: 0px !important;</attribute>
     </xpath>
-    <xpath expr="(//h5)[3]" position="before">
+    <xpath expr="(//h2)[3]" position="before">
         <p class="h4-fs">$455,000</p>
     </xpath>
-    <xpath expr="(//h5)[3]" position="replace" mode="inner">
+    <xpath expr="(//h2)[3]" position="replace" mode="inner">
         Paradise Residence
     </xpath>
     <xpath expr="(//p[hasclass('card-text')])[3]" position="replace" mode="inner">

--- a/theme_treehouse/views/snippets/s_call_to_action.xml
+++ b/theme_treehouse/views/snippets/s_call_to_action.xml
@@ -15,8 +15,8 @@
     <xpath expr="//div[hasclass('row')]/*[1]" position="attributes">
         <attribute name="class" add="col-lg-12" remove="col-lg-9" separator=" "/>
     </xpath>
-    <xpath expr="//h3" position="replace">
-        <h3 style="text-align: center;">Help us protect and preserve for future generations</h3>
+    <xpath expr="//h2" position="replace">
+        <h2 class="h3-fs" style="text-align: center;">Help us protect and preserve for future generations</h2>
     </xpath>
     <xpath expr="//p" position="replace">
         <p class="lead" style="text-align: center;">Join us and make the planet a better place.</p>

--- a/theme_treehouse/views/snippets/s_card_offset.xml
+++ b/theme_treehouse/views/snippets/s_card_offset.xml
@@ -11,7 +11,7 @@
         <attribute name="src">/web/image/website.s_carousel_default_image_3</attribute>
     </xpath>
     <!-- Title -->
-    <xpath expr="//h3" position="replace" mode="inner">
+    <xpath expr="//h2" position="replace" mode="inner">
         Sustainability for a Better Tomorrow
     </xpath>
     <!-- Paragraph 1 -->

--- a/theme_treehouse/views/snippets/s_cards_grid.xml
+++ b/theme_treehouse/views/snippets/s_cards_grid.xml
@@ -3,32 +3,32 @@
 
     <template id="s_cards_grid" inherit_id="website.s_cards_grid">
         <!-- Title -->
-        <xpath expr="//h3" position="replace" mode="inner">
+        <xpath expr="//h2" position="replace" mode="inner">
             Committed to a Greener Future
         </xpath>
         <!-- Card 1 -->
-        <xpath expr="(//h5)[1]" position="replace" mode="inner">
+        <xpath expr="(//h3)[1]" position="replace" mode="inner">
             Sustainable Practices
         </xpath>
         <xpath expr="(//p)[1]" position="replace" mode="inner">
             We implement sustainable practices across all aspects of our operations, from reducing waste and conserving resources to supporting eco-friendly initiatives.
         </xpath>
         <!-- Card 2 -->
-        <xpath expr="(//h5)[2]" position="replace" mode="inner">
+        <xpath expr="(//h3)[2]" position="replace" mode="inner">
             Eco-Friendly Materials
         </xpath>
         <xpath expr="(//p)[2]" position="replace" mode="inner">
             Our commitment to the environment includes using eco-friendly materials in our products and services, ensuring minimal impact on the planet while maintaining high quality.
         </xpath>
         <!-- Card 3 -->
-        <xpath expr="(//h5)[3]" position="replace" mode="inner">
+        <xpath expr="(//h3)[3]" position="replace" mode="inner">
             Community Engagement
         </xpath>
         <xpath expr="(//p)[3]" position="replace" mode="inner">
             We actively engage with our community to promote environmental awareness and participate in local green initiatives, fostering a collective effort toward a more sustainable future.
         </xpath>
         <!-- Card 4 -->
-        <xpath expr="(//h5)[4]" position="replace" mode="inner">
+        <xpath expr="(//h3)[4]" position="replace" mode="inner">
             Energy Efficiency
         </xpath>
         <xpath expr="(//p)[4]" position="replace" mode="inner">

--- a/theme_treehouse/views/snippets/s_numbers_list.xml
+++ b/theme_treehouse/views/snippets/s_numbers_list.xml
@@ -7,7 +7,7 @@
         <attribute name="class" add="o_cc3" remove="o_cc1" separator=" "/>
     </xpath>
     <!-- Title -->
-    <xpath expr="//h3" position="replace" mode="inner">
+    <xpath expr="//h2" position="replace" mode="inner">
         Key milestones in our environmental impact
     </xpath>
     <!-- Paragraph -->

--- a/theme_vehicle/views/customizations.xml
+++ b/theme_vehicle/views/customizations.xml
@@ -179,10 +179,10 @@
         <div class="o_we_shape o_web_editor_Floats_09"/>
     </xpath>
     <!-- Content -->
-    <xpath expr="//h3" position="replace" mode="inner">
+    <xpath expr="//h2" position="replace" mode="inner">
         <b>50,000 pre-orders</b> already registered.
     </xpath>
-    <xpath expr="//h3" position="attributes">
+    <xpath expr="//h2" position="attributes">
         <attribute name="style" add="text-align: left;" separator=";"/>
     </xpath>
     <xpath expr="//p" position="replace" mode="inner">
@@ -272,21 +272,21 @@
 <!-- ======== THREE COLUMNS ======== -->
 <template id="s_three_columns" inherit_id="website.s_three_columns">
     <!-- Column 1 -->
-    <xpath expr="//h5" position="replace" mode="inner">
+    <xpath expr="//h2" position="replace" mode="inner">
         Koran Mini
     </xpath>
         <xpath expr="//p[hasclass('card-text')]" position="replace" mode="inner">
         Unleashing power with elegance, the Koran Mini blends advanced engineering with classic design, delivering a thrilling ride that’s both swift and smooth.
     </xpath>
     <!-- Column 2 -->
-    <xpath expr="(//h5)[2]" position="replace" mode="inner">
+    <xpath expr="(//h2)[2]" position="replace" mode="inner">
         Koran X
     </xpath>
         <xpath expr="(//p[hasclass('card-text')])[2]" position="replace" mode="inner">
         A bold statement in every detail, the Koran X captures the spirit of modern adventure. Built for those who refuse to compromise on performance and style.
     </xpath>
     <!-- Column 3 -->
-    <xpath expr="(//h5)[3]" position="replace" mode="inner">
+    <xpath expr="(//h2)[3]" position="replace" mode="inner">
         Koran GT
     </xpath>
         <xpath expr="(//p[hasclass('card-text')])[3]" position="replace" mode="inner">
@@ -746,7 +746,7 @@
         <attribute name="src">/web/image/website.library_image_05</attribute>
     </xpath>
     <!-- Title -->
-    <xpath expr="//h3" position="replace" mode="inner">
+    <xpath expr="//h2" position="replace" mode="inner">
         Reliable Vehicle Services &amp; Repairs
     </xpath>
     <!-- Paragraph 1 -->
@@ -800,32 +800,32 @@
 <!-- ======== CARDS GRID ======== -->
 <template id="s_cards_grid" inherit_id="website.s_cards_grid">
     <!-- Title -->
-    <xpath expr="//h3" position="replace" mode="inner">
+    <xpath expr="//h2" position="replace" mode="inner">
         Unleash the Power of Our Sports Cars
     </xpath>
     <!-- Card 1 -->
-    <xpath expr="(//h5)[1]" position="replace" mode="inner">
+    <xpath expr="(//h3)[1]" position="replace" mode="inner">
         High-Performance Engine
     </xpath>
     <xpath expr="(//p)[1]" position="replace" mode="inner">
         Experience thrilling acceleration and top speeds with our sports car’s high-performance engine, designed for an exhilarating driving experience on both the track and the road.
     </xpath>
     <!-- Card 2 -->
-    <xpath expr="(//h5)[2]" position="replace" mode="inner">
+    <xpath expr="(//h3)[2]" position="replace" mode="inner">
         Sporty Interior
     </xpath>
     <xpath expr="(//p)[2]" position="replace" mode="inner">
         Immerse yourself in a driver-focused cockpit with sport seats, intuitive controls, and premium materials, all crafted to enhance your driving pleasure and comfort.
     </xpath>
     <!-- Card 3 -->
-    <xpath expr="(//h5)[3]" position="replace" mode="inner">
+    <xpath expr="(//h3)[3]" position="replace" mode="inner">
         Precision Handling
     </xpath>
     <xpath expr="(//p)[3]" position="replace" mode="inner">
         Enjoy exceptional control and responsiveness with advanced suspension systems and precise steering, offering unmatched agility and cornering capabilities.
     </xpath>
     <!-- Card 4 -->
-    <xpath expr="(//h5)[4]" position="replace" mode="inner">
+    <xpath expr="(//h3)[4]" position="replace" mode="inner">
         Aerodynamic Design
     </xpath>
     <xpath expr="(//p)[4]" position="replace" mode="inner">
@@ -893,8 +893,8 @@
     <xpath expr="//section" position="attributes">
         <attribute name="class" add="pt88 pb88" remove="pt48 pb48" separator=" "/>
     </xpath>
-    <xpath expr="//div[hasclass('o_grid_item')]//h3" position="replace">
-        <h2>Key Metrics of our Achievements</h2>
+    <xpath expr="//div[hasclass('o_grid_item')]//h2" position="replace" mode="inner">
+        Key Metrics of our Achievements
     </xpath>
     <xpath expr="//div[hasclass('o_grid_item')]//p" position="replace" mode="inner">
         Our commitment to innovation, performance, and sustainability drives us forward, enabling us to deliver excellence across all categories of the automotive industry.

--- a/theme_yes/views/snippets/s_call_to_action.xml
+++ b/theme_yes/views/snippets/s_call_to_action.xml
@@ -10,7 +10,7 @@
         <div class="o_we_bg_filter bg-black-25"/>
     </xpath>
     <!-- Title -->
-    <xpath expr="//h3" position="replace">
+    <xpath expr="//h2" position="replace">
         <h2>Discover how we can help you<br/>making this day unforgettable.</h2>
     </xpath>
     <!-- Paragraph -->

--- a/theme_yes/views/snippets/s_card_offset.xml
+++ b/theme_yes/views/snippets/s_card_offset.xml
@@ -15,7 +15,7 @@
         <attribute name="src">/web/image/website.s_carousel_default_image_3</attribute>
     </xpath>
     <!-- Title -->
-    <xpath expr="//h3" position="replace" mode="inner">
+    <xpath expr="//h2" position="replace" mode="inner">
         Capturing Your Love Story
     </xpath>
     <!-- Paragraph 1 -->

--- a/theme_yes/views/snippets/s_cards_grid.xml
+++ b/theme_yes/views/snippets/s_cards_grid.xml
@@ -2,28 +2,28 @@
 <odoo>
 
 <template id="s_cards_grid" inherit_id="website.s_cards_grid">
-    <xpath expr="(//h5)[1]" position="replace" mode="inner">
+    <xpath expr="(//h3)[1]" position="replace" mode="inner">
         Dream Wedding Venues
     </xpath>
     <xpath expr="(//p)[1]" position="replace" mode="inner">
         Discover breathtaking venues that capture the essence of romance, from grand castles to scenic beach resorts, perfect for your unforgettable day.
     </xpath>
     <!-- Card 2 -->
-    <xpath expr="(//h5)[2]" position="replace" mode="inner">
+    <xpath expr="(//h3)[2]" position="replace" mode="inner">
         Bespoke Wedding Planning
     </xpath>
     <xpath expr="(//p)[2]" position="replace" mode="inner">
         Our expert team crafts personalized wedding experiences, managing every detail so you can enjoy a stress-free celebration with your loved ones.
     </xpath>
     <!-- Card 3 -->
-    <xpath expr="(//h5)[3]" position="replace" mode="inner">
+    <xpath expr="(//h3)[3]" position="replace" mode="inner">
         Dance and Music Entertainment
     </xpath>
     <xpath expr="(//p)[3]" position="replace" mode="inner">
         From romantic first dances to lively late-night parties, we'll create the perfect mood on a stunning dancefloor for your special day.
     </xpath>
     <!-- Card 4 -->
-    <xpath expr="(//h5)[4]" position="replace" mode="inner">
+    <xpath expr="(//h3)[4]" position="replace" mode="inner">
         Luxury Honeymoon Packages
     </xpath>
     <xpath expr="(//p)[4]" position="replace" mode="inner">

--- a/theme_yes/views/snippets/s_company_team.xml
+++ b/theme_yes/views/snippets/s_company_team.xml
@@ -8,7 +8,7 @@
     </xpath>
     <xpath expr="//p" position="replace"/>
     <!-- Row #1 - Col #1 -->
-    <xpath expr="//div[hasclass('col-lg-9')]//h4" position="replace" mode="inner">
+    <xpath expr="//div[hasclass('col-lg-9')]//h3" position="replace" mode="inner">
         Livia Sailor
     </xpath>
     <xpath expr="//div[hasclass('col-lg-9')]//p" position="replace" mode="inner">
@@ -18,7 +18,7 @@
         Livia is our head wedding coordinator and stylist, she'll turn any of your ideas into reality, making sure your wedding day is smooth and looks better than anything you have ever seen on Pinterest.
     </xpath>
     <!-- Row #1 - Col #2 -->
-    <xpath expr="(//div[hasclass('col-lg-9')])[2]//h4" position="replace" mode="inner">
+    <xpath expr="(//div[hasclass('col-lg-9')])[2]//h3" position="replace" mode="inner">
         Clair Stark
     </xpath>
     <xpath expr="(//div[hasclass('col-lg-9')])[2]//p" position="replace" mode="inner">

--- a/theme_yes/views/snippets/s_company_team_basic.xml
+++ b/theme_yes/views/snippets/s_company_team_basic.xml
@@ -1,11 +1,11 @@
 <?xml version="1.0" encoding="utf-8"?>
 <odoo>
 <template id="s_company_team_basic" inherit_id="website.s_company_team_basic">
-    <xpath expr="//h3" position="replace" mode="inner">
+    <xpath expr="//h2" position="replace" mode="inner">
         Meet our team
     </xpath>
     <!-- Team #01 - Title -->
-    <xpath expr="//h4" position="replace" mode="inner">
+    <xpath expr="//h3" position="replace" mode="inner">
         Tony Fred
     </xpath>
     <!-- Team #01 - Work Description -->
@@ -14,7 +14,7 @@
     </xpath>
 
     <!-- Team #02 - Title -->
-    <xpath expr="(//h4)[2]" position="replace" mode="inner">
+    <xpath expr="(//h3)[2]" position="replace" mode="inner">
         Clair Stark
     </xpath>
     <!-- Team #02 - Work Description -->
@@ -23,7 +23,7 @@
     </xpath>
 
     <!-- Team #03 - Title -->
-    <xpath expr="(//h4)[3]" position="replace" mode="inner">
+    <xpath expr="(//h3)[3]" position="replace" mode="inner">
         Aline Turner
     </xpath>
     <!-- Team #03 - Work Description -->
@@ -32,7 +32,7 @@
     </xpath>
 
     <!-- Team #04 - Title -->
-    <xpath expr="(//h4)[4]" position="replace" mode="inner">
+    <xpath expr="(//h3)[4]" position="replace" mode="inner">
         Iris Joe
     </xpath>
     <!-- Team #04 - Work Description -->

--- a/theme_yes/views/snippets/s_features.xml
+++ b/theme_yes/views/snippets/s_features.xml
@@ -7,7 +7,7 @@
         <attribute name="class" add="o_cc o_cc2 pb88" remove="pb64" separator=" "/>
     </xpath>
     <!-- Remove title and subtitle -->
-    <xpath expr="//div[hasclass('container')]/h3" position="replace"/>
+    <xpath expr="//div[hasclass('container')]/h2" position="replace"/>
     <xpath expr="//div[hasclass('container')]/p" position="replace"/>
     <!-- Column #01 -->
     <xpath expr="//div[hasclass('row')]/div[1]/div[hasclass('s_hr')]" position="replace"/>

--- a/theme_yes/views/snippets/s_masonry_block.xml
+++ b/theme_yes/views/snippets/s_masonry_block.xml
@@ -4,7 +4,7 @@
 <template id="s_masonry_block_default_template" inherit_id="website.s_masonry_block_default_template">
     <!-- Little Blocks -->
     <!-- Little block #01 - Title -->
-    <xpath expr="//h3" position="replace" mode="inner">
+    <xpath expr="//h2" position="replace" mode="inner">
         Caterers
     </xpath>
     <!-- Little block #01 - Text -->
@@ -14,7 +14,7 @@
     </xpath>
 
     <!-- Bigger block #02 - Title -->
-    <xpath expr="(//h3)[2]" position="replace" mode="inner">
+    <xpath expr="(//h2)[2]" position="replace" mode="inner">
         Venues
     </xpath>
     <!-- Bigger block #02 - Text -->
@@ -24,7 +24,7 @@
     </xpath>
 
     <!-- Bigger block #03 - Title -->
-    <xpath expr="(//h3)[3]" position="replace" mode="inner">
+    <xpath expr="(//h2)[3]" position="replace" mode="inner">
         Attire
     </xpath>
     <!-- Bigger block #03 - Text -->
@@ -34,7 +34,7 @@
     </xpath>
 
     <!-- Little block #04 - Title -->
-    <xpath expr="(//h3)[4]" position="replace" mode="inner">
+    <xpath expr="(//h2)[4]" position="replace" mode="inner">
         FAQ
     </xpath>
     <!-- Little block #04 - Text -->

--- a/theme_zap/views/snippets/s_card_offset.xml
+++ b/theme_zap/views/snippets/s_card_offset.xml
@@ -11,7 +11,7 @@
         <attribute name="src">/web/image/website.s_carousel_default_image_3</attribute>
     </xpath>
     <!-- Title -->
-    <xpath expr="//h3" position="replace" mode="inner">
+    <xpath expr="//h2" position="replace" mode="inner">
         Elevate Your Brand with Digital Marketing
     </xpath>
     <!-- Paragraph 1 -->

--- a/theme_zap/views/snippets/s_masonry_block.xml
+++ b/theme_zap/views/snippets/s_masonry_block.xml
@@ -3,29 +3,29 @@
 
 <template id="s_masonry_block_default_template" inherit_id="website.s_masonry_block_default_template">
     <!-- Block #01 -->
-    <xpath expr="//h3" position="replace"/>
+    <xpath expr="//h2" position="replace"/>
     <xpath expr="//p" position="replace" mode="inner">
         <em class="lead">Maintain a position of constant change<br/> and evolution, while always aiming<br/> for your success.</em>
     </xpath>
     <!-- Block #02 -->
-    <xpath expr="//h3" position="before">
+    <xpath expr="//h2" position="before">
         <i class="fa fa-2x fa-star text-o-color-2 rounded-circle shadow mx-auto my-3"/>
     </xpath>
-    <xpath expr="//h3" position="replace" mode="inner">
+    <xpath expr="//h2" position="replace" mode="inner">
         Super <b>Easy</b>
     </xpath>
-    <xpath expr="//h3" position="attributes">
+    <xpath expr="//h2" position="attributes">
         <attribute name="class" add="text-center" separator=" "/>
     </xpath>
     <xpath expr="(//p)[2]" position="replace" mode="inner"/>
     <!-- Block #03 -->
-    <xpath expr="(//h3)[2]" position="before">
+    <xpath expr="(//h2)[2]" position="before">
         <i class="fa fa-2x fa-rocket text-o-color-1 rounded-circle shadow mx-auto my-3"/>
     </xpath>
-    <xpath expr="(//h3)[2]" position="replace" mode="inner">
+    <xpath expr="(//h2)[2]" position="replace" mode="inner">
         Super <b>Fast</b>
     </xpath>
-    <xpath expr="(//h3)[2]" position="attributes">
+    <xpath expr="(//h2)[2]" position="attributes">
         <attribute name="class" add="text-center" separator=" "/>
     </xpath>
     <xpath expr="(//p)[3]" position="replace" mode="inner"/>

--- a/theme_zap/views/snippets/s_showcase.xml
+++ b/theme_zap/views/snippets/s_showcase.xml
@@ -7,7 +7,7 @@
         <attribute name="class" add="pt72 pb72" remove="pt48 pb48" separator=" "/>
     </xpath>
     <!-- Title -->
-    <xpath expr="//h3" position="replace" mode="inner">
+    <xpath expr="//h2" position="replace" mode="inner">
         Meet Our Specialists
     </xpath>
     <!-- Lead -->
@@ -26,7 +26,7 @@
     <xpath expr="(//div[hasclass('col-12')])[2]//i" position="attributes">
         <attribute name="class" remove="bg-o-color-3" add="bg-o-color-2" separator=" "/>
     </xpath>
-    <xpath expr="(//div[hasclass('col-12')])[2]//h5" position="replace" mode="inner">
+    <xpath expr="(//div[hasclass('col-12')])[2]//h3" position="replace" mode="inner">
         Coding Excellence
     </xpath>
     <xpath expr="(//div[hasclass('col-12')])[2]//p" position="replace" mode="inner">
@@ -36,7 +36,7 @@
     <xpath expr="(//div[hasclass('col-12')])[3]//i" position="attributes">
         <attribute name="class" remove="bg-o-color-3" add="bg-o-color-2" separator=" "/>
     </xpath>
-    <xpath expr="(//div[hasclass('col-12')])[3]//h5" position="replace" mode="inner">
+    <xpath expr="(//div[hasclass('col-12')])[3]//h3" position="replace" mode="inner">
         Agile Approach
     </xpath>
     <xpath expr="(//div[hasclass('col-12')])[3]//p" position="replace" mode="inner">
@@ -46,7 +46,7 @@
     <xpath expr="(//div[hasclass('col-12')])[4]//i" position="attributes">
         <attribute name="class" remove="bg-o-color-3" add="bg-o-color-2" separator=" "/>
     </xpath>
-    <xpath expr="(//div[hasclass('col-12')])[4]//h5" position="replace" mode="inner">
+    <xpath expr="(//div[hasclass('col-12')])[4]//h3" position="replace" mode="inner">
         Security First
     </xpath>
     <xpath expr="(//div[hasclass('col-12')])[4]//p" position="replace" mode="inner">


### PR DESCRIPTION
Requires : 
- https://github.com/odoo/odoo/pull/191300
- https://github.com/odoo/design-themes/pull/1043

-------
*: anelusia, artists, avantgarde, aviato, beauty, bewise, bistro, bookstore, buzzy, clean, cobalt, enark, graphene, kea, kiddo, loftspace, monglia, nano, notes, odoo_experts, orchid, paptic, real estate, treehouse, vehicle, yes, zap

This PR adapts all the `xpath` expressions inside design themes to target the new heading tags that were changed within the snippet files.

task-4349019