### PR TITLE
[IMP] theme_*: add e-commerce specific homepage list

### DIFF
--- a/theme_anelusia/__manifest__.py
+++ b/theme_anelusia/__manifest__.py
@@ -86,6 +86,13 @@
     'configurator_snippets': {
         'homepage': ['s_text_cover', 's_images_wall', 's_color_blocks_2', 's_references', 's_media_list','s_key_images', 's_call_to_action'],
     },
+    'configurator_snippets_addons': {
+        'website_sale': {
+            'homepage': [
+                ('website_sale.s_dynamic_snippet_products', 'after', 's_images_wall'),
+            ],
+        },
+    },
     'author': 'Odoo S.A.',
     'license': 'LGPL-3',
     'live_test_url': 'https://theme-anelusia.odoo.com',

--- a/theme_artists/__manifest__.py
+++ b/theme_artists/__manifest__.py
@@ -132,6 +132,13 @@
     'configurator_snippets': {
         'homepage': ['s_sidegrid', 's_product_catalog', 's_cta_box', 's_title', 's_image_frame', 's_images_wall', 's_shape_image'],
     },
+    'configurator_snippets_addons': {
+        'website_sale': {
+            'homepage': [
+                ('website_sale.s_dynamic_snippet_products', 'after', 's_product_catalog'),
+            ],
+        },
+    },
     'author': 'Odoo S.A.',
     'license': 'LGPL-3',
     'live_test_url': 'https://theme-artists.odoo.com',

--- a/theme_avantgarde/__manifest__.py
+++ b/theme_avantgarde/__manifest__.py
@@ -25,6 +25,13 @@
     'configurator_snippets': {
         'homepage': ['s_sidegrid', 's_features_wall', 's_carousel', 's_timeline', 's_quadrant'],
     },
+    'configurator_snippets_addons': {
+        'website_sale': {
+            'homepage': [
+                ('website_sale.s_dynamic_snippet_products', 'after', 's_features_wall'),
+            ],
+        },
+    },
     'depends': ['theme_common'],
     'author': 'Odoo S.A.',
     'license': 'LGPL-3',

--- a/theme_aviato/__manifest__.py
+++ b/theme_aviato/__manifest__.py
@@ -80,6 +80,13 @@
     'configurator_snippets': {
         'homepage': ['s_banner', 's_text_image', 's_image_text', 's_picture', 's_title', 's_masonry_block_default_template', 's_company_team', 's_showcase', 's_quotes_carousel'],
     },
+    'configurator_snippets_addons': {
+        'website_sale': {
+            'homepage': [
+                ('website_sale.s_dynamic_snippet_products', 'after', 's_text_image'),
+            ],
+        },
+    },
     'author': 'Odoo S.A.',
     'license': 'LGPL-3',
     'live_test_url': 'https://theme-aviato.odoo.com',

--- a/theme_beauty/__manifest__.py
+++ b/theme_beauty/__manifest__.py
@@ -83,6 +83,13 @@
     'configurator_snippets': {
         'homepage': ['s_intro_pill', 's_masonry_block_mosaic_template', 's_pricelist_boxed', 's_features_wall', 's_image_frame', 's_call_to_action'],
     },
+    'configurator_snippets_addons': {
+        'website_sale': {
+            'homepage': [
+                ('website_sale.s_dynamic_snippet_products', 'after', 's_masonry_block_mosaic_template'),
+            ],
+        },
+    },
     'author': 'Odoo S.A.',
     'license': 'LGPL-3',
     'live_test_url': 'https://theme-beauty.odoo.com',

--- a/theme_bewise/__manifest__.py
+++ b/theme_bewise/__manifest__.py
@@ -26,6 +26,13 @@
     'configurator_snippets': {
         'homepage': ['s_striped_center_top', 's_title', 's_color_blocks_2', 's_faq_collapse', 's_masonry_block_default_template', 's_company_team_shapes'],
     },
+    'configurator_snippets_addons': {
+        'website_sale': {
+            'homepage': [
+                ('website_sale.s_dynamic_snippet_products', 'after', 's_title'),
+            ],
+        },
+    },
     'author': 'Odoo S.A.',
     'license': 'LGPL-3',
     'live_test_url': 'https://theme-bewise.odoo.com',

--- a/theme_bistro/__manifest__.py
+++ b/theme_bistro/__manifest__.py
@@ -81,6 +81,39 @@
         'homepage': ['s_image_title', 's_key_images', 's_pricelist_cafe', 's_quotes_carousel', 's_quadrant'],
         'pricing': ["s_text_image", "s_product_catalog"],
     },
+    'configurator_snippets_addons': {
+        'website_sale': {
+            'homepage': [
+                ('website_sale.s_dynamic_snippet_products', 'after', 's_key_images'),
+            ],
+        },
+    },
+    'theme_customizations': {
+        'website_sale.s_dynamic_snippet_products': {
+            'data_attributes': {
+                'number-of-records': '6',
+                'carousel-interval': '3000',
+            },
+            'background': {
+                'color': 'o_cc3',
+                'shape': {
+                    'data-oe-shape-data': '{"shape":"web_editor/Wavy/07","flip":["x"]}',
+                    'element': """<div class="o_we_shape o_web_editor_Airy_07_001" style="background-image: url(&quot;/web_editor/shape/web_editor/Airy/07_001.svg?c5=rgba(255,255,255,0.25)&quot;); left: -0.165px; right: -0.165px; background-position: 50% 0%;"/>""",
+                },
+            },
+            'add_classes': [
+                'o_wsale_products_opt_design_grid',
+                'o_wsale_products_opt_has_comparison',
+            ],
+            'remove_classes': [
+                'o_wsale_products_opt_design_thumbs',
+                'o_wsale_products_opt_has_description',
+            ],
+            'style': {
+                'color': 'brown',
+            },
+        },
+    },
     'author': 'Odoo S.A.',
     'license': 'LGPL-3',
     'live_test_url': 'https://theme-bistro.odoo.com',

--- a/theme_bookstore/__manifest__.py
+++ b/theme_bookstore/__manifest__.py
@@ -83,6 +83,13 @@
     'configurator_snippets': {
         'homepage': ['s_banner', 's_key_images', 's_title', 's_accordion_image', 's_cta_box'],
     },
+    'configurator_snippets_addons': {
+        'website_sale': {
+            'homepage': [
+                ('website_sale.s_dynamic_snippet_products', 'after', 's_key_images'),
+            ],
+        },
+    },
     'new_page_templates': {
         'about': {
             'personal': ['s_text_cover', 's_image_text', 's_text_block_h2', 's_numbers', 's_features', 's_call_to_action'],

--- a/theme_buzzy/__manifest__.py
+++ b/theme_buzzy/__manifest__.py
@@ -77,6 +77,13 @@
     'configurator_snippets': {
         'homepage': ['s_banner', 's_discovery', 's_showcase', 's_key_benefits', 's_accordion_image', 's_cta_box'],
     },
+    'configurator_snippets_addons': {
+        'website_sale': {
+            'homepage': [
+                ('website_sale.s_dynamic_snippet_products', 'after', 's_discovery'),
+            ],
+        },
+    },
     'new_page_templates': {
         'about': {
             'personal': ['s_text_cover', 's_image_text', 's_text_block_h2', 's_numbers', 's_features', 's_call_to_action'],

--- a/theme_clean/__manifest__.py
+++ b/theme_clean/__manifest__.py
@@ -64,6 +64,13 @@
     'configurator_snippets': {
         'homepage': ['s_banner', 's_color_blocks_2', 's_title', 's_text_image', 's_image_text', 's_numbers_showcase', 's_company_team', 's_accordion_image', 's_cta_card'], 
     },
+    'configurator_snippets_addons': {
+        'website_sale': {
+            'homepage': [
+                ('website_sale.s_dynamic_snippet_products', 'after', 's_color_blocks_2'),
+            ],
+        },
+    },
     'author': 'Odoo S.A.',
     'license': 'LGPL-3',
     'live_test_url': 'https://theme-clean.odoo.com',

--- a/theme_cobalt/__manifest__.py
+++ b/theme_cobalt/__manifest__.py
@@ -20,6 +20,13 @@
     'configurator_snippets': {
         'homepage': ['s_banner', 's_image_text', 's_key_images', 's_text_image', 's_company_team_detail', 's_references_grid'],
     },
+    'configurator_snippets_addons': {
+        'website_sale': {
+            'homepage': [
+                ('website_sale.s_dynamic_snippet_products', 'after', 's_image_text'),
+            ],
+        },
+    },
     'author': 'Odoo S.A.',
     'license': 'LGPL-3',
     'live_test_url': 'https://theme-cobalt.odoo.com',

--- a/theme_enark/__manifest__.py
+++ b/theme_enark/__manifest__.py
@@ -74,6 +74,13 @@
     'configurator_snippets': {
         'homepage': ['s_freegrid', 's_features_wall', 's_numbers_list', 's_title', 's_images_wall', 's_references', 's_cta_box'],
     },
+    'configurator_snippets_addons': {
+        'website_sale': {
+            'homepage': [
+                ('website_sale.s_dynamic_snippet_products', 'after', 's_features_wall'),
+            ],
+        },
+    },
     'new_page_templates': {
         'about': {
             'personal': ['s_text_cover', 's_image_text', 's_text_block_h2', 's_numbers', 's_features', 's_call_to_action'],

--- a/theme_graphene/__manifest__.py
+++ b/theme_graphene/__manifest__.py
@@ -22,6 +22,13 @@
     'configurator_snippets': {
         'homepage': ['s_cover', 's_text_image', 's_numbers_grid', 's_mockup_image', 's_comparisons', 's_references'],
     },
+    'configurator_snippets_addons': {
+        'website_sale': {
+            'homepage': [
+                ('website_sale.s_dynamic_snippet_products', 'after', 's_text_image'),
+            ],
+        },
+    },
     'new_page_templates': {
         'about': {
             'personal': ['s_text_cover', 's_image_text', 's_text_block_h2', 's_numbers', 's_features', 's_call_to_action'],

--- a/theme_kea/__manifest__.py
+++ b/theme_kea/__manifest__.py
@@ -75,6 +75,13 @@
     'configurator_snippets': {
         'homepage': ['s_cover', 's_text_image', 's_picture', 's_image_text', 's_color_blocks_2', 's_media_list'],
     },
+    'configurator_snippets_addons': {
+        'website_sale': {
+            'homepage': [
+                ('website_sale.s_dynamic_snippet_products', 'after', 's_text_image'),
+            ],
+        },
+    },
     'new_page_templates': {
         'about': {
             'personal': ['s_text_cover', 's_image_text', 's_text_block_h2', 's_numbers', 's_features', 's_call_to_action'],

--- a/theme_kiddo/__manifest__.py
+++ b/theme_kiddo/__manifest__.py
@@ -76,6 +76,13 @@
     'configurator_snippets': {
         'homepage': ['s_banner', 's_image_text', 's_three_columns', 's_product_list', 's_call_to_action'],
     },
+    'configurator_snippets_addons': {
+        'website_sale': {
+            'homepage': [
+                ('website_sale.s_dynamic_snippet_products', 'after', 's_image_text'),
+            ],
+        },
+    },
     'new_page_templates': {
         'about': {
             'personal': ['s_text_cover', 's_image_text', 's_text_block_h2', 's_numbers', 's_features', 's_call_to_action'],

--- a/theme_loftspace/__manifest__.py
+++ b/theme_loftspace/__manifest__.py
@@ -86,6 +86,13 @@
     'configurator_snippets': {
         'homepage': ['s_banner', 's_text_block', 's_striped', 's_key_images', 's_features', 's_quotes_carousel', 's_faq_collapse', 's_cta_box',],
     },
+    'configurator_snippets_addons': {
+        'website_sale': {
+            'homepage': [
+                ('website_sale.s_dynamic_snippet_products', 'after', 's_text_block'),
+            ],
+        },
+    },
     'new_page_templates': {
         'about': {
             'personal': ['s_text_cover', 's_image_text', 's_text_block_h2', 's_numbers', 's_features', 's_call_to_action'],

--- a/theme_monglia/__manifest__.py
+++ b/theme_monglia/__manifest__.py
@@ -37,6 +37,13 @@
     'configurator_snippets': {
         'homepage': ['s_cover', 's_numbers_grid', 's_company_team_shapes', 's_text_block', 's_freegrid', 's_cta_box', 's_shape_image', 's_title', 's_images_wall', 's_faq_collapse', 's_references'],
     },
+    'configurator_snippets_addons': {
+        'website_sale': {
+            'homepage': [
+                ('website_sale.s_dynamic_snippet_products', 'after', 's_numbers_grid'),
+            ],
+        },
+    },
     'new_page_templates': {
         'about': {
             'personal': ['s_text_cover', 's_image_text', 's_text_block_h2', 's_numbers', 's_features', 's_call_to_action'],

--- a/theme_nano/__manifest__.py
+++ b/theme_nano/__manifest__.py
@@ -86,6 +86,13 @@
     'configurator_snippets': {
         'homepage': ['s_discovery', 's_parallax', 's_text_block', 's_key_images', 's_image_text_overlap', 's_company_team_basic', 's_references', 's_numbers', 's_cta_box'],
     },
+    'configurator_snippets_addons': {
+        'website_sale': {
+            'homepage': [
+                ('website_sale.s_dynamic_snippet_products', 'after', 's_parallax'),
+            ],
+        },
+    },
     'new_page_templates': {
         'about': {
             'personal': ['s_text_cover', 's_image_text', 's_text_block_h2', 's_numbers', 's_features', 's_call_to_action'],

--- a/theme_notes/__manifest__.py
+++ b/theme_notes/__manifest__.py
@@ -96,6 +96,13 @@
     'configurator_snippets': {
         'homepage': ['s_framed_intro', 's_image_text', 's_three_columns', 's_images_wall', 's_text_image', 's_company_team_shapes', 's_title', 's_call_to_action'],
     },
+    'configurator_snippets_addons': {
+        'website_sale': {
+            'homepage': [
+                ('website_sale.s_dynamic_snippet_products', 'after', 's_image_text'),
+            ],
+        },
+    },
     'new_page_templates': {
         'about': {
             'personal': ['s_text_cover', 's_image_text', 's_text_block_h2', 's_numbers', 's_features', 's_call_to_action'],

--- a/theme_odoo_experts/__manifest__.py
+++ b/theme_odoo_experts/__manifest__.py
@@ -72,6 +72,13 @@
     'configurator_snippets': {
         'homepage': ['s_mockup_image', 's_references', 's_image_text', 's_text_image', 's_showcase', 's_faq_collapse', 's_cta_box'],
     },
+    'configurator_snippets_addons': {
+        'website_sale': {
+            'homepage': [
+                ('website_sale.s_dynamic_snippet_products', 'after', 's_references'),
+            ],
+        },
+    },
     'new_page_templates': {
         'about': {
             'personal': ['s_text_cover', 's_image_text', 's_text_block_h2', 's_numbers', 's_features', 's_call_to_action'],

--- a/theme_orchid/__manifest__.py
+++ b/theme_orchid/__manifest__.py
@@ -72,6 +72,13 @@
     'configurator_snippets': {
         'homepage': ['s_kickoff', 's_key_images', 's_process_steps', 's_freegrid', 's_image_text_overlap', 's_company_team_basic', 's_title', 's_images_wall', 's_references'],
     },
+    'configurator_snippets_addons': {
+        'website_sale': {
+            'homepage': [
+                ('website_sale.s_dynamic_snippet_products', 'after', 's_key_images'),
+            ],
+        },
+    },
     'new_page_templates': {
         'about': {
             'personal': ['s_text_cover', 's_image_text', 's_text_block_h2', 's_numbers', 's_features', 's_call_to_action'],

--- a/theme_paptic/__manifest__.py
+++ b/theme_paptic/__manifest__.py
@@ -20,6 +20,13 @@
     'configurator_snippets': {
         'homepage': ['s_cover', 's_references', 's_image_text', 's_text_image', 's_masonry_block_images_template', 's_faq_list', 's_cta_box'],
     },
+    'configurator_snippets_addons': {
+        'website_sale': {
+            'homepage': [
+                ('website_sale.s_dynamic_snippet_products', 'after', 's_references'),
+            ],
+        },
+    },
     'new_page_templates': {
         'about': {
             'personal': ['s_text_cover', 's_image_text', 's_text_block_h2', 's_numbers', 's_features', 's_call_to_action'],

--- a/theme_real_estate/__manifest__.py
+++ b/theme_real_estate/__manifest__.py
@@ -71,6 +71,60 @@
     'configurator_snippets': {
         'homepage': ['s_cover', 's_text_image', 's_image_text', 's_three_columns', 's_title', 's_references', 's_numbers_showcase', 's_quotes_carousel', 's_call_to_action'],
     },
+    'configurator_snippets_addons': {
+        'website_sale': {
+            'homepage': [
+                ('website_sale.s_dynamic_snippet_products', 'after', 's_cover'),
+                ('website_sale.s_dynamic_snippet_category_list', 'after', 's_text_image'),
+            ],
+        },
+    },
+    'theme_customizations': {
+        'website_sale.s_dynamic_snippet_products': {
+            'data_attributes': {
+                'number-of-records': '7',
+                'carousel-interval': '3000',
+            },
+            'background': {
+                'color': 'o_cc3',
+                'shape': {
+                    'data-oe-shape-data': '{"shape":"web_editor/Wavy/07","flip":["x"]}',
+                    'element': """<div class="o_we_shape o_web_editor_Airy_07_001" style="background-image: url(&quot;/web_editor/shape/web_editor/Airy/07_001.svg?c5=rgba(255,255,255,0.25)&quot;); left: -0.165px; right: -0.165px; background-position: 50% 0%;"/>""",
+                },
+            },
+            'add_classes': [
+                'o_wsale_products_opt_design_chips',
+                'o_wsale_products_opt_rounded_4',
+                'o_wsale_products_opt_has_comparison',
+                'o_wsale_products_opt_actions_inline',
+                'o_wsale_products_opt_actions_promote',
+                'o_wsale_products_opt_wishlist_inline',
+                'o_wsale_products_opt_cc',
+                'o_wsale_products_opt_cc1',
+            ],
+            'remove_classes': [
+                'o_wsale_products_opt_design_thumbs',
+                'o_wsale_products_opt_has_description',
+                'o_wsale_products_opt_actions_onhover',
+                'o_wsale_products_opt_actions_subtle',
+                'o_wsale_products_opt_wishlist_fixed',
+            ],
+            'style': {
+                '--o-wsale-products-grid-gap': '16px',
+                'color': 'green',
+            },
+        },
+        'website_sale.s_dynamic_snippet_category_list': {
+            'background': {
+                'color': 'o_cc4',
+                'image': 'background-image: url(&quot;/web_editor/shape/web_editor/Airy/07_001.svg?c5=rgba(255,255,255,0.25)&quot;); left: -0.165px; right: -0.165px;',
+                'shape': {
+                    'data-oe-shape-data': '{"shape":"web_editor/Wavy/07","flip":["x"]}',
+                    'element': """<div class="o_we_shape o_web_editor_Wavy_07" style="background-image: url('/web_editor/shape/web_editor/Wavy/07.svg?&amp;flip=x'); background-position: 50% 0%;"/>""",
+                },
+            },
+        },
+    },
     'new_page_templates': {
         'about': {
             'personal': ['s_text_cover', 's_image_text', 's_text_block_h2', 's_numbers', 's_features', 's_call_to_action'],

--- a/theme_treehouse/__manifest__.py
+++ b/theme_treehouse/__manifest__.py
@@ -80,6 +80,13 @@
     'configurator_snippets': {
         'homepage': ['s_sidegrid', 's_numbers_list', 's_color_blocks_2', 's_references', 's_freegrid'],
     },
+    'configurator_snippets_addons': {
+        'website_sale': {
+            'homepage': [
+                ('website_sale.s_dynamic_snippet_products', 'after', 's_numbers_list'),
+            ],
+        },
+    },
     'new_page_templates': {
         'about': {
             'personal': ['s_text_cover', 's_image_text', 's_text_block_h2', 's_numbers', 's_features', 's_call_to_action'],

--- a/theme_vehicle/__manifest__.py
+++ b/theme_vehicle/__manifest__.py
@@ -34,6 +34,13 @@
     'configurator_snippets': {
         'homepage': ['s_cover', 's_title', 's_three_columns', 's_picture', 's_key_images', 's_numbers_charts', 's_media_list'],
     },
+    'configurator_snippets_addons': {
+        'website_sale': {
+            'homepage': [
+                ('website_sale.s_dynamic_snippet_products', 'after', 's_title'),
+            ],
+        },
+    },
     'new_page_templates': {
         'about': {
             'personal': ['s_text_cover', 's_image_text', 's_text_block_h2', 's_numbers', 's_features', 's_call_to_action'],

--- a/theme_yes/__manifest__.py
+++ b/theme_yes/__manifest__.py
@@ -91,6 +91,13 @@
     'configurator_snippets': {
         'homepage': ['s_kickoff', 's_title', 's_company_team', 's_image_text_overlap', 's_features', 's_freegrid', 's_quotes_carousel', 's_call_to_action'],
     },
+    'configurator_snippets_addons': {
+        'website_sale': {
+            'homepage': [
+                ('website_sale.s_dynamic_snippet_products', 'after', 's_title'),
+            ],
+        },
+    },
     'new_page_templates': {
         'about': {
             'personal': ['s_text_cover', 's_image_text', 's_text_block_h2', 's_numbers', 's_features', 's_call_to_action'],

--- a/theme_zap/__manifest__.py
+++ b/theme_zap/__manifest__.py
@@ -71,6 +71,13 @@
     'configurator_snippets': {
         'homepage': ['s_discovery', 's_key_images', 's_striped', 's_showcase', 's_image_title', 's_numbers_charts', 's_cta_card'],
     },
+    'configurator_snippets_addons': {
+        'website_sale': {
+            'homepage': [
+                ('website_sale.s_dynamic_snippet_products', 'after', 's_key_images'),
+            ],
+        },
+    },
     'new_page_templates': {
         'about': {
             'personal': ['s_text_cover', 's_image_text', 's_text_block_h2', 's_numbers', 's_features', 's_call_to_action'],


### PR DESCRIPTION
Desired behavior after PR is merged:
- configurator_snippets now includes an e-commerce-specific homepage list to define which snippets should be loaded when the website_sale is installed during website creation via the configurator.

Related: https://github.com/odoo/odoo/pull/203436

task-4502087