### PR TITLE
[FIX] theme_test_custo: rename wrong template parent

### DIFF
--- a/theme_test_custo/static/src/builder/footer.xml
+++ b/theme_test_custo/static/src/builder/footer.xml
@@ -2,7 +2,7 @@
 <templates xml:space="preserve">
 
 <!-- Theme Footer - Option -->
-<t t-name="theme_test_custo.FooterTemplateOption" t-inherit="html_builder.FooterTemplateOption" t-inherit-mode="extension">
+<t t-name="theme_test_custo.FooterTemplateOption" t-inherit="website.FooterTemplateOption" t-inherit-mode="extension">
     <xpath expr="//BuilderSelect[@action=&quot;'websiteConfigFooter'&quot;]" position="inside">
         <BuilderSelectItem title.translate="Custom Theme"
                 actionParam="{ view: 'theme_test_custo.template_footer_custom', vars: { 'footer-template': 'custom-theme' } }"


### PR DESCRIPTION
[FIX] theme_test_custo: rename wrong template

[1] adapted the code to work with the new website builder (introduced by
[2]). The problem is that since [3], some templates have been renamed
and `html_builder.FooterTemplateOption` became
`website.FooterTemplateOption`. The commit changes the occurrence of
`html_builder.FooterTemplateOption` into `website.FooterTemplateOption`
in `design-themes`.

[1]: https://github.com/odoo/design-themes/commit/0ce1455aac7d95154b92daa98fb8ffbf27d12f1a
[2]: https://github.com/odoo/odoo/commit/9fe45e2b7ddbbfd0445ffe25a859e67a316d02b2
[3]: https://github.com/odoo/odoo/commit/f32212f6a4e1c9915791a5d4d63a57bbcb40ac61

runbot-226494