### PR TITLE
[FIX] test_themes: use new website switcher systray

### DIFF
--- a/test_themes/static/src/systray_items/website_switcher.js
+++ b/test_themes/static/src/systray_items/website_switcher.js
@@ -2,10 +2,10 @@
 
 import { patch } from "@web/core/utils/patch";
 import { useService } from '@web/core/utils/hooks';
-import { WebsiteSwitcherSystray } from '@website/systray_items/website_switcher';
+import { WebsiteSwitcherSystrayItem } from "@website/client_actions/website_preview/website_switcher_systray_item";
 import { onMounted, useState } from "@odoo/owl";
 
-patch(WebsiteSwitcherSystray.prototype, {
+patch(WebsiteSwitcherSystrayItem.prototype, {
     setup() {
         super.setup();
 
@@ -39,5 +39,5 @@ patch(WebsiteSwitcherSystray.prototype, {
         });
     },
 
-    template: 'test_themes.WebsiteSwitcherSystray',
+    template: "test_themes.WebsiteSwitcherSystrayItem",
 });

--- a/test_themes/static/src/systray_items/website_switcher.xml
+++ b/test_themes/static/src/systray_items/website_switcher.xml
@@ -4,7 +4,7 @@
     <img t-att-src="url" width="150"/>
 </t>
 
-<t t-name="test_themes.WebsiteSwitcherSystray" t-inherit="website.WebsiteSwitcherSystray" t-inherit-mode="extension">
+<t t-name="test_themes.WebsiteSwitcherSystrayItem" t-inherit="website.WebsiteSwitcherSystrayItem" t-inherit-mode="extension">
     <!-- With this module installed, disable the warning -->
     <xpath expr="//DropdownItem/t[@t-if='!element.domain']" position="replace">
     </xpath>


### PR DESCRIPTION
Commit [e96ce8ed] deleted the old website systray items, which have been moved and slightly rewritten with the [refactor into html_builder]. In the process, patches made in test_themes were overlooked. This commit makes sure to patch the right component and template.

[e96ce8ed]: https://github.com/odoo/odoo/commit/e96ce8edb020b55bc6ccd7fa579f31ee80d600f7
[refactor into html_builder]: https://github.com/odoo/odoo/commit/9fe45e2b7ddb

runbot-226545