### PR TITLE
[FIX] theme_test_custo: correct tour trigger to look for svg images

### DIFF
--- a/theme_test_custo/static/src/builder/footer.xml
+++ b/theme_test_custo/static/src/builder/footer.xml
@@ -7,7 +7,7 @@
         <BuilderSelectItem title.translate="Custom Theme"
                 actionParam="{ view: 'theme_test_custo.template_footer_custom', vars: { 'footer-template': 'custom-theme' } }"
         >
-            <Img src="'/theme_test_custo/static/src/img/template_footer_opt.svg'"/>
+            <Img src="'/theme_test_custo/static/src/img/template_footer_opt.svg'" class="'theme_test_custo_footer'"/>
         </BuilderSelectItem>
     </xpath>
 </t>

--- a/theme_test_custo/static/src/builder/header.xml
+++ b/theme_test_custo/static/src/builder/header.xml
@@ -16,7 +16,7 @@
                     },
                 ]"
         >
-            <Img src="'/theme_test_custo/static/src/img/template_header_opt.svg'"/>
+            <Img src="'/theme_test_custo/static/src/img/template_header_opt.svg'" class="'theme_test_custo_header'"/>
         </BuilderSelectItem>
     </xpath>
 </t>

--- a/theme_test_custo/static/tests/tours/theme_menu_hierarchies.js
+++ b/theme_test_custo/static/tests/tours/theme_menu_hierarchies.js
@@ -39,7 +39,7 @@ wTourUtils.registerWebsitePreviewTour('theme_menu_hierarchies', {
         run: "click",
     }, {
         content: 'The theme custom footer template should be listed and selected',
-        trigger: '[data-container-title="Footer"] [data-label="Template"] button.btn-primary img[src*="/theme_test_custo"]',
+        trigger: '[data-container-title="Footer"] [data-label="Template"] button.btn-secondary svg.theme_test_custo_footer',
         run: () => null, // It's a check.
     }, {
         content: 'Click on header',
@@ -47,7 +47,7 @@ wTourUtils.registerWebsitePreviewTour('theme_menu_hierarchies', {
         run: "click",
     }, {
         content: 'The theme custom header template should be listed and selected',
-        trigger: '[data-container-title="Header"] [data-label="Template"] button.btn-primary img[src*="/theme_test_custo"]',
+        trigger: '[data-container-title="Header"] [data-label="Template"] button.btn-secondary svg.theme_test_custo_header',
         run: () => null, // It's a check.
     }, {
         content: 'Click on image which has a shape',
@@ -63,7 +63,7 @@ wTourUtils.registerWebsitePreviewTour('theme_menu_hierarchies', {
         run: "click",
     }, {
         content: 'The theme custom "Curve 01" shape should be listed and selected',
-        trigger: '[data-container-title="Text"] [data-label="Shape"] button.btn-primary:contains("Curve 01")',
+        trigger: '[data-container-title="Text"] [data-label="Shape"] button.btn-secondary:contains("Curve 01")',
         run: () => null, // It's a check.
     },
 ]);


### PR DESCRIPTION
Since [1], the test "test_01_menu_hierarchies" fails.

Note that the check is not as strong as before as we cannot check the source of the image.

Since [2], the btn-primary is now btn-secondary

---

[1]: https://github.com/odoo/odoo/commit/3cc5ff6e96493f2b068090f880987def3787895e
[2]: https://github.com/odoo/odoo/commit/eca4d1b1d4ea58959793b0a2cbfa443308759372

runbot-226641