### PR TITLE
[IMP] all: add missing author in all manifests

### DIFF
--- a/test_themes/__manifest__.py
+++ b/test_themes/__manifest__.py
@@ -48,5 +48,6 @@
             'test_themes/static/src/systray_items/*',
         ],
     },
+    'author': 'Odoo S.A.',
     'license': 'LGPL-3',
 }

--- a/theme_anelusia/__manifest__.py
+++ b/theme_anelusia/__manifest__.py
@@ -85,6 +85,7 @@
     'configurator_snippets': {
         'homepage': ['s_text_cover', 's_images_wall', 's_color_blocks_2', 's_references', 's_media_list','s_key_images', 's_call_to_action'],
     },
+    'author': 'Odoo S.A.',
     'license': 'LGPL-3',
     'live_test_url': 'https://theme-anelusia.odoo.com',
     'assets': {

--- a/theme_artists/__manifest__.py
+++ b/theme_artists/__manifest__.py
@@ -128,6 +128,7 @@
     'configurator_snippets': {
         'homepage': ['s_sidegrid', 's_product_catalog', 's_cta_box', 's_title', 's_image_frame', 's_images_wall', 's_shape_image'],
     },
+    'author': 'Odoo S.A.',
     'license': 'LGPL-3',
     'live_test_url': 'https://theme-artists.odoo.com',
     'assets': {

--- a/theme_avantgarde/__manifest__.py
+++ b/theme_avantgarde/__manifest__.py
@@ -26,6 +26,7 @@
         'homepage': ['s_sidegrid', 's_features_wall', 's_carousel', 's_timeline', 's_quadrant'],
     },
     'depends': ['theme_common'],
+    'author': 'Odoo S.A.',
     'license': 'LGPL-3',
     'live_test_url': 'https://theme-avantgarde.odoo.com',
     'assets': {

--- a/theme_aviato/__manifest__.py
+++ b/theme_aviato/__manifest__.py
@@ -79,6 +79,7 @@
     'configurator_snippets': {
         'homepage': ['s_banner', 's_text_image', 's_image_text', 's_picture', 's_title', 's_masonry_block_default_template', 's_company_team', 's_showcase', 's_quotes_carousel'],
     },
+    'author': 'Odoo S.A.',
     'license': 'LGPL-3',
     'live_test_url': 'https://theme-aviato.odoo.com',
 

--- a/theme_beauty/__manifest__.py
+++ b/theme_beauty/__manifest__.py
@@ -82,6 +82,7 @@
     'configurator_snippets': {
         'homepage': ['s_intro_pill', 's_masonry_block_mosaic_template', 's_pricelist_boxed', 's_features_wall', 's_image_frame', 's_call_to_action'],
     },
+    'author': 'Odoo S.A.',
     'license': 'LGPL-3',
     'live_test_url': 'https://theme-beauty.odoo.com',
     'assets': {

--- a/theme_bewise/__manifest__.py
+++ b/theme_bewise/__manifest__.py
@@ -26,6 +26,7 @@
     'configurator_snippets': {
         'homepage': ['s_striped_center_top', 's_title', 's_color_blocks_2', 's_faq_collapse', 's_masonry_block_default_template', 's_company_team_shapes'],
     },
+    'author': 'Odoo S.A.',
     'license': 'LGPL-3',
     'live_test_url': 'https://theme-bewise.odoo.com',
     'assets': {

--- a/theme_bistro/__manifest__.py
+++ b/theme_bistro/__manifest__.py
@@ -80,6 +80,7 @@
         'homepage': ['s_image_title', 's_key_images', 's_pricelist_cafe', 's_quotes_carousel', 's_quadrant'],
         'pricing': ["s_text_image", "s_product_catalog"],
     },
+    'author': 'Odoo S.A.',
     'license': 'LGPL-3',
     'live_test_url': 'https://theme-bistro.odoo.com',
     'assets': {

--- a/theme_bookstore/__manifest__.py
+++ b/theme_bookstore/__manifest__.py
@@ -95,6 +95,7 @@
             '2': ['s_text_cover', 's_image_text', 's_text_image', 's_image_text_2nd', 's_call_to_action'],
         },
     },
+    'author': 'Odoo S.A.',
     'license': 'LGPL-3',
     'live_test_url': 'https://theme-bookstore.odoo.com',
     'assets': {

--- a/theme_buzzy/__manifest__.py
+++ b/theme_buzzy/__manifest__.py
@@ -90,6 +90,7 @@
             '2': ['s_text_cover', 's_image_text', 's_text_image', 's_image_text_2nd', 's_call_to_action'],
         },
     },
+    'author': 'Odoo S.A.',
     'license': 'LGPL-3',
     'live_test_url': 'https://theme-buzzy.odoo.com',
     'assets': {

--- a/theme_clean/__manifest__.py
+++ b/theme_clean/__manifest__.py
@@ -62,6 +62,7 @@
     'configurator_snippets': {
         'homepage': ['s_banner', 's_color_blocks_2', 's_title', 's_text_image', 's_image_text', 's_numbers_showcase', 's_company_team', 's_accordion_image', 's_cta_card'], 
     },
+    'author': 'Odoo S.A.',
     'license': 'LGPL-3',
     'live_test_url': 'https://theme-clean.odoo.com',
     'assets': {

--- a/theme_cobalt/__manifest__.py
+++ b/theme_cobalt/__manifest__.py
@@ -20,6 +20,7 @@
     'configurator_snippets': {
         'homepage': ['s_banner', 's_image_text', 's_key_images', 's_text_image', 's_company_team_detail', 's_references_grid'],
     },
+    'author': 'Odoo S.A.',
     'license': 'LGPL-3',
     'live_test_url': 'https://theme-cobalt.odoo.com',
     'assets': {

--- a/theme_common/__manifest__.py
+++ b/theme_common/__manifest__.py
@@ -11,5 +11,6 @@
         'views/old_snippets/s_page_header.xml',
         'views/old_snippets/s_three_columns_circle.xml',
     ],
+    'author': 'Odoo S.A.',
     'license': 'LGPL-3',
 }

--- a/theme_enark/__manifest__.py
+++ b/theme_enark/__manifest__.py
@@ -86,6 +86,7 @@
             '2': ['s_text_cover', 's_image_text', 's_text_image', 's_image_text_2nd', 's_call_to_action'],
         },
     },
+    'author': 'Odoo S.A.',
     'license': 'LGPL-3',
     'live_test_url': 'https://theme-enark.odoo.com',
     'assets': {

--- a/theme_graphene/__manifest__.py
+++ b/theme_graphene/__manifest__.py
@@ -28,6 +28,7 @@
         },
     },
     'depends': ['theme_common'],
+    'author': 'Odoo S.A.',
     'license': 'LGPL-3',
     'live_test_url': 'https://theme-graphene.odoo.com',
     'assets': {

--- a/theme_kea/__manifest__.py
+++ b/theme_kea/__manifest__.py
@@ -79,6 +79,7 @@
             'personal': ['s_text_cover', 's_image_text', 's_text_block_h2', 's_numbers', 's_features', 's_call_to_action'],
         },
     },
+    'author': 'Odoo S.A.',
     'license': 'LGPL-3',
     'live_test_url': 'https://theme-kea.odoo.com',
     'assets': {

--- a/theme_kiddo/__manifest__.py
+++ b/theme_kiddo/__manifest__.py
@@ -80,6 +80,7 @@
             'personal': ['s_text_cover', 's_image_text', 's_text_block_h2', 's_numbers', 's_features', 's_call_to_action'],
         },
     },
+    'author': 'Odoo S.A.',
     'license': 'LGPL-3',
     'live_test_url': 'https://theme-kiddo.odoo.com',
     'assets': {

--- a/theme_loftspace/__manifest__.py
+++ b/theme_loftspace/__manifest__.py
@@ -88,6 +88,7 @@
             'personal': ['s_text_cover', 's_image_text', 's_text_block_h2', 's_numbers', 's_features', 's_call_to_action'],
         },
     },
+    'author': 'Odoo S.A.',
     'license': 'LGPL-3',
     'live_test_url': 'https://theme-loftspace.odoo.com',
     'assets': {

--- a/theme_monglia/__manifest__.py
+++ b/theme_monglia/__manifest__.py
@@ -42,6 +42,7 @@
             'personal': ['s_text_cover', 's_image_text', 's_text_block_h2', 's_numbers', 's_features', 's_call_to_action'],
         },
     },
+    'author': 'Odoo S.A.',
     'license': 'LGPL-3',
     'live_test_url': 'https://theme-monglia.odoo.com',
     'assets': {

--- a/theme_nano/__manifest__.py
+++ b/theme_nano/__manifest__.py
@@ -95,6 +95,7 @@
             '2': ['s_text_cover', 's_image_text', 's_text_image', 's_image_text_2nd', 's_call_to_action'],
         },
     },
+    'author': 'Odoo S.A.',
     'license': 'LGPL-3',
     'live_test_url': 'https://theme-nano.odoo.com',
     'assets': {

--- a/theme_notes/__manifest__.py
+++ b/theme_notes/__manifest__.py
@@ -98,6 +98,7 @@
             'personal': ['s_text_cover', 's_image_text', 's_text_block_h2', 's_numbers', 's_features', 's_call_to_action'],
         },
     },
+    'author': 'Odoo S.A.',
     'license': 'LGPL-3',
     'live_test_url': 'https://theme-notes.odoo.com',
     'assets': {

--- a/theme_odoo_experts/__manifest__.py
+++ b/theme_odoo_experts/__manifest__.py
@@ -76,6 +76,7 @@
             'personal': ['s_text_cover', 's_image_text', 's_text_block_h2', 's_numbers', 's_features', 's_call_to_action'],
         },
     },
+    'author': 'Odoo S.A.',
     'license': 'LGPL-3',
     'live_test_url': 'https://theme-odoo-experts.odoo.com',
     'assets': {

--- a/theme_orchid/__manifest__.py
+++ b/theme_orchid/__manifest__.py
@@ -83,6 +83,7 @@
             '2': ['s_text_cover', 's_image_text', 's_text_image', 's_image_text_2nd', 's_call_to_action'],
         },
     },
+    'author': 'Odoo S.A.',
     'license': 'LGPL-3',
     'live_test_url': 'https://theme-orchid.odoo.com',
     'assets': {

--- a/theme_paptic/__manifest__.py
+++ b/theme_paptic/__manifest__.py
@@ -25,6 +25,7 @@
             'personal': ['s_text_cover', 's_image_text', 's_text_block_h2', 's_numbers', 's_features', 's_call_to_action'],
         },
     },
+    'author': 'Odoo S.A.',
     'license': 'LGPL-3',
     'live_test_url': 'https://theme-paptic.odoo.com',
     'assets': {

--- a/theme_real_estate/__manifest__.py
+++ b/theme_real_estate/__manifest__.py
@@ -75,6 +75,7 @@
             'personal': ['s_text_cover', 's_image_text', 's_text_block_h2', 's_numbers', 's_features', 's_call_to_action'],
         },
     },
+    'author': 'Odoo S.A.',
     'license': 'LGPL-3',
     'live_test_url': 'https://theme-real-estate.odoo.com',
     'assets': {

--- a/theme_test_custo/__manifest__.py
+++ b/theme_test_custo/__manifest__.py
@@ -17,5 +17,6 @@
             'theme_test_custo/static/tests/tours/**/*',
         ],
     },
+    'author': 'Odoo S.A.',
     'license': 'LGPL-3',
 }

--- a/theme_treehouse/__manifest__.py
+++ b/theme_treehouse/__manifest__.py
@@ -84,6 +84,7 @@
             'personal': ['s_text_cover', 's_image_text', 's_text_block_h2', 's_numbers', 's_features', 's_call_to_action'],
         },
     },
+    'author': 'Odoo S.A.',
     'license': 'LGPL-3',
     'live_test_url': 'https://theme-treehouse.odoo.com',
     'assets': {

--- a/theme_vehicle/__manifest__.py
+++ b/theme_vehicle/__manifest__.py
@@ -42,6 +42,7 @@
             '5': ['s_text_block_h1', 's_text_block', 's_image_gallery', 's_picture'],
         },
     },
+    'author': 'Odoo S.A.',
     'license': 'LGPL-3',
     'live_test_url': 'https://theme-vehicle.odoo.com',
     'assets': {

--- a/theme_yes/__manifest__.py
+++ b/theme_yes/__manifest__.py
@@ -95,6 +95,7 @@
             'personal': ['s_text_cover', 's_image_text', 's_text_block_h2', 's_numbers', 's_features', 's_call_to_action'],
         },
     },
+    'author': 'Odoo S.A.',
     'license': 'LGPL-3',
     'live_test_url': 'https://theme-yes.odoo.com',
     'assets': {

--- a/theme_zap/__manifest__.py
+++ b/theme_zap/__manifest__.py
@@ -75,6 +75,7 @@
             'personal': ['s_text_cover', 's_image_text', 's_text_block_h2', 's_numbers', 's_features', 's_call_to_action'],
         },
     },
+    'author': 'Odoo S.A.',
     'license': 'LGPL-3',
     'live_test_url': 'https://theme-zap.odoo.com',
     'assets': {


### PR DESCRIPTION
The author field was made required by the previous commit, this commit add the missing field in all manifests.

The upgrade-code script `18.2-01-manifest-author.py` was used. See related community branch (same commit title).

task-4485983