### PR TITLE
[FIX] theme_test, theme_odoo_expert : fix classes test

### DIFF
--- a/test_themes/tests/test_new_page_templates.py
+++ b/test_themes/tests/test_new_page_templates.py
@@ -155,6 +155,7 @@ class TestNewPageTemplates(TransactionCase):
         self.assertGreater(len(view_ids), 1250, "Test should have encountered a lot of views")
         self.assertFalse(errors, "No error should have been collected")
 
+    # TODO should handle the fact that grid items can't have padding classes
     def test_render_applied_templates(self):
         View = self.env['ir.ui.view']
         errors = []

--- a/test_themes/tests/test_new_page_templates.py
+++ b/test_themes/tests/test_new_page_templates.py
@@ -37,7 +37,12 @@ CONFLICTUAL_CLASSES = [
 CONFLICTUAL_CLASSES_RE = {
     # Align
     re.compile(r'^align-(?!(self|items)-).+'): [],
-    re.compile(r'^align-self-.+'): [],
+    re.compile(r'^align-self-(?:start|center|end)$'): [],
+    re.compile(r'^align-self-sm-(?:start|center|end)$'): [],
+    re.compile(r'^align-self-md-(?:start|center|end)$'): [],
+    re.compile(r'^align-self-lg-(?:start|center|end)$'): [],
+    re.compile(r'^align-self-xl-(?:start|center|end)$'): [],
+    re.compile(r'^align-self-xxl-(?:start|center|end)$'): [],
     re.compile(r'^align-items-.+'): [],
     # BG
     re.compile(r'^bg(-|_)'): [

--- a/theme_artists/views/new_page_template.xml
+++ b/theme_artists/views/new_page_template.xml
@@ -151,12 +151,6 @@
 
 <!-- Snippet customization Landing Pages -->
 
-<template id="new_page_template_landing_s_features" inherit_id="website.new_page_template_landing_s_features">
-    <xpath expr="//section" position="attributes">
-        <attribute name="class" add="o_cc4" separator=" "/>
-    </xpath>
-</template>
-
 <template id="new_page_template_landing_s_text_image" inherit_id="website.new_page_template_landing_s_text_image">
     <xpath expr="//section" position="attributes">
         <attribute name="class" remove="pb56" separator=" "/>

--- a/theme_buzzy/views/new_page_template.xml
+++ b/theme_buzzy/views/new_page_template.xml
@@ -209,7 +209,7 @@
 
 <template id="new_page_template_landing_s_features" inherit_id="website.new_page_template_landing_s_features">
     <xpath expr="//section" position="attributes">
-        <attribute name="class" add="o_cc2" separator=" "/>
+        <attribute name="class" add="o_cc2" remove="o_cc5" separator=" "/>
         <attribute name="data-oe-shape-data"/>
     </xpath>
     <!-- Remove shape -->

--- a/theme_loftspace/views/new_page_template.xml
+++ b/theme_loftspace/views/new_page_template.xml
@@ -30,14 +30,6 @@
     </xpath>
 </template>
 
-<!-- Landing -->
-
-<template id="new_page_template_landing_s_features" inherit_id="website.new_page_template_landing_s_features">
-    <xpath expr="//section" position="attributes">
-        <attribute name="class" add="pt48" separator=" "/>
-    </xpath>
-</template>
-
 <!-- Gallery -->
 
 <template id="new_page_template_gallery_s_banner" inherit_id="website.new_page_template_gallery_s_banner">

--- a/theme_odoo_experts/views/snippets/s_references.xml
+++ b/theme_odoo_experts/views/snippets/s_references.xml
@@ -19,27 +19,27 @@
 
     <!-- Items -->
     <xpath expr="//div[hasclass('col-lg-2')]" position="attributes">
-        <attribute name="class" add="o_grid_item g-col-lg-2 g-height-2 o_grid_item_image o_cc o_cc2" separator=" "/>
+        <attribute name="class" add="o_grid_item g-col-lg-2 g-height-2 o_grid_item_image o_cc o_cc2" remove="pt16 pb16" separator=" "/>
         <attribute name="style" add="grid-area: 1 / 1 / 3 / 3; z-index: 1;" separator=";"/>
     </xpath>
     <xpath expr="(//div[hasclass('col-lg-2')])[2]" position="attributes">
-        <attribute name="class" add="o_grid_item g-col-lg-2 g-height-2 o_grid_item_image o_cc o_cc2" separator=" "/>
+        <attribute name="class" add="o_grid_item g-col-lg-2 g-height-2 o_grid_item_image o_cc o_cc2" remove="pt16 pb16" separator=" "/>
         <attribute name="style" add="grid-area: 1 / 3 / 3 / 5; z-index: 2;" separator=";"/>
     </xpath>
     <xpath expr="(//div[hasclass('col-lg-2')])[3]" position="attributes">
-        <attribute name="class" add="o_grid_item g-col-lg-2 g-height-2 o_grid_item_image o_cc o_cc2" separator=" "/>
+        <attribute name="class" add="o_grid_item g-col-lg-2 g-height-2 o_grid_item_image o_cc o_cc2" remove="pt16 pb16" separator=" "/>
         <attribute name="style" add="grid-area: 1 / 5 / 3 / 7; z-index: 3;" separator=";"/>
     </xpath>
     <xpath expr="(//div[hasclass('col-lg-2')])[4]" position="attributes">
-        <attribute name="class" add="o_grid_item g-col-lg-2 g-height-2 o_grid_item_image o_cc o_cc2" separator=" "/>
+        <attribute name="class" add="o_grid_item g-col-lg-2 g-height-2 o_grid_item_image o_cc o_cc2" remove="pt16 pb16" separator=" "/>
         <attribute name="style" add="grid-area: 1 / 7 / 3 / 9; z-index: 4;" separator=";"/>
     </xpath>
     <xpath expr="(//div[hasclass('col-lg-2')])[5]" position="attributes">
-        <attribute name="class" add="o_grid_item g-col-lg-2 g-height-2 o_grid_item_image o_cc o_cc2" separator=" "/>
+        <attribute name="class" add="o_grid_item g-col-lg-2 g-height-2 o_grid_item_image o_cc o_cc2" remove="pt16 pb16" separator=" "/>
         <attribute name="style" add="grid-area: 1 / 9 / 3 / 11; z-index: 5;" separator=";"/>
     </xpath>
     <xpath expr="(//div[hasclass('col-lg-2')])[6]" position="attributes">
-        <attribute name="class" add="o_grid_item g-col-lg-2 g-height-2 o_grid_item_image o_cc o_cc2" separator=" "/>
+        <attribute name="class" add="o_grid_item g-col-lg-2 g-height-2 o_grid_item_image o_cc o_cc2" remove="pt16 pb16" separator=" "/>
         <attribute name="style" add="grid-area: 1 / 11 / 3 / 13; z-index: 6;" separator=";"/>
     </xpath>
 </template>

--- a/theme_yes/views/new_page_template.xml
+++ b/theme_yes/views/new_page_template.xml
@@ -139,12 +139,6 @@
 
 <!-- Snippet customization Landing Pages -->
 
-<template id="new_page_template_landing_s_features" inherit_id="website.new_page_template_landing_s_features">
-    <xpath expr="//section" position="attributes">
-        <attribute name="class" add="o_cc2" separator=" "/>
-    </xpath>
-</template>
-
 <template id="new_page_template_landing_s_text_image" inherit_id="website.new_page_template_landing_s_text_image">
     <xpath expr="//section" position="attributes">
         <attribute name="class" add="o_cc2" separator=" "/>


### PR DESCRIPTION
The test was incorrectly flagging inner classes that follow our naming convention (eg. `s_floating_blocks_wrapper` for `s_floating_blocks` snippet). This made maintaining the whitelist tedious and error prone.

The change enables proper enforcement of our conventions while simplifying whitelist maintenance. It also allow more flexibility on the use of `align-self-*-*` classes combination to better handle responsiveness in some scenario.

As a side-effect of these changes, since the new test provides a more complete tree traversal analysis, it also exposes pre-existing grid layouts issue that we not flagged before.

task-4373543

Related:
- https://github.com/odoo/odoo/pull/189299