### PR TITLE
[IMP] theme_artists: adapt radius units

### DIFF
--- a/theme_artists/static/src/scss/primary_variables.scss
+++ b/theme_artists/static/src/scss/primary_variables.scss
@@ -111,12 +111,12 @@ $o-website-values-palettes: (
         'btn-padding-x-sm': .5rem,
         'btn-padding-y-lg': .75rem,
         'btn-padding-x-lg': 1.5rem,
-        'btn-border-radius': 2px,
-        'btn-border-radius-sm': 2px,
-        'btn-border-radius-lg': 2px,
-        'input-border-radius': 2px,
-        'input-border-radius-sm': 2px,
-        'input-border-radius-lg': 2px,
+        'btn-border-radius': .125rem,
+        'btn-border-radius-sm': .125rem,
+        'btn-border-radius-lg': .125rem,
+        'input-border-radius': .125rem,
+        'input-border-radius-sm': .125rem,
+        'input-border-radius-lg': .125rem,
     ),
 );
 


### PR DESCRIPTION
This commit replaces pixel (`px`) values with `rem` units. Using `px` was causing issues with some SCSS calculations, specifically the checkbox roundness computation that we implemented in the community counterpart of this branch.

COM: https://github.com/odoo/odoo/pull/216826
task-4643128