### PR TITLE
[FIX] theme_test_custo: fix nightly theme preview tour

### DIFF
--- a/theme_test_custo/static/tests/tours/website_theme_preview.js
+++ b/theme_test_custo/static/tests/tours/website_theme_preview.js
@@ -26,6 +26,9 @@ registry.category("web_tour.tours").add("website_theme_preview", {
 }, {
     content: "Click on the Live preview of a theme",
     trigger: ".o_theme_preview button:not(:visible)",
+/*
+TODO The feature that the following steps are testing is currently disabled.
+It will either be restored or entirely removed at some point. See task-3454790.
     run: "click",
 }, {
     content: "Switch from desktop to mobile preview",
@@ -43,4 +46,5 @@ registry.category("web_tour.tours").add("website_theme_preview", {
     content: "Check that the desktop view is active",
     trigger: ".o_view_form_theme_preview_controller .o_field_iframe > div:not(.is_mobile):visible",
     run: () => null, // it's a check
+*/
 }]});

--- a/theme_test_custo/tests/test_theme_creation.py
+++ b/theme_test_custo/tests/test_theme_creation.py
@@ -3,6 +3,7 @@
 from odoo.tests import HttpCase, tagged
 from odoo.addons.website.tests.test_configurator import TestConfiguratorCommon
 
+
 # TODO: `test_themes` tag should not be there, runbot config should be adapted
 #       to test this module too. There is a special config for the theme repo.
 @tagged('post_install', '-at_install', 'test_themes')
@@ -13,6 +14,7 @@ class Crawler(HttpCase):
         website.theme_id = theme_custo.id
         theme_custo.with_context(load_all_views=True, apply_new_theme=True)._theme_load(website)
         self.start_tour('/@/example', "theme_menu_hierarchies", login='admin')
+
 
 @tagged('post_install', '-at_install')
 class TestThemeConfigurator(TestConfiguratorCommon):


### PR DESCRIPTION
The theme preview feature before selection was disabled in [1]. This commit disables the related tour steps that were testing it a nightly tour... that was red since then.

[1]: https://github.com/odoo/odoo/commit/7cb71e9479df0ee9af0b7ad39302857666726177

Related to task-3454790