### PR TITLE
[FIX] theme_cobalt,theme_paptic: enable blog Inter bolder


### DIFF
--- a/theme_cobalt/static/src/scss/primary_variables.scss
+++ b/theme_cobalt/static/src/scss/primary_variables.scss
@@ -12,7 +12,7 @@ $o-theme-h6-font-size-multiplier: 1.1;
 $o-theme-font-configs: (
     'Inter': (
         'family': ('Inter', serif),
-        'url': 'Inter:400,400i,600,600i,800,800i',
+        'url': 'Inter:300,300i,400,400i,600,600i,800,800i',
     ),
 
     'Abril Fatface': (

--- a/theme_paptic/static/src/scss/primary_variables.scss
+++ b/theme_paptic/static/src/scss/primary_variables.scss
@@ -12,7 +12,7 @@ $o-theme-h6-font-size-multiplier: (18 / 14);
 $o-theme-font-configs: (
     'Inter': (
         'family': ('Inter', serif),
-        'url': 'Inter:400,400i,600,600i,800,800i',
+        'url': 'Inter:300,300i,400,400i,600,600i,800,800i',
     ),
 
     'Nunito': (


### PR DESCRIPTION
Scenario:
- install theme_cobalt or theme_paptic
- go to a website blog post
- put a word in bold

Result: the bold is not shown bolder than the text

Issue: Inter font in theme_cobalt and theme_paptic loads weights 400,
600 and 800. The blog post normal font weight is 300 since 2019 (in
odoo/odoo@bb0cdec4594fab8c22265ed8af0c2d431a263b72) and so both normal
font-weight and bold inside it are shown with weight 400 which make bold
not differentiated.

Fix: add 300 weight to Inter font.

Note: in 18.0, Inter font already has weight 300 in theme_odoo_experts,
theme_enark, theme_vehicle, theme_bookstore, theme_nano, theme_clean and
website but it is still missing for cobalt and paptic themes.

opw-4818737