### PR TITLE
[FIX] theme_*: upgrade image datasets

### DIFF
--- a/theme_anelusia/views/snippets/s_accordion_image.xml
+++ b/theme_anelusia/views/snippets/s_accordion_image.xml
@@ -8,7 +8,7 @@
     <xpath expr="//img" position="attributes">
         <attribute name="src">/web_editor/image_shape/website.s_accordion_image_default_image/web_editor/solid/solid_square_1.svg?c2=o-color-1</attribute>
         <attribute name="data-shape">web_editor/solid/solid_square_1</attribute>
-        <attribute name="data-original-mimetype">image/webp</attribute>
+        <attribute name="data-format-mimetype">image/webp</attribute>
         <attribute name="data-file-name">s_accordion_image_default_image.svg</attribute>
         <attribute name="data-shape-colors">;o-color-1;;;</attribute>
     </xpath>

--- a/theme_anelusia/views/snippets/s_company_team.xml
+++ b/theme_anelusia/views/snippets/s_company_team.xml
@@ -27,7 +27,7 @@
     <xpath expr="//img" position="attributes">
         <attribute name="src">/web_editor/image_shape/website.s_company_team_image_1/web_editor/geometric/geo_square_1.svg</attribute>
         <attribute name="data-shape">web_editor/geometric/geo_square_1</attribute>
-        <attribute name="data-original-mimetype">image/webp</attribute>
+        <attribute name="data-format-mimetype">image/webp</attribute>
         <attribute name="data-file-name">uiface_1.svg</attribute>
         <attribute name="data-shape-colors">;;;;</attribute>
     </xpath>
@@ -53,7 +53,7 @@
     <xpath expr="(//img)[2]" position="attributes">
         <attribute name="src">/web_editor/image_shape/website.s_company_team_image_2/web_editor/geometric/geo_square_2.svg</attribute>
         <attribute name="data-shape">web_editor/geometric/geo_square_2</attribute>
-        <attribute name="data-original-mimetype">image/webp</attribute>
+        <attribute name="data-format-mimetype">image/webp</attribute>
         <attribute name="data-file-name">uiface_2.svg</attribute>
         <attribute name="data-shape-colors">;;;;</attribute>
     </xpath>
@@ -78,7 +78,7 @@
     <xpath expr="(//img)[3]" position="attributes">
         <attribute name="src">/web_editor/image_shape/website.s_company_team_image_3/web_editor/geometric/geo_square_3.svg</attribute>
         <attribute name="data-shape">web_editor/geometric/geo_square_3</attribute>
-        <attribute name="data-original-mimetype">image/webp</attribute>
+        <attribute name="data-format-mimetype">image/webp</attribute>
         <attribute name="data-file-name">uiface_3.svg</attribute>
         <attribute name="data-shape-colors">;;;;</attribute>
     </xpath>
@@ -103,7 +103,7 @@
     <xpath expr="(//img)[4]" position="attributes">
         <attribute name="src">/web_editor/image_shape/website.s_company_team_image_4/web_editor/geometric/geo_square_1.svg</attribute>
         <attribute name="data-shape">web_editor/geometric/geo_square_1</attribute>
-        <attribute name="data-original-mimetype">image/webp</attribute>
+        <attribute name="data-format-mimetype">image/webp</attribute>
         <attribute name="data-file-name">uiface_4.svg</attribute>
         <attribute name="data-shape-colors">;;;;</attribute>
     </xpath>

--- a/theme_anelusia/views/snippets/s_company_team_basic.xml
+++ b/theme_anelusia/views/snippets/s_company_team_basic.xml
@@ -15,7 +15,7 @@
         <attribute name="class" remove="rounded-circle" separator=" "/>
         <attribute name="src">/web_editor/image_shape/website.s_company_team_image_1/web_editor/geometric/geo_square_6.svg</attribute>
         <attribute name="data-shape">web_editor/geometric/geo_square_6</attribute>
-        <attribute name="data-original-mimetype">image/webp</attribute>
+        <attribute name="data-format-mimetype">image/webp</attribute>
         <attribute name="data-file-name">uiface_1.svg</attribute>
         <attribute name="data-shape-colors">;;;;</attribute>
     </xpath>
@@ -33,7 +33,7 @@
         <attribute name="class" remove="rounded-circle" separator=" "/>
         <attribute name="src">/web_editor/image_shape/website.s_company_team_image_2/web_editor/geometric/geo_square_4.svg</attribute>
         <attribute name="data-shape">web_editor/geometric/geo_square_4</attribute>
-        <attribute name="data-original-mimetype">image/webp</attribute>
+        <attribute name="data-format-mimetype">image/webp</attribute>
         <attribute name="data-file-name">uiface_2.svg</attribute>
         <attribute name="data-shape-colors">;;;;</attribute>
     </xpath>
@@ -51,7 +51,7 @@
         <attribute name="class" remove="rounded-circle" separator=" "/>
         <attribute name="src">/web_editor/image_shape/website.s_company_team_image_3/web_editor/geometric/geo_square_3.svg</attribute>
         <attribute name="data-shape">web_editor/geometric/geo_square_3</attribute>
-        <attribute name="data-original-mimetype">image/webp</attribute>
+        <attribute name="data-format-mimetype">image/webp</attribute>
         <attribute name="data-file-name">uiface_3.svg</attribute>
         <attribute name="data-shape-colors">;;;;</attribute>
     </xpath>
@@ -69,7 +69,7 @@
         <attribute name="class" remove="rounded-circle" separator=" "/>
         <attribute name="src">/web_editor/image_shape/website.s_company_team_image_4/web_editor/geometric/geo_square_5.svg</attribute>
         <attribute name="data-shape">web_editor/geometric/geo_square_5</attribute>
-        <attribute name="data-original-mimetype">image/webp</attribute>
+        <attribute name="data-format-mimetype">image/webp</attribute>
         <attribute name="data-file-name">uiface_4.svg</attribute>
         <attribute name="data-shape-colors">;;;;</attribute>
     </xpath>

--- a/theme_anelusia/views/snippets/s_company_team_grid.xml
+++ b/theme_anelusia/views/snippets/s_company_team_grid.xml
@@ -13,7 +13,7 @@
     <xpath expr="//img" position="attributes">
         <attribute name="src">/web_editor/image_shape/website.s_company_team_image_1/web_editor/composition/composition_square_4.svg?c2=o-color-2&amp;c5=o-color-3</attribute>
         <attribute name="data-shape">web_editor/composition/composition_square_4</attribute>
-        <attribute name="data-original-mimetype">image/webp</attribute>
+        <attribute name="data-format-mimetype">image/webp</attribute>
         <attribute name="data-file-name">uiface_1.svg</attribute>
         <attribute name="data-shape-colors">;o-color-2;;;o-color-3</attribute>
     </xpath>
@@ -24,7 +24,7 @@
     <xpath expr="(//img)[2]" position="attributes">
         <attribute name="src">/web_editor/image_shape/website.s_company_team_image_2/web_editor/solid/solid_square_2.svg?c1=o-color-1</attribute>
         <attribute name="data-shape">web_editor/solid/solid_square_2</attribute>
-        <attribute name="data-original-mimetype">image/webp</attribute>
+        <attribute name="data-format-mimetype">image/webp</attribute>
         <attribute name="data-file-name">uiface_2.svg</attribute>
         <attribute name="data-shape-colors">o-color-1;;;;</attribute>
     </xpath>
@@ -35,7 +35,7 @@
     <xpath expr="(//img)[3]" position="attributes">
         <attribute name="src">/web_editor/image_shape/website.s_company_team_image_3/web_editor/composition/composition_square_2.svg?c2=o-color-3&amp;c5=o-color-2</attribute>
         <attribute name="data-shape">web_editor/composition/composition_square_2</attribute>
-        <attribute name="data-original-mimetype">image/webp</attribute>
+        <attribute name="data-format-mimetype">image/webp</attribute>
         <attribute name="data-file-name">uiface_3.svg</attribute>
         <attribute name="data-shape-colors">;o-color-3;;;o-color-2</attribute>
     </xpath>
@@ -46,7 +46,7 @@
     <xpath expr="(//img)[4]" position="attributes">
         <attribute name="src">/web_editor/image_shape/website.s_company_team_image_4/web_editor/composition/composition_square_1.svg?c1=o-color-3&amp;c2=o-color-1</attribute>
         <attribute name="data-shape">web_editor/composition/composition_square_1</attribute>
-        <attribute name="data-original-mimetype">image/webp</attribute>
+        <attribute name="data-format-mimetype">image/webp</attribute>
         <attribute name="data-file-name">uiface_4.svg</attribute>
         <attribute name="data-shape-colors">o-color-3;o-color-1;;;</attribute>
     </xpath>
@@ -57,7 +57,7 @@
     <xpath expr="(//img)[5]" position="attributes">
         <attribute name="src">/web_editor/image_shape/website.s_company_team_image_5/web_editor/solid/solid_square_1.svg?c2=o-color-2</attribute>
         <attribute name="data-shape">web_editor/solid/solid_square_1</attribute>
-        <attribute name="data-original-mimetype">image/webp</attribute>
+        <attribute name="data-format-mimetype">image/webp</attribute>
         <attribute name="data-file-name">uiface_5.svg</attribute>
         <attribute name="data-shape-colors">;o-color-2;;;</attribute>
     </xpath>
@@ -68,7 +68,7 @@
     <xpath expr="(//img)[6]" position="attributes">
         <attribute name="src">/web_editor/image_shape/website.s_company_team_image_6/web_editor/composition/composition_square_3.svg?c1=o-color-1&amp;c5=o-color-3</attribute>
         <attribute name="data-shape">web_editor/composition/composition_square_3</attribute>
-        <attribute name="data-original-mimetype">image/webp</attribute>
+        <attribute name="data-format-mimetype">image/webp</attribute>
         <attribute name="data-file-name">uiface_6.svg</attribute>
         <attribute name="data-shape-colors">o-color-1;;;;o-color-3</attribute>
     </xpath>

--- a/theme_anelusia/views/snippets/s_image_text.xml
+++ b/theme_anelusia/views/snippets/s_image_text.xml
@@ -6,7 +6,7 @@
     <xpath expr="//img" position="attributes">
         <attribute name="src">/web_editor/image_shape/website.s_image_text_default_image/web_editor/composition/composition_square_1.svg?c1=o-color-1&amp;c2=o-color-3</attribute>
         <attribute name="data-shape">web_editor/composition/composition_square_1</attribute>
-        <attribute name="data-original-mimetype">image/webp</attribute>
+        <attribute name="data-format-mimetype">image/webp</attribute>
         <attribute name="data-file-name">s_image_text.svg</attribute>
         <attribute name="data-shape-colors">o-color-1;o-color-3;;;</attribute>
     </xpath>

--- a/theme_anelusia/views/snippets/s_key_images.xml
+++ b/theme_anelusia/views/snippets/s_key_images.xml
@@ -9,14 +9,14 @@
     <xpath expr="//img" position="attributes">
         <attribute name="src">/web_editor/image_shape/website.s_key_images_default_image_1/web_editor/geometric/geo_square_6.svg</attribute>
         <attribute name="data-shape">web_editor/geometric/geo_square_6</attribute>
-        <attribute name="data-original-mimetype">image/webp</attribute>
+        <attribute name="data-format-mimetype">image/webp</attribute>
         <attribute name="data-file-name">s_key_images_default_image_1.svg</attribute>
         <attribute name="data-shape-colors">;;;;</attribute>
     </xpath>
     <xpath expr="(//img)[4]" position="attributes">
         <attribute name="src">/web_editor/image_shape/website.s_key_images_default_image_4/web_editor/geometric/geo_square_5.svg</attribute>
         <attribute name="data-shape">web_editor/geometric/geo_square_5</attribute>
-        <attribute name="data-original-mimetype">image/webp</attribute>
+        <attribute name="data-format-mimetype">image/webp</attribute>
         <attribute name="data-file-name">s_key_images_default_image_4.svg</attribute>
         <attribute name="data-shape-colors">;;;;</attribute>
     </xpath>

--- a/theme_anelusia/views/snippets/s_media_list.xml
+++ b/theme_anelusia/views/snippets/s_media_list.xml
@@ -19,7 +19,7 @@
     <xpath expr="//div[hasclass('s_media_list_img_wrapper')]//img" position="attributes">
         <attribute name="src">/web_editor/image_shape/website.s_media_list_default_image_1/web_editor/composition/composition_square_1.svg?c1=o-color-4&amp;c2=o-color-2</attribute>
         <attribute name="data-shape">web_editor/composition/composition_square_1</attribute>
-        <attribute name="data-original-mimetype">image/webp</attribute>
+        <attribute name="data-format-mimetype">image/webp</attribute>
         <attribute name="data-file-name">s_media_list_1.svg</attribute>
         <attribute name="data-shape-colors">o-color-4;o-color-2;;;</attribute>
     </xpath>
@@ -48,7 +48,7 @@
     <xpath expr="(//div[hasclass('s_media_list_img_wrapper')])[2]//img" position="attributes">
         <attribute name="src">/web_editor/image_shape/website.s_media_list_default_image_2/web_editor/composition/composition_square_3.svg?c1=o-color-1&amp;c5=o-color-2</attribute>
         <attribute name="data-shape">web_editor/composition/composition_square_3</attribute>
-        <attribute name="data-original-mimetype">image/webp</attribute>
+        <attribute name="data-format-mimetype">image/webp</attribute>
         <attribute name="data-file-name">s_media_list_2.svg</attribute>
         <attribute name="data-shape-colors">o-color-1;;;;o-color-2</attribute>
     </xpath>

--- a/theme_anelusia/views/snippets/s_product_list.xml
+++ b/theme_anelusia/views/snippets/s_product_list.xml
@@ -29,7 +29,7 @@
     <xpath expr="//img" position="attributes">
         <attribute name="src">/web_editor/image_shape/website.s_product_list_default_image_1/web_editor/geometric/geo_square_1.svg</attribute>
         <attribute name="data-shape">web_editor/geometric/geo_square_1</attribute>
-        <attribute name="data-original-mimetype">image/webp</attribute>
+        <attribute name="data-format-mimetype">image/webp</attribute>
         <attribute name="data-file-name">s_product_1.svg</attribute>
         <attribute name="data-shape-colors">;;;;</attribute>
     </xpath>
@@ -37,7 +37,7 @@
     <xpath expr="(//img)[2]" position="attributes">
         <attribute name="src">/web_editor/image_shape/website.s_product_list_default_image_2/web_editor/geometric/geo_square_3.svg</attribute>
         <attribute name="data-shape">web_editor/geometric/geo_square_3</attribute>
-        <attribute name="data-original-mimetype">image/webp</attribute>
+        <attribute name="data-format-mimetype">image/webp</attribute>
         <attribute name="data-file-name">s_product_2.svg</attribute>
         <attribute name="data-shape-colors">;;;;</attribute>
     </xpath>
@@ -45,7 +45,7 @@
     <xpath expr="(//img)[3]" position="attributes">
         <attribute name="src">/web_editor/image_shape/website.s_product_list_default_image_3/web_editor/geometric/geo_square_2.svg</attribute>
         <attribute name="data-shape">web_editor/geometric/geo_square_2</attribute>
-        <attribute name="data-original-mimetype">image/webp</attribute>
+        <attribute name="data-format-mimetype">image/webp</attribute>
         <attribute name="data-file-name">s_product_3.svg</attribute>
         <attribute name="data-shape-colors">;;;;</attribute>
     </xpath>
@@ -53,7 +53,7 @@
     <xpath expr="(//img)[4]" position="attributes">
         <attribute name="src">/web_editor/image_shape/website.s_product_list_default_image_4/web_editor/geometric/geo_square_1.svg</attribute>
         <attribute name="data-shape">web_editor/geometric/geo_square_1</attribute>
-        <attribute name="data-original-mimetype">image/webp</attribute>
+        <attribute name="data-format-mimetype">image/webp</attribute>
         <attribute name="data-file-name">s_product_4.svg</attribute>
         <attribute name="data-shape-colors">;;;;</attribute>
     </xpath>
@@ -61,7 +61,7 @@
     <xpath expr="(//img)[5]" position="attributes">
         <attribute name="src">/web_editor/image_shape/website.s_product_list_default_image_5/web_editor/geometric/geo_square_2.svg</attribute>
         <attribute name="data-shape">web_editor/geometric/geo_square_2</attribute>
-        <attribute name="data-original-mimetype">image/webp</attribute>
+        <attribute name="data-format-mimetype">image/webp</attribute>
         <attribute name="data-file-name">s_product_5.svg</attribute>
         <attribute name="data-shape-colors">;;;;</attribute>
     </xpath>
@@ -69,7 +69,7 @@
     <xpath expr="(//img)[6]" position="attributes">
         <attribute name="src">/web_editor/image_shape/website.s_product_list_default_image_6/web_editor/geometric/geo_square_3.svg</attribute>
         <attribute name="data-shape">web_editor/geometric/geo_square_3</attribute>
-        <attribute name="data-original-mimetype">image/webp</attribute>
+        <attribute name="data-format-mimetype">image/webp</attribute>
         <attribute name="data-file-name">s_product_6.svg</attribute>
         <attribute name="data-shape-colors">;;;;</attribute>
     </xpath>

--- a/theme_anelusia/views/snippets/s_text_image.xml
+++ b/theme_anelusia/views/snippets/s_text_image.xml
@@ -10,7 +10,7 @@
     <xpath expr="//img" position="attributes">
         <attribute name="src">/web_editor/image_shape/website.s_text_image_default_image/web_editor/composition/composition_square_3.svg?c1=o-color-2&amp;c5=o-color-1</attribute>
         <attribute name="data-shape">web_editor/composition/composition_square_3</attribute>
-        <attribute name="data-original-mimetype">image/webp</attribute>
+        <attribute name="data-format-mimetype">image/webp</attribute>
         <attribute name="data-file-name">s_text_image.svg</attribute>
         <attribute name="data-shape-colors">o-color-2;;;;o-color-1</attribute>
     </xpath>

--- a/theme_anelusia/views/snippets/s_wavy_grid.xml
+++ b/theme_anelusia/views/snippets/s_wavy_grid.xml
@@ -11,14 +11,14 @@
     <xpath expr="//img" position="attributes">
         <attribute name="src">/web_editor/image_shape/website.s_wavy_grid_default_image_1/web_editor/geometric/geo_square_3.svg</attribute>
         <attribute name="data-shape">web_editor/geometric/geo_square_3</attribute>
-        <attribute name="data-original-mimetype">image/webp</attribute>
+        <attribute name="data-format-mimetype">image/webp</attribute>
         <attribute name="data-file-name">s_wavy_grid_default_image_1.svg</attribute>
         <attribute name="data-shape-colors">;;;;</attribute>
     </xpath>
     <xpath expr="(//img)[4]" position="attributes">
         <attribute name="src">/web_editor/image_shape/website.s_wavy_grid_default_image_4/web_editor/geometric/geo_square_6.svg</attribute>
         <attribute name="data-shape">web_editor/geometric/geo_square_6</attribute>
-        <attribute name="data-original-mimetype">image/webp</attribute>
+        <attribute name="data-format-mimetype">image/webp</attribute>
         <attribute name="data-file-name">s_wavy_grid_default_image_4.svg</attribute>
         <attribute name="data-shape-colors">;;;;</attribute>
     </xpath>

--- a/theme_artists/views/snippets/s_accordion_image.xml
+++ b/theme_artists/views/snippets/s_accordion_image.xml
@@ -8,7 +8,7 @@
     <xpath expr="//img" position="attributes">
         <attribute name="src">/web_editor/image_shape/website.s_accordion_image_default_image/web_editor/geometric/geo_square_3.svg</attribute>
         <attribute name="data-shape">web_editor/geometric/geo_square_3</attribute>
-        <attribute name="data-original-mimetype">image/webp</attribute>
+        <attribute name="data-format-mimetype">image/webp</attribute>
         <attribute name="data-file-name">s_accordion_image_default_image.svg</attribute>
         <attribute name="data-shape-colors">;;;;</attribute>
     </xpath>

--- a/theme_artists/views/snippets/s_image_text.xml
+++ b/theme_artists/views/snippets/s_image_text.xml
@@ -17,7 +17,7 @@
     <xpath expr="//img" position="attributes">
         <attribute name="src">/web_editor/image_shape/website.s_image_text_default_image/web_editor/geometric/geo_square_3.svg</attribute>
         <attribute name="data-shape">web_editor/geometric/geo_square_3</attribute>
-        <attribute name="data-original-mimetype">image/webp</attribute>
+        <attribute name="data-format-mimetype">image/webp</attribute>
         <attribute name="data-file-name">s_image_text.svg</attribute>
         <attribute name="data-shape-colors">;;;;</attribute>
     </xpath>

--- a/theme_artists/views/snippets/s_text_image.xml
+++ b/theme_artists/views/snippets/s_text_image.xml
@@ -24,7 +24,7 @@
     <xpath expr="//img" position="attributes">
         <attribute name="src">/web_editor/image_shape/website.s_text_image_default_image/web_editor/geometric/geo_square_2.svg</attribute>
         <attribute name="data-shape">web_editor/geometric/geo_square_2</attribute>
-        <attribute name="data-original-mimetype">image/webp</attribute>
+        <attribute name="data-format-mimetype">image/webp</attribute>
         <attribute name="data-file-name">s_text_image.svg</attribute>
         <attribute name="data-shape-colors">;;;;</attribute>
     </xpath>

--- a/theme_avantgarde/views/customizations.xml
+++ b/theme_avantgarde/views/customizations.xml
@@ -126,7 +126,7 @@
     <xpath expr="//img" position="attributes">
         <attribute name="src">/web_editor/image_shape/website.s_picture_default_image/web_editor/panel/panel_duo_step.svg</attribute>
         <attribute name="data-shape">web_editor/panel/panel_duo_step</attribute>
-        <attribute name="data-original-mimetype">image/webp</attribute>
+        <attribute name="data-format-mimetype">image/webp</attribute>
         <attribute name="data-file-name">bg_image_14.svg</attribute>
     </xpath>
     <xpath expr="//figcaption" position="attributes">
@@ -211,7 +211,7 @@
     <xpath expr="//img" position="attributes">
         <attribute name="src">/web_editor/image_shape/website.s_text_image_default_image/web_editor/panel/panel_trio_out_r.svg</attribute>
         <attribute name="data-shape">web_editor/panel/panel_trio_out_r</attribute>
-        <attribute name="data-original-mimetype">image/webp</attribute>
+        <attribute name="data-format-mimetype">image/webp</attribute>
         <attribute name="data-file-name">bg_image_13.svg</attribute>
     </xpath>
 </template>
@@ -812,7 +812,7 @@
     <xpath expr="//img" position="attributes">
         <attribute name="src">/web_editor/image_shape/website.s_company_team_image_1/web_editor/geometric_round/geo_round_gem.svg</attribute>
         <attribute name="data-shape">web_editor/geometric_round/geo_round_gem</attribute>
-        <attribute name="data-original-mimetype">image/jpeg</attribute>
+        <attribute name="data-format-mimetype">image/jpeg</attribute>
         <attribute name="data-file-name">uiface_1.svg</attribute>
         <attribute name="data-shape-colors">;;;;</attribute>
     </xpath>
@@ -824,7 +824,7 @@
         <attribute name="src">/web_editor/image_shape/website.s_company_team_image_2/web_editor/geometric_round/geo_round_gem.svg</attribute>
         <attribute name="data-shape">web_editor/geometric_round/geo_round_gem</attribute>
         <attribute name="data-shape-rotate">90</attribute>
-        <attribute name="data-original-mimetype">image/jpeg</attribute>
+        <attribute name="data-format-mimetype">image/jpeg</attribute>
         <attribute name="data-file-name">uiface_1.svg</attribute>
         <attribute name="data-shape-colors">;;;;</attribute>
     </xpath>
@@ -836,7 +836,7 @@
         <attribute name="src">/web_editor/image_shape/website.s_company_team_image_3/web_editor/geometric_round/geo_round_gem.svg</attribute>
         <attribute name="data-shape">web_editor/geometric_round/geo_round_gem</attribute>
         <attribute name="data-shape-flip">x</attribute>
-        <attribute name="data-original-mimetype">image/jpeg</attribute>
+        <attribute name="data-format-mimetype">image/jpeg</attribute>
         <attribute name="data-file-name">uiface_1.svg</attribute>
         <attribute name="data-shape-colors">;;;;</attribute>
     </xpath>
@@ -848,7 +848,7 @@
         <attribute name="src">/web_editor/image_shape/website.s_company_team_image_4/web_editor/geometric_round/geo_round_gem.svg</attribute>
         <attribute name="data-shape">web_editor/geometric_round/geo_round_gem</attribute>
         <attribute name="data-shape-flip">y</attribute>
-        <attribute name="data-original-mimetype">image/jpeg</attribute>
+        <attribute name="data-format-mimetype">image/jpeg</attribute>
         <attribute name="data-file-name">uiface_1.svg</attribute>
         <attribute name="data-shape-colors">;;;;</attribute>
     </xpath>
@@ -859,7 +859,7 @@
     <xpath expr="(//img)[5]" position="attributes">
         <attribute name="src">/web_editor/image_shape/website.s_company_team_image_5/web_editor/geometric_round/geo_round_gem.svg</attribute>
         <attribute name="data-shape">web_editor/geometric_round/geo_round_gem</attribute>
-        <attribute name="data-original-mimetype">image/jpeg</attribute>
+        <attribute name="data-format-mimetype">image/jpeg</attribute>
         <attribute name="data-file-name">uiface_1.svg</attribute>
         <attribute name="data-shape-colors">;;;;</attribute>
     </xpath>
@@ -871,7 +871,7 @@
         <attribute name="src">/web_editor/image_shape/website.s_company_team_image_6/web_editor/geometric_round/geo_round_gem.svg</attribute>
         <attribute name="data-shape">web_editor/geometric_round/geo_round_gem</attribute>
         <attribute name="data-shape-flip">xy</attribute>
-        <attribute name="data-original-mimetype">image/jpeg</attribute>
+        <attribute name="data-format-mimetype">image/jpeg</attribute>
         <attribute name="data-file-name">uiface_1.svg</attribute>
         <attribute name="data-shape-colors">;;;;</attribute>
     </xpath>

--- a/theme_beauty/views/snippets/s_accordion_image.xml
+++ b/theme_beauty/views/snippets/s_accordion_image.xml
@@ -8,7 +8,7 @@
     <xpath expr="//img" position="attributes">
         <attribute name="src">/web_editor/image_shape/website.s_accordion_image_default_image/web_editor/geometric_round/geo_round_blob_soft.svg</attribute>
         <attribute name="data-shape">web_editor/geometric_round/geo_round_blob_soft</attribute>
-        <attribute name="data-original-mimetype">image/webp</attribute>
+        <attribute name="data-format-mimetype">image/webp</attribute>
         <attribute name="data-file-name">s_accordion_image_default_image.svg</attribute>
         <attribute name="data-shape-colors">;;;;</attribute>
     </xpath>

--- a/theme_beauty/views/snippets/s_image_text.xml
+++ b/theme_beauty/views/snippets/s_image_text.xml
@@ -6,7 +6,7 @@
     <xpath expr="//img" position="attributes">
         <attribute name="src">/web_editor/image_shape/website.s_image_text_default_image/web_editor/pattern/pattern_wave_3.svg?c1=o-color-1&amp;c3=o-color-4</attribute>
         <attribute name="data-shape">web_editor/pattern/pattern_wave_3</attribute>
-        <attribute name="data-original-mimetype">image/webp</attribute>
+        <attribute name="data-format-mimetype">image/webp</attribute>
         <attribute name="data-file-name">s_image_text.svg</attribute>
         <attribute name="data-shape-colors">o-color-1;;o-color-4;;</attribute>
     </xpath>

--- a/theme_beauty/views/snippets/s_media_list.xml
+++ b/theme_beauty/views/snippets/s_media_list.xml
@@ -10,7 +10,7 @@
     <xpath expr="//img" position="attributes">
         <attribute name="src">/web_editor/image_shape/website.s_media_list_default_image_1/web_editor/composition/composition_line_2.svg?c1=o-color-1</attribute>
         <attribute name="data-shape">web_editor/composition/composition_line_2</attribute>
-        <attribute name="data-original-mimetype">image/webp</attribute>
+        <attribute name="data-format-mimetype">image/webp</attribute>
         <attribute name="data-file-name">s_media_list_1.svg</attribute>
         <attribute name="data-shape-colors">o-color-1;;;;</attribute>
     </xpath>
@@ -18,7 +18,7 @@
     <xpath expr="(//img)[2]" position="attributes">
         <attribute name="src">/web_editor/image_shape/website.s_media_list_default_image_2/web_editor/composition/composition_line_3.svg?c1=o-color-1&amp;c2=o-color-2&amp;c5=o-color-3</attribute>
         <attribute name="data-shape">web_editor/composition/composition_line_3</attribute>
-        <attribute name="data-original-mimetype">image/webp</attribute>
+        <attribute name="data-format-mimetype">image/webp</attribute>
         <attribute name="data-file-name">s_media_list_2.svg</attribute>
         <attribute name="data-shape-colors">o-color-1;o-color-2;;;o-color-3</attribute>
     </xpath>
@@ -26,7 +26,7 @@
     <xpath expr="(//img)[3]" position="attributes">
         <attribute name="src">/web_editor/image_shape/website.s_media_list_default_image_3/web_editor/composition/composition_line_2.svg?c2=o-color-2</attribute>
         <attribute name="data-shape">web_editor/composition/composition_line_2</attribute>
-        <attribute name="data-original-mimetype">image/webp</attribute>
+        <attribute name="data-format-mimetype">image/webp</attribute>
         <attribute name="data-file-name">s_media_list_3.svg</attribute>
         <attribute name="data-shape-colors">;o-color-2;;;</attribute>
     </xpath>

--- a/theme_beauty/views/snippets/s_text_image.xml
+++ b/theme_beauty/views/snippets/s_text_image.xml
@@ -20,7 +20,7 @@
     <xpath expr="//img" position="attributes">
         <attribute name="src">/web_editor/image_shape/website.s_text_image_default_image/web_editor/pattern/pattern_wave_4.svg?c1=o-color-1&amp;c2=o-color-2&amp;c3=o-color-3&amp;c5=o-color-1</attribute>
         <attribute name="data-shape">web_editor/pattern/pattern_wave_4</attribute>
-        <attribute name="data-original-mimetype">image/webp</attribute>
+        <attribute name="data-format-mimetype">image/webp</attribute>
         <attribute name="data-file-name">s_text_image.svg</attribute>
         <attribute name="data-shape-colors">o-color-1;o-color-2;o-color-3;;o-color-1</attribute>
     </xpath>

--- a/theme_buzzy/views/snippets/s_image_punchy.xml
+++ b/theme_buzzy/views/snippets/s_image_punchy.xml
@@ -5,7 +5,7 @@
     <xpath expr="//img" position="attributes">
         <attribute name="src">/web_editor/image_shape/website.s_image_punchy_default_image/web_editor/geometric/geo_slanted.svg</attribute>
         <attribute name="data-shape">web_editor/geometric/geo_slanted</attribute>
-        <attribute name="data-original-mimetype">image/webp</attribute>
+        <attribute name="data-format-mimetype">image/webp</attribute>
         <attribute name="data-file-name">s_image_punchy_default_image.svg</attribute>
         <attribute name="data-shape-colors">;;;;</attribute>
     </xpath>

--- a/theme_clean/views/snippets/s_banner.xml
+++ b/theme_clean/views/snippets/s_banner.xml
@@ -18,7 +18,7 @@
     <xpath expr="//img" position="attributes">
         <attribute name="src">/web_editor/image_shape/website.s_banner_default_image_2/web_editor/composition/composition_oval_line.svg?c2=o-color-2</attribute>
         <attribute name="data-shape">web_editor/composition/composition_oval_line</attribute>
-        <attribute name="data-original-mimetype">image/webp</attribute>
+        <attribute name="data-format-mimetype">image/webp</attribute>
         <attribute name="data-file-name">s_banner_2.svg</attribute>
         <attribute name="data-shape-colors">;#34495E;;;</attribute>
     </xpath>

--- a/theme_clean/views/snippets/s_image_text.xml
+++ b/theme_clean/views/snippets/s_image_text.xml
@@ -14,7 +14,7 @@
     <xpath expr="//img" position="attributes">
         <attribute name="src">/web_editor/image_shape/website.s_image_text_default_image/web_editor/pattern/pattern_labyrinth.svg?c1=o-color-3&amp;c2=o-color-5&amp;c4=o-color-1</attribute>
         <attribute name="data-shape">web_editor/pattern/pattern_labyrinth</attribute>
-        <attribute name="data-original-mimetype">image/webp</attribute>
+        <attribute name="data-format-mimetype">image/webp</attribute>
         <attribute name="data-file-name">image_content_20.svg</attribute>
         <attribute name="data-shape-colors">o-color-3;o-color-5;;o-color-1;</attribute>
     </xpath>

--- a/theme_clean/views/snippets/s_text_image.xml
+++ b/theme_clean/views/snippets/s_text_image.xml
@@ -20,7 +20,7 @@
     <xpath expr="//img" position="attributes">
         <attribute name="src">/web_editor/image_shape/website.s_text_image_default_image/web_editor/pattern/pattern_point.svg?c1=o-color-1</attribute>
         <attribute name="data-shape">web_editor/pattern/pattern_point</attribute>
-        <attribute name="data-original-mimetype">image/webp</attribute>
+        <attribute name="data-format-mimetype">image/webp</attribute>
         <attribute name="data-file-name">image_content_19.svg</attribute>
         <attribute name="data-shape-colors">o-color-1;;;;</attribute>
     </xpath>

--- a/theme_kea/views/snippets/s_company_team_grid.xml
+++ b/theme_kea/views/snippets/s_company_team_grid.xml
@@ -9,7 +9,7 @@
     <xpath expr="//img" position="attributes">
         <attribute name="src">/web_editor/image_shape/website.s_company_team_image_1/web_editor/composition/composition_line_1.svg?c1=o-color-1</attribute>
         <attribute name="data-shape">web_editor/composition/composition_line_1</attribute>
-        <attribute name="data-original-mimetype">image/webp</attribute>
+        <attribute name="data-format-mimetype">image/webp</attribute>
         <attribute name="data-file-name">uiface_1.svg</attribute>
         <attribute name="data-shape-colors">o-color-1;;;;</attribute>
     </xpath>
@@ -20,7 +20,7 @@
     <xpath expr="(//img)[2]" position="attributes">
         <attribute name="src">/web_editor/image_shape/website.s_company_team_image_2/web_editor/composition/composition_mixed_1.svg?c1=o-color-1&amp;c2=o-color-2&amp;c5=o-color-5</attribute>
         <attribute name="data-shape">web_editor/composition/composition_mixed_1</attribute>
-        <attribute name="data-original-mimetype">image/webp</attribute>
+        <attribute name="data-format-mimetype">image/webp</attribute>
         <attribute name="data-file-name">uiface_1.svg</attribute>
         <attribute name="data-shape-colors">o-color-1;o-color-2;;;o-color-5</attribute>
     </xpath>
@@ -31,7 +31,7 @@
     <xpath expr="(//img)[3]" position="attributes">
         <attribute name="src">/web_editor/image_shape/website.s_company_team_image_3/web_editor/composition/composition_planet_1.svg?c1=o-color-1&amp;c2=o-color-2&amp;c5=o-color-5</attribute>
         <attribute name="data-shape">web_editor/composition/composition_planet_1</attribute>
-        <attribute name="data-original-mimetype">image/webp</attribute>
+        <attribute name="data-format-mimetype">image/webp</attribute>
         <attribute name="data-file-name">uiface_1.svg</attribute>
         <attribute name="data-shape-colors">o-color-1;o-color-2;;;o-color-5</attribute>
     </xpath>
@@ -42,7 +42,7 @@
     <xpath expr="(//img)[4]" position="attributes">
         <attribute name="src">/web_editor/image_shape/website.s_company_team_image_4/web_editor/composition/composition_planet_2.svg?c1=o-color-1&amp;c2=o-color-2&amp;c5=o-color-5</attribute>
         <attribute name="data-shape">web_editor/composition/composition_planet_2</attribute>
-        <attribute name="data-original-mimetype">image/webp</attribute>
+        <attribute name="data-format-mimetype">image/webp</attribute>
         <attribute name="data-file-name">uiface_1.svg</attribute>
         <attribute name="data-shape-colors">o-color-1;o-color-2;;;o-color-5</attribute>
     </xpath>
@@ -53,7 +53,7 @@
     <xpath expr="(//img)[5]" position="attributes">
         <attribute name="src">/web_editor/image_shape/website.s_company_team_image_5/web_editor/pattern/pattern_point.svg?c1=o-color-1</attribute>
         <attribute name="data-shape">web_editor/pattern/pattern_point</attribute>
-        <attribute name="data-original-mimetype">image/webp</attribute>
+        <attribute name="data-format-mimetype">image/webp</attribute>
         <attribute name="data-file-name">uiface_1.svg</attribute>
         <attribute name="data-shape-colors">o-color-1;;;;</attribute>
     </xpath>
@@ -64,7 +64,7 @@
     <xpath expr="(//img)[6]" position="attributes">
         <attribute name="src">/web_editor/image_shape/website.s_company_team_image_6/web_editor/composition/composition_mixed_2.svg?c1=o-color-1&amp;c2=o-color-2&amp;c5=o-color-5</attribute>
         <attribute name="data-shape">web_editor/composition/composition_mixed_2</attribute>
-        <attribute name="data-original-mimetype">image/webp</attribute>
+        <attribute name="data-format-mimetype">image/webp</attribute>
         <attribute name="data-file-name">uiface_1.svg</attribute>
         <attribute name="data-shape-colors">o-color-1;o-color-2;;;o-color-5</attribute>
     </xpath>

--- a/theme_kea/views/snippets/s_media_list.xml
+++ b/theme_kea/views/snippets/s_media_list.xml
@@ -24,7 +24,7 @@
     <xpath expr="(//img)" position="attributes">
         <attribute name="src">/web_editor/image_shape/website.s_media_list_default_image_3/web_editor/geometric_round/geo_round_blob_medium.svg</attribute>
         <attribute name="data-shape">web_editor/geometric_round/geo_round_blob_medium</attribute>
-        <attribute name="data-original-mimetype">image/webp</attribute>
+        <attribute name="data-format-mimetype">image/webp</attribute>
         <attribute name="data-file-name">s_media_list_3.svg</attribute>
         <attribute name="data-shape-colors">;;;;</attribute>
     </xpath>
@@ -41,7 +41,7 @@
     <xpath expr="(//img)[2]" position="attributes">
         <attribute name="src">/web_editor/image_shape/website.s_media_list_default_image_2/web_editor/geometric_round/geo_round_blob_medium.svg</attribute>
         <attribute name="data-shape">web_editor/geometric_round/geo_round_blob_medium</attribute>
-        <attribute name="data-original-mimetype">image/webp</attribute>
+        <attribute name="data-format-mimetype">image/webp</attribute>
         <attribute name="data-file-name">s_media_list_2.svg</attribute>
         <attribute name="data-shape-colors">;;;;</attribute>
     </xpath>
@@ -58,7 +58,7 @@
     <xpath expr="(//img)[3]" position="attributes">
         <attribute name="src">/web_editor/image_shape/website.s_media_list_default_image_1/web_editor/geometric_round/geo_round_blob_medium.svg</attribute>
         <attribute name="data-shape">web_editor/geometric_round/geo_round_blob_medium</attribute>
-        <attribute name="data-original-mimetype">image/webp</attribute>
+        <attribute name="data-format-mimetype">image/webp</attribute>
         <attribute name="data-file-name">s_media_list_1.svg</attribute>
         <attribute name="data-shape-colors">;;;;</attribute>
     </xpath>

--- a/theme_kea/views/snippets/s_picture.xml
+++ b/theme_kea/views/snippets/s_picture.xml
@@ -15,7 +15,7 @@
         <attribute name="style">width: 100%;</attribute>
         <attribute name="src">/web_editor/image_shape/website.s_media_list_default_image_1/web_editor/geometric_round/geo_round_blob_medium.svg</attribute>
         <attribute name="data-shape">web_editor/geometric_round/geo_round_blob_medium</attribute>
-        <attribute name="data-original-mimetype">image/webp</attribute>
+        <attribute name="data-format-mimetype">image/webp</attribute>
         <attribute name="data-file-name">s_media_list_1.svg</attribute>
         <attribute name="data-shape-colors">;;;;</attribute>
     </xpath>

--- a/theme_kiddo/views/snippets/s_accordion_image.xml
+++ b/theme_kiddo/views/snippets/s_accordion_image.xml
@@ -5,7 +5,7 @@
     <xpath expr="//img" position="attributes">
         <attribute name="src">/web_editor/image_shape/website.s_accordion_image_default_image/web_editor/geometric_round/geo_round_blob_medium.svg</attribute>
         <attribute name="data-shape">web_editor/geometric_round/geo_round_blob_medium</attribute>
-        <attribute name="data-original-mimetype">image/webp</attribute>
+        <attribute name="data-format-mimetype">image/webp</attribute>
         <attribute name="data-file-name">s_accordion_image_default_image.svg</attribute>
         <attribute name="data-shape-colors">;;;;</attribute>
     </xpath>

--- a/theme_kiddo/views/snippets/s_company_team_grid.xml
+++ b/theme_kiddo/views/snippets/s_company_team_grid.xml
@@ -9,7 +9,7 @@
     <xpath expr="//img" position="attributes">
         <attribute name="src">/web_editor/image_shape/website.s_company_team_image_1/web_editor/solid/solid_blob_3.svg?c5=o-color-1</attribute>
         <attribute name="data-shape">web_editor/composition/solid_blob_3</attribute>
-        <attribute name="data-original-mimetype">image/webp</attribute>
+        <attribute name="data-format-mimetype">image/webp</attribute>
         <attribute name="data-file-name">uiface_1.svg</attribute>
         <attribute name="data-shape-colors">;;;;o-color-1</attribute>
     </xpath>
@@ -20,7 +20,7 @@
     <xpath expr="(//img)[2]" position="attributes">
         <attribute name="src">/web_editor/image_shape/website.s_company_team_image_2/web_editor/composition/composition_organic_line.svg?c1=o-color-5</attribute>
         <attribute name="data-shape">web_editor/composition/composition_organic_line</attribute>
-        <attribute name="data-original-mimetype">image/webp</attribute>
+        <attribute name="data-format-mimetype">image/webp</attribute>
         <attribute name="data-file-name">uiface_1.svg</attribute>
         <attribute name="data-shape-colors">o-color-5;;;;</attribute>
     </xpath>
@@ -31,7 +31,7 @@
     <xpath expr="(//img)[3]" position="attributes">
         <attribute name="src">/web_editor/image_shape/website.s_company_team_image_3/web_editor/solid/solid_blob_1.svg?c2=o-color-2</attribute>
         <attribute name="data-shape">web_editor/solid/solid_blob_1</attribute>
-        <attribute name="data-original-mimetype">image/webp</attribute>
+        <attribute name="data-format-mimetype">image/webp</attribute>
         <attribute name="data-file-name">uiface_1.svg</attribute>
         <attribute name="data-shape-colors">;o-color-2;;;</attribute>
     </xpath>
@@ -42,7 +42,7 @@
     <xpath expr="(//img)[4]" position="attributes">
         <attribute name="src">/web_editor/image_shape/website.s_company_team_image_4/web_editor/solid/solid_blob_4.svg?c5=o-color-2</attribute>
         <attribute name="data-shape">web_editor/solid/solid_blob_4</attribute>
-        <attribute name="data-original-mimetype">image/webp</attribute>
+        <attribute name="data-format-mimetype">image/webp</attribute>
         <attribute name="data-file-name">uiface_1.svg</attribute>
         <attribute name="data-shape-colors">;;;;o-color-2</attribute>
     </xpath>
@@ -53,7 +53,7 @@
     <xpath expr="(//img)[5]" position="attributes">
         <attribute name="src">/web_editor/image_shape/website.s_company_team_image_5/web_editor/composition/composition_oval_line.svg?c2=o-color-1</attribute>
         <attribute name="data-shape">web_editor/composition/composition_oval_line</attribute>
-        <attribute name="data-original-mimetype">image/webp</attribute>
+        <attribute name="data-format-mimetype">image/webp</attribute>
         <attribute name="data-file-name">uiface_1.svg</attribute>
         <attribute name="data-shape-colors">;o-color-1;;;</attribute>
     </xpath>
@@ -64,7 +64,7 @@
     <xpath expr="(//img)[6]" position="attributes">
         <attribute name="src">/web_editor/image_shape/website.s_company_team_image_6/web_editor/solid/solid_blob_3.svg?c5=o-color-5</attribute>
         <attribute name="data-shape">web_editor/solid/solid_blob_3</attribute>
-        <attribute name="data-original-mimetype">image/webp</attribute>
+        <attribute name="data-format-mimetype">image/webp</attribute>
         <attribute name="data-file-name">uiface_1.svg</attribute>
         <attribute name="data-shape-colors">;;;;o-color-5</attribute>
     </xpath>

--- a/theme_kiddo/views/snippets/s_image_text.xml
+++ b/theme_kiddo/views/snippets/s_image_text.xml
@@ -36,7 +36,7 @@
     <xpath expr="//img" position="attributes">
         <attribute name="src">/web_editor/image_shape/website.s_image_text_default_image/web_editor/geometric_round/geo_round_square_2.svg</attribute>
         <attribute name="data-shape">web_editor/geometric_round/geo_round_square_2</attribute>
-        <attribute name="data-original-mimetype">image/webp</attribute>
+        <attribute name="data-format-mimetype">image/webp</attribute>
         <attribute name="data-file-name">s_image_text.svg</attribute>
         <attribute name="data-shape-colors">;;;;</attribute>
     </xpath>

--- a/theme_kiddo/views/snippets/s_text_image.xml
+++ b/theme_kiddo/views/snippets/s_text_image.xml
@@ -24,7 +24,7 @@
     <xpath expr="//img" position="attributes">
         <attribute name="src">/web_editor/image_shape/website.s_text_image_default_image/web_editor/geometric_round/geo_round_square_1.svg</attribute>
         <attribute name="data-shape">web_editor/geometric_round/geo_round_square_1</attribute>
-        <attribute name="data-original-mimetype">image/webp</attribute>
+        <attribute name="data-format-mimetype">image/webp</attribute>
         <attribute name="data-file-name">content_img_13.svg</attribute>
         <attribute name="data-shape-colors">;;;;</attribute>
     </xpath>

--- a/theme_kiddo/views/snippets/s_three_columns.xml
+++ b/theme_kiddo/views/snippets/s_three_columns.xml
@@ -14,7 +14,7 @@
     <xpath expr="//img" position="attributes">
         <attribute name="src">/web_editor/image_shape/website.s_three_columns_default_image_1/web_editor/solid/solid_blob_1.svg?c2=o-color-1</attribute>
         <attribute name="data-shape">web_editor/solid/solid_blob_1</attribute>
-        <attribute name="data-original-mimetype">image/webp</attribute>
+        <attribute name="data-format-mimetype">image/webp</attribute>
         <attribute name="data-file-name">s_three_columns_default_image_1.svg</attribute>
         <attribute name="data-shape-colors">;o-color-1;;;</attribute>
     </xpath>
@@ -51,7 +51,7 @@
     <xpath expr="(//img)[2]" position="attributes">
         <attribute name="src">/web_editor/image_shape/website.s_three_columns_default_image_2/web_editor/composition/composition_organic_line.svg?c2=o-color-3</attribute>
         <attribute name="data-shape">web_editor/composition/composition_organic_line</attribute>
-        <attribute name="data-original-mimetype">image/webp</attribute>
+        <attribute name="data-format-mimetype">image/webp</attribute>
         <attribute name="data-file-name">s_three_columns_default_image_2.svg</attribute>
         <attribute name="data-shape-colors">;o-color-3;;;</attribute>
     </xpath>
@@ -88,7 +88,7 @@
     <xpath expr="(//img)[3]" position="attributes">
         <attribute name="src">/web_editor/image_shape/website.s_three_columns_default_image_3/web_editor/solid/solid_blob_3.svg?c5=o-color-2</attribute>
         <attribute name="data-shape">web_editor/solid/solid_blob_3</attribute>
-        <attribute name="data-original-mimetype">image/webp</attribute>
+        <attribute name="data-format-mimetype">image/webp</attribute>
         <attribute name="data-file-name">s_three_columns_default_image_3.svg</attribute>
         <attribute name="data-shape-colors">;;;;o-color-2</attribute>
     </xpath>

--- a/theme_monglia/views/customizations.xml
+++ b/theme_monglia/views/customizations.xml
@@ -169,7 +169,7 @@
     <xpath expr="//img" position="attributes">
         <attribute name="src">/web_editor/image_shape/website.s_text_image_default_image/web_editor/geometric/geo_square_3.svg</attribute>
         <attribute name="data-shape">web_editor/geometric/geo_square_3</attribute>
-        <attribute name="data-original-mimetype">image/webp</attribute>
+        <attribute name="data-format-mimetype">image/webp</attribute>
         <attribute name="data-file-name">s_text_image.svg</attribute>
         <attribute name="data-shape-colors">;;;;</attribute>
     </xpath>
@@ -200,7 +200,7 @@
     <xpath expr="//img" position="attributes">
         <attribute name="src">/web_editor/image_shape/website.s_image_text_default_image/web_editor/geometric/geo_square_6.svg</attribute>
         <attribute name="data-shape">web_editor/geometric/geo_square_6</attribute>
-        <attribute name="data-original-mimetype">image/webp</attribute>
+        <attribute name="data-format-mimetype">image/webp</attribute>
         <attribute name="data-file-name">s_image_text.svg</attribute>
         <attribute name="data-shape-colors">;;;;</attribute>
     </xpath>
@@ -884,7 +884,7 @@
     <xpath expr="//img" position="attributes">
         <attribute name="src">/web_editor/image_shape/website.s_masonry_block_default_image_1/web_editor/panel/panel_duo_step.svg</attribute>
         <attribute name="data-shape">web_editor/panel/panel_duo_step</attribute>
-        <attribute name="data-original-mimetype">image/webp</attribute>
+        <attribute name="data-format-mimetype">image/webp</attribute>
         <attribute name="data-file-name">s_masonry_block_default_image_1.webp</attribute>
         <attribute name="data-shape-colors">;;;;</attribute>
     </xpath>
@@ -952,7 +952,7 @@
     <xpath expr="//img" position="attributes">
         <attribute name="src">/web_editor/image_shape/website.s_company_team_image_1/web_editor/geometric_round/geo_round_diamond.svg</attribute>
         <attribute name="data-shape">web_editor/geometric_round/geo_round_diamond</attribute>
-        <attribute name="data-original-mimetype">image/webp</attribute>
+        <attribute name="data-format-mimetype">image/webp</attribute>
         <attribute name="data-file-name">uiface_1.svg</attribute>
         <attribute name="data-shape-colors">;;;;</attribute>
     </xpath>
@@ -964,7 +964,7 @@
     <xpath expr="(//img)[2]" position="attributes">
         <attribute name="src">/web_editor/image_shape/website.s_company_team_image_2/web_editor/geometric_round/geo_round_diamond.svg</attribute>
         <attribute name="data-shape">web_editor/geometric_round/geo_round_diamond</attribute>
-        <attribute name="data-original-mimetype">image/webp</attribute>
+        <attribute name="data-format-mimetype">image/webp</attribute>
         <attribute name="data-file-name">uiface_2.svg</attribute>
         <attribute name="data-shape-colors">;;;;</attribute>
     </xpath>
@@ -975,7 +975,7 @@
     <xpath expr="(//img)[3]" position="attributes">
         <attribute name="src">/web_editor/image_shape/website.s_company_team_image_3/web_editor/geometric_round/geo_round_diamond.svg</attribute>
         <attribute name="data-shape">web_editor/geometric_round/geo_round_diamond</attribute>
-        <attribute name="data-original-mimetype">image/webp</attribute>
+        <attribute name="data-format-mimetype">image/webp</attribute>
         <attribute name="data-file-name">uiface_3.svg</attribute>
         <attribute name="data-shape-colors">;;;;</attribute>
     </xpath>
@@ -986,7 +986,7 @@
     <xpath expr="(//img)[4]" position="attributes">
         <attribute name="src">/web_editor/image_shape/website.s_company_team_image_4/web_editor/geometric_round/geo_round_diamond.svg</attribute>
         <attribute name="data-shape">web_editor/geometric_round/geo_round_diamond</attribute>
-        <attribute name="data-original-mimetype">image/webp</attribute>
+        <attribute name="data-format-mimetype">image/webp</attribute>
         <attribute name="data-file-name">uiface_4.svg</attribute>
         <attribute name="data-shape-colors">;;;;</attribute>
     </xpath>
@@ -997,7 +997,7 @@
     <xpath expr="(//img)[5]" position="attributes">
         <attribute name="src">/web_editor/image_shape/website.s_company_team_image_5/web_editor/geometric_round/geo_round_diamond.svg</attribute>
         <attribute name="data-shape">web_editor/geometric_round/geo_round_diamond</attribute>
-        <attribute name="data-original-mimetype">image/webp</attribute>
+        <attribute name="data-format-mimetype">image/webp</attribute>
         <attribute name="data-file-name">uiface_5.svg</attribute>
         <attribute name="data-shape-colors">;;;;</attribute>
     </xpath>
@@ -1008,7 +1008,7 @@
     <xpath expr="(//img)[6]" position="attributes">
         <attribute name="src">/web_editor/image_shape/website.s_company_team_image_6/web_editor/geometric_round/geo_round_diamond.svg</attribute>
         <attribute name="data-shape">web_editor/geometric_round/geo_round_diamond</attribute>
-        <attribute name="data-original-mimetype">image/webp</attribute>
+        <attribute name="data-format-mimetype">image/webp</attribute>
         <attribute name="data-file-name">uiface_6.svg</attribute>
         <attribute name="data-shape-colors">;;;;</attribute>
     </xpath>

--- a/theme_odoo_experts/views/snippets/s_image_text.xml
+++ b/theme_odoo_experts/views/snippets/s_image_text.xml
@@ -27,7 +27,7 @@
     <xpath expr="//img" position="attributes">
         <attribute name="src">/web_editor/image_shape/website.s_image_text_default_image/web_editor/devices/browser_03.svg?</attribute>
         <attribute name="data-shape">web_editor/devices/browser_03</attribute>
-        <attribute name="data-original-mimetype">image/webp</attribute>
+        <attribute name="data-format-mimetype">image/webp</attribute>
         <attribute name="data-file-name">s_image_text.svg</attribute>
         <attribute name="class" add="shadow" separator=" "/>
     </xpath>

--- a/theme_odoo_experts/views/snippets/s_mockup_image.xml
+++ b/theme_odoo_experts/views/snippets/s_mockup_image.xml
@@ -28,7 +28,7 @@
     <xpath expr="//img" position="attributes">
         <attribute name="src">/web_editor/image_shape/website.s_image_text_device_perspective/web_editor/devices/iphone_3d_portrait_02.svg?c5=o-color-5</attribute>
         <attribute name="data-shape">web_editor/devices/iphone_3d_portrait_02</attribute>
-        <attribute name="data-original-mimetype">image/webp</attribute>
+        <attribute name="data-format-mimetype">image/webp</attribute>
         <attribute name="data-file-name">s_image_text_device_perspective.svg</attribute>
         <attribute name="data-shape-colors">;;;;o-color-5</attribute>
         <attribute name="style" add="width: 50% !important;" separator=";"/>

--- a/theme_odoo_experts/views/snippets/s_picture.xml
+++ b/theme_odoo_experts/views/snippets/s_picture.xml
@@ -35,7 +35,7 @@
     <xpath expr="//div[hasclass('col-lg-12')]//img" position="attributes">
         <attribute name="src">/web_editor/image_shape/website.s_picture_default_image/web_editor/devices/macbook_front.svg?c3=o-color-3</attribute>
         <attribute name="data-shape">web_editor/devices/macbook_front</attribute>
-        <attribute name="data-original-mimetype">image/webp</attribute>
+        <attribute name="data-format-mimetype">image/webp</attribute>
         <attribute name="data-file-name">s_picture.svg</attribute>
         <attribute name="data-shape-colors">;;o-color-3;;</attribute>
         <attribute name="class">img-fluid</attribute>

--- a/theme_odoo_experts/views/snippets/s_showcase.xml
+++ b/theme_odoo_experts/views/snippets/s_showcase.xml
@@ -46,7 +46,7 @@
     <xpath expr="//img" position="attributes">
         <attribute name="src">/web_editor/image_shape/website.s_showcase_default_image/web_editor/devices/macbook_front.svg?</attribute>
         <attribute name="data-shape">web_editor/devices/macbook_front</attribute>
-        <attribute name="data-original-mimetype">image/webp</attribute>
+        <attribute name="data-format-mimetype">image/webp</attribute>
         <attribute name="data-file-name">s_showcase_default_image.svg</attribute>
         <attribute name="class" remove="rounded" separator=" "/>
     </xpath>

--- a/theme_odoo_experts/views/snippets/s_text_image.xml
+++ b/theme_odoo_experts/views/snippets/s_text_image.xml
@@ -27,7 +27,7 @@
     <xpath expr="//img" position="attributes">
         <attribute name="src">/web_editor/image_shape/website.s_text_image_default_image/web_editor/devices/ipad_front_landscape.svg</attribute>
         <attribute name="data-shape">web_editor/devices/ipad_front_landscape</attribute>
-        <attribute name="data-original-mimetype">image/webp</attribute>
+        <attribute name="data-format-mimetype">image/webp</attribute>
         <attribute name="data-file-name">s_text_image.svg</attribute>
         <attribute name="class" remove="rounded" separator=" "/>
     </xpath>

--- a/theme_orchid/views/snippets/s_image_text.xml
+++ b/theme_orchid/views/snippets/s_image_text.xml
@@ -21,7 +21,7 @@
     <xpath expr="//img" position="attributes">
         <attribute name="src">/web_editor/image_shape/website.s_image_text_default_image/web_editor/composition/composition_mixed_1.svg?c1=o-color-2&amp;c2=o-color-2&amp;c5=o-color-5</attribute>
         <attribute name="data-shape">web_editor/composition/composition_mixed_1</attribute>
-        <attribute name="data-original-mimetype">image/webp</attribute>
+        <attribute name="data-format-mimetype">image/webp</attribute>
         <attribute name="data-file-name">s_carousel_2.svg</attribute>
         <attribute name="data-shape-colors">o-color-2;o-color-2;;;o-color-5</attribute>
     </xpath>

--- a/theme_orchid/views/snippets/s_text_image.xml
+++ b/theme_orchid/views/snippets/s_text_image.xml
@@ -34,7 +34,7 @@
     <xpath expr="//img" position="attributes">
         <attribute name="src">/web_editor/image_shape/website.s_text_image_default_image/web_editor/solid/solid_blob_shadow_2.svg?c2=o-color-2</attribute>
         <attribute name="data-shape">web_editor/solid/solid_blob_shadow_2</attribute>
-        <attribute name="data-original-mimetype">image/webp</attribute>
+        <attribute name="data-format-mimetype">image/webp</attribute>
         <attribute name="data-file-name">s_media_list_3.svg</attribute>
         <attribute name="data-shape-colors">;o-color-2;;;</attribute>
     </xpath>

--- a/theme_real_estate/views/snippets/s_image_text.xml
+++ b/theme_real_estate/views/snippets/s_image_text.xml
@@ -22,7 +22,7 @@
     <xpath expr="//img" position="attributes">
         <attribute name="src">/web_editor/image_shape/website.s_image_text_default_image/web_editor/panel/panel_duo_step.svg</attribute>
         <attribute name="data-shape">web_editor/panel/panel_duo_step</attribute>
-        <attribute name="data-original-mimetype">image/webp</attribute>
+        <attribute name="data-format-mimetype">image/webp</attribute>
         <attribute name="data-file-name">s_image_text.svg</attribute>
         <attribute name="data-shape-colors">;;;;</attribute>
     </xpath>

--- a/theme_real_estate/views/snippets/s_text_image.xml
+++ b/theme_real_estate/views/snippets/s_text_image.xml
@@ -17,7 +17,7 @@
     <xpath expr="//img" position="attributes">
         <attribute name="src">/web_editor/image_shape/website.s_text_image_default_image/web_editor/panel/panel_duo_step.svg</attribute>
         <attribute name="data-shape">web_editor/panel/panel_duo_step</attribute>
-        <attribute name="data-original-mimetype">image/webp</attribute>
+        <attribute name="data-format-mimetype">image/webp</attribute>
         <attribute name="data-file-name">s_text_image.svg</attribute>
         <attribute name="data-shape-colors">;;;;</attribute>
     </xpath>

--- a/theme_test_custo/data/pages.xml
+++ b/theme_test_custo/data/pages.xml
@@ -17,7 +17,7 @@
                             <p><a href="#" class="btn btn-primary">Learn more</a></p>
                         </div>
                         <div class="col-lg-6 pt16 pb16">
-                            <img src="/web_editor/image_shape/website.s_text_image_default_image/theme_test_custo/blob/01.svg" class="img img-fluid mx-auto" alt="" data-original-mimetype="image/webp" data-file-name="01.svg" data-shape="theme_test_custo/blob/01" data-shape-colors=";;;;"/>
+                            <img src="/web_editor/image_shape/website.s_text_image_default_image/theme_test_custo/blob/01.svg" class="img img-fluid mx-auto" alt="" data-format-mimetype="image/webp" data-file-name="01.svg" data-shape="theme_test_custo/blob/01" data-shape-colors=";;;;"/>
                         </div>
                     </div>
                 </div>

--- a/theme_vehicle/views/customizations.xml
+++ b/theme_vehicle/views/customizations.xml
@@ -62,7 +62,7 @@
     <xpath expr="//img" position="attributes">
         <attribute name="src">/web_editor/image_shape/website.s_text_image_default_image/web_editor/composition/composition_square_3.svg?c1=o-color-1&amp;c5=o-color-5</attribute>
         <attribute name="data-shape">web_editor/composition/composition_square_3</attribute>
-        <attribute name="data-original-mimetype">image/webp</attribute>
+        <attribute name="data-format-mimetype">image/webp</attribute>
         <attribute name="data-file-name">s_text_image.svg</attribute>
         <attribute name="data-shape-colors">o-color-1;;;;o-color-5</attribute>
     </xpath>
@@ -91,7 +91,7 @@
     <xpath expr="//img" position="attributes">
         <attribute name="src">/web_editor/image_shape/website.s_image_text_default_image/web_editor/composition/composition_square_2.svg?c2=o-color-1&amp;c5=o-color-5</attribute>
         <attribute name="data-shape">web_editor/composition/composition_square_2</attribute>
-        <attribute name="data-original-mimetype">image/webp</attribute>
+        <attribute name="data-format-mimetype">image/webp</attribute>
         <attribute name="data-file-name">s_image_text.svg</attribute>
         <attribute name="data-shape-colors">;o-color-1;;;o-color-5</attribute>
     </xpath>

--- a/theme_zap/views/snippets/s_striped.xml
+++ b/theme_zap/views/snippets/s_striped.xml
@@ -18,7 +18,7 @@
     <xpath expr="//img" position="attributes">
         <attribute name="src">/web_editor/image_shape/website.s_text_cover_default_image/web_editor/geometric/geo_square_5.svg</attribute>
         <attribute name="data-shape">web_editor/geometric/geo_square_5</attribute>
-        <attribute name="data-original-mimetype">image/webp</attribute>
+        <attribute name="data-format-mimetype">image/webp</attribute>
         <attribute name="data-file-name">s_striped_default_image.svg</attribute>
         <attribute name="data-shape-colors">;;;;</attribute>
     </xpath>


### PR DESCRIPTION
*: theme_anelusia, theme_artists, theme_avantgarde, theme_beauty,
   theme_buzzy, theme_clean, theme_kea, theme_kiddo, theme_monglia,
   theme_odoo_experts, theme_orchid, theme_real_estate,
   theme_test_custo, theme_vehicle, theme_zap

When `html_builder` was introduced, some data attributes related to images have changed. Unfortunately, the attributes on static data were not adapted accordingly. Because of this, both namings might appear in this version.

This commit migrates images and background images attributes to use the new attributes.

Dataset changes:
- copy `originalId` to `attachmentId`
- rename `originalMimetype` to `formatMimetype`

task-4367641