### PR TITLE
[IMP] test_themes, theme_*: adapts themes for new parallax structure

### DIFF
--- a/test_themes/tests/test_new_page_templates.py
+++ b/test_themes/tests/test_new_page_templates.py
@@ -96,7 +96,7 @@ S_CLASSES_WHITELIST = [
     # Classes that rightfully belong here at the moment
     's_col_no_bgcolor', 's_col_no_resize', 's_allow_columns',
     's_nb_column_fixed', 's_dialog_preview',
-    's_parallax_is_fixed', 's_parallax_bg', 's_parallax_no_overflow_hidden',
+    's_parallax_is_fixed', 's_parallax_bg',
     's_carousel_cards_card', 's_timeline_card', 's_blog_posts', 's_events',
     's_appointments',
 

--- a/theme_anelusia/views/snippets/s_pricelist_boxed.xml
+++ b/theme_anelusia/views/snippets/s_pricelist_boxed.xml
@@ -5,10 +5,10 @@
     <!-- Layout -->
     <xpath expr="//section" position="attributes">
         <attribute name="data-scroll-background-ratio"/>
-        <attribute name="class" add="o_cc o_cc5" remove="parallax s_parallax_is_fixed s_parallax_no_overflow_hidden" separator=" "/>
+        <attribute name="class" add="o_cc o_cc5" remove="parallax s_parallax_is_fixed" separator=" "/>
         <attribute name="data-oe-shape-data">{'shape':'web_editor/Floats/12','flip':[],'showOnMobile':false,'shapeAnimationSpeed':'0','animated':'true'}</attribute>
     </xpath>
-    <xpath expr="//span[hasclass('s_parallax_bg')]" position="replace"/>
+    <xpath expr="//span[hasclass('s_parallax_bg_wrap')]" position="replace"/>
     <xpath expr="//div[hasclass('container')]" position="before">
         <div class="o_we_shape o_web_editor_Floats_12 o_we_animated"/>
     </xpath>

--- a/theme_artists/views/snippets/s_cover.xml
+++ b/theme_artists/views/snippets/s_cover.xml
@@ -4,7 +4,7 @@
 <template id="s_cover" inherit_id="website.s_cover">
     <!-- Section -->
     <xpath expr="//section" position="attributes">
-        <attribute name="class" add="pt224 pb200" remove="pt232 pb232 s_parallax_bg parallax s_parallax_is_fixed bg-black-50" separator=" "/>
+        <attribute name="class" add="pt224 pb200" remove="pt232 pb232 parallax s_parallax_is_fixed bg-black-50" separator=" "/>
         <attribute name="data-oe-shape-data">{'shape':'web_editor/Connections/20','colors':{'c5': 'o-color-1'},'flip':['y'], 'showOnMobile':true}</attribute>
     </xpath>
     <!-- Shape -->
@@ -13,7 +13,7 @@
     </xpath>
     <!-- Remove filter & parallax -->
     <xpath expr="//div[hasclass('o_we_bg_filter')]" position="replace"/>
-    <xpath expr="//span[hasclass('s_parallax_bg')]" position="replace"/>
+    <xpath expr="//span[hasclass('s_parallax_bg_wrap')]" position="replace"/>
     <!-- Title -->
     <xpath expr="//h1" position="replace" mode="inner">
         Emotions <br/>through the colors

--- a/theme_artists/views/snippets/s_pricelist_boxed.xml
+++ b/theme_artists/views/snippets/s_pricelist_boxed.xml
@@ -5,10 +5,10 @@
     <!-- Layout -->
     <xpath expr="//section" position="attributes">
         <attribute name="data-scroll-background-ratio"/>
-        <attribute name="class" add="o_cc o_cc5" remove="parallax s_parallax_is_fixed s_parallax_no_overflow_hidden" separator=" "/>
+        <attribute name="class" add="o_cc o_cc5" remove="parallax s_parallax_is_fixed" separator=" "/>
         <attribute name="data-oe-shape-data">{'shape':'web_editor/Wavy/27','flip':[],'showOnMobile':false,'shapeAnimationSpeed':'0','animated':'true'}</attribute>
     </xpath>
-    <xpath expr="//span[hasclass('s_parallax_bg')]" position="replace"/>
+    <xpath expr="//span[hasclass('s_parallax_bg_wrap')]" position="replace"/>
     <xpath expr="//div[hasclass('container')]" position="before">
         <div class="o_we_shape o_web_editor_Wavy_27 o_we_animated"/>
     </xpath>

--- a/theme_artists/views/snippets/s_title.xml
+++ b/theme_artists/views/snippets/s_title.xml
@@ -9,7 +9,9 @@
     </xpath>
     <!-- Parallax background & filter -->
     <xpath expr="//div[hasclass('container')]" position="before">
-        <span class="s_parallax_bg oe_img_bg" style="background-image: url('/web/image/website.s_cover_default_image');"/>
+        <span class="s_parallax_bg_wrap">
+            <span class="s_parallax_bg oe_img_bg" style="background-image: url('/web/image/website.s_cover_default_image');"/>
+        </span>
         <div class="o_we_bg_filter" style="background-color: rgba(17, 13, 22, 0.85) !important;"/>
     </xpath>
     <!-- Title -->
@@ -27,7 +29,7 @@
     <xpath expr="//h2" position="attributes">
         <attribute name="class" remove="display-3-fs" separator=" "/>
     </xpath>
-    <xpath expr="//span[hasclass('s_parallax_bg')]" position="replace"/>
+    <xpath expr="//span[hasclass('s_parallax_bg_wrap')]" position="replace"/>
     <xpath expr="//div[hasclass('o_we_bg_filter')]" position="replace"/>
 </template>
 

--- a/theme_avantgarde/views/customizations.xml
+++ b/theme_avantgarde/views/customizations.xml
@@ -12,7 +12,8 @@
 <!-- ======== COVER ======== -->
 <template id="s_cover" inherit_id="website.s_cover" name="Avantgarde s_cover">
     <xpath expr="//section" position="attributes">
-        <attribute name="class" add="s_parallax_no_overflow_hidden o_full_screen_height" remove="s_parallax_is_fixed s_parallax" separator=" "/>
+        <attribute name="class" add="o_full_screen_height" remove="s_parallax_is_fixed" separator=" "/>
+        <attribute name="data-scroll-background-ratio" add="1.5" remove="1"/>
     </xpath>
     <xpath expr="//span[hasclass('s_parallax_bg')]" position="attributes">
         <attribute name="style" remove="background-position: 50% 75%;" add="background-position: 50% 80%;" separator=";"/>

--- a/theme_bewise/views/customizations.xml
+++ b/theme_bewise/views/customizations.xml
@@ -14,7 +14,7 @@
         <div class="o_we_shape o_web_editor_Rainy_08_001"/>
     </xpath>
     <!-- Remove the background image for parallax -->
-    <xpath expr="//span[hasclass('s_parallax_bg')]" position="replace"/>
+    <xpath expr="//span[hasclass('s_parallax_bg_wrap')]" position="replace"/>
     <!-- Title -->
     <xpath expr="//h1" position="replace" mode="inner">
         Always at the top

--- a/theme_bistro/views/snippets/s_image_title.xml
+++ b/theme_bistro/views/snippets/s_image_title.xml
@@ -9,7 +9,9 @@
         <attribute name="data-scroll-background-ratio">-3</attribute>
     </xpath>
     <xpath expr="//div[hasclass('o_we_bg_filter')]" position="before">
-        <span class="s_parallax_bg oe_img_bg o_bg_img_center" style="background-image: url('/web/image/website.s_image_title_default_image') !important;"/>
+        <span class="s_parallax_bg_wrap">
+            <span class="s_parallax_bg oe_img_bg o_bg_img_center" style="background-image: url('/web/image/website.s_image_title_default_image') !important;"/>
+        </span>
     </xpath>
 
     <!-- Texts -->

--- a/theme_bistro/views/snippets/s_product_catalog.xml
+++ b/theme_bistro/views/snippets/s_product_catalog.xml
@@ -9,7 +9,9 @@
         <attribute name="data-scroll-background-ratio">1</attribute>
     </xpath>
     <xpath expr="//div[hasclass('o_we_bg_filter')]" position="replace">
-        <span class="s_parallax_bg oe_img_bg" style="background-image: url('/web/image/website.s_product_catalog_default_image'); background-position: 50% 0%;"/>
+        <span class="s_parallax_bg_wrap">
+            <span class="s_parallax_bg oe_img_bg" style="background-image: url('/web/image/website.s_product_catalog_default_image'); background-position: 50% 0%;"/>
+        </span>
         <div class="o_we_bg_filter bg-black-50"/>
     </xpath>
     <!-- Remove Title & lead -->

--- a/theme_bookstore/views/snippets/s_cover.xml
+++ b/theme_bookstore/views/snippets/s_cover.xml
@@ -14,7 +14,7 @@
         <div class="o_we_shape o_web_editor_Bold_26" style="background-image: url('/web_editor/shape/web_editor/Bold/26.svg?c5=o-color-1');"/>
     </xpath>
     <!-- Disable Parallax -->
-    <xpath expr="//span[hasclass('s_parallax_bg')]" position="replace"/>
+    <xpath expr="//span[hasclass('s_parallax_bg_wrap')]" position="replace"/>
     <!-- Title -->
     <xpath expr="//h1" position="replace" mode="inner">
         Immerse yourself <br/>in original universes

--- a/theme_bookstore/views/snippets/s_pricelist_boxed.xml
+++ b/theme_bookstore/views/snippets/s_pricelist_boxed.xml
@@ -5,7 +5,7 @@
     <!-- Layout -->
     <xpath expr="//section" position="attributes">
         <attribute name="data-scroll-background-ratio"/>
-        <attribute name="class" remove="parallax s_parallax_is_fixed s_parallax_no_overflow_hidden" separator=" "/>
+        <attribute name="class" remove="parallax s_parallax_is_fixed" separator=" "/>
         <attribute name="data-oe-shape-data">{'shape':'web_editor/Airy/13_002','colors':{'c5':'o-color-1','c3':'o-color-4'},'flip':[],'showOnMobile':false,'shapeAnimationSpeed':'0','animated':'true'}</attribute>
     </xpath>
     <xpath expr="//div[hasclass('container')]" position="before">
@@ -14,7 +14,7 @@
     <xpath expr="//div[hasclass('col-lg-8')]" position="attributes">
         <attribute name="class" add="o_cc3" remove="o_cc1 rounded" separator=" "/>
     </xpath>
-    <xpath expr="//span[hasclass('s_parallax_bg')]" position="replace"/>
+    <xpath expr="//span[hasclass('s_parallax_bg_wrap')]" position="replace"/>
 
     <!-- Texts -->
     <xpath expr="//h2" position="replace" mode="inner">

--- a/theme_buzzy/views/snippets/s_pricelist_boxed.xml
+++ b/theme_buzzy/views/snippets/s_pricelist_boxed.xml
@@ -5,13 +5,13 @@
     <!-- Layout -->
     <xpath expr="//section" position="attributes">
         <attribute name="data-scroll-background-ratio"/>
-        <attribute name="class" add="o_cc o_cc3" remove="parallax s_parallax_is_fixed s_parallax_no_overflow_hidden" separator=" "/>
+        <attribute name="class" add="o_cc o_cc3" remove="parallax s_parallax_is_fixed" separator=" "/>
         <attribute name="data-oe-shape-data">{'shape':'web_editor/Bold/15','colors':{'c5': 'o-color-3'},'flip':[],'showOnMobile':false,'shapeAnimationSpeed':'0'}</attribute>
     </xpath>
     <xpath expr="//div[hasclass('container')]" position="before">
         <div class="o_we_shape o_web_editor_Bold_15" style="background-image: url('/web_editor/shape/web_editor/Bold/15.svg?c5=o-color-3');"/>
     </xpath>
-    <xpath expr="//span[hasclass('s_parallax_bg')]" position="replace"/>
+    <xpath expr="//span[hasclass('s_parallax_bg_wrap')]" position="replace"/>
 
     <!-- Texts -->
     <xpath expr="//h2" position="replace" mode="inner">

--- a/theme_clean/views/snippets/s_pricelist_boxed.xml
+++ b/theme_clean/views/snippets/s_pricelist_boxed.xml
@@ -5,13 +5,13 @@
     <!-- Layout -->
     <xpath expr="//section" position="attributes">
         <attribute name="data-scroll-background-ratio"/>
-        <attribute name="class" add="o_cc o_cc2" remove="parallax s_parallax_is_fixed s_parallax_no_overflow_hidden" separator=" "/>
+        <attribute name="class" add="o_cc o_cc2" remove="parallax s_parallax_is_fixed" separator=" "/>
         <attribute name="data-oe-shape-data">{'shape':'web_editor/Connections/20','colors':{'c5': 'o-color-1'},'flip':['y'],'showOnMobile':false,'shapeAnimationSpeed':'0'}</attribute>
     </xpath>
     <xpath expr="//div[hasclass('container')]" position="before">
         <div class="o_we_shape o_web_editor_Connections_20" style="background-image: url('/web_editor/shape/web_editor/Connections/20.svg?c5=o-color-1&amp;flip=y');  background-position: 50% 0%"/>
     </xpath>
-    <xpath expr="//span[hasclass('s_parallax_bg')]" position="replace"/>
+    <xpath expr="//span[hasclass('s_parallax_bg_wrap')]" position="replace"/>
 
     <!-- Texts -->
     <xpath expr="//h2" position="replace" mode="inner">

--- a/theme_clean/views/snippets/s_product_catalog.xml
+++ b/theme_clean/views/snippets/s_product_catalog.xml
@@ -10,7 +10,9 @@
     </xpath>
     <!-- Filter & Parallax -->
     <xpath expr="//div[hasclass('o_we_bg_filter')]" position="replace">
-        <span class="s_parallax_bg oe_img_bg" style="background-image: url('/web/image/website.s_product_catalog_default_image');"/>
+        <span class="s_parallax_bg_wrap">
+            <span class="s_parallax_bg oe_img_bg" style="background-image: url('/web/image/website.s_product_catalog_default_image');"/>
+        </span>
         <div class="o_we_bg_filter bg-black-50"/>
     </xpath>
 </template>

--- a/theme_cobalt/views/customizations.xml
+++ b/theme_cobalt/views/customizations.xml
@@ -344,13 +344,13 @@
     <!-- Layout -->
     <xpath expr="//section" position="attributes">
         <attribute name="data-scroll-background-ratio"/>
-        <attribute name="class" add="o_cc o_cc2" remove="parallax s_parallax_is_fixed s_parallax_no_overflow_hidden" separator=" "/>
+        <attribute name="class" add="o_cc o_cc2" remove="parallax s_parallax_is_fixed" separator=" "/>
         <attribute name="data-oe-shape-data">{'shape':'web_editor/Bold/01_001','colors':{'c5':'o-color-1'},'flip':[],'showOnMobile':false,'shapeAnimationSpeed':'0'}</attribute>
     </xpath>
     <xpath expr="//div[hasclass('container')]" position="before">
         <div class="o_we_shape o_web_editor_Bold_01_001" style="background-image: url('/web_editor/shape/web_editor/Bold/01_001.svg?c5=o-color-1');"/>
     </xpath>
-    <xpath expr="//span[hasclass('s_parallax_bg')]" position="replace"/>
+    <xpath expr="//span[hasclass('s_parallax_bg_wrap')]" position="replace"/>
 
     <!-- Texts -->
     <xpath expr="//h2" position="replace" mode="inner">

--- a/theme_enark/views/snippets/s_banner.xml
+++ b/theme_enark/views/snippets/s_banner.xml
@@ -8,7 +8,9 @@
         <attribute name="data-scroll-background-ratio">1</attribute>
     </xpath>
     <xpath expr="//section/div" position="before">
-        <span class="s_parallax_bg oe_img_bg" style="background-image: url('/web/image/website.s_banner_default_image'); background-position: 50% 0;"/>
+        <span class="s_parallax_bg_wrap">
+            <span class="s_parallax_bg oe_img_bg" style="background-image: url('/web/image/website.s_banner_default_image'); background-position: 50% 0;"/>
+        </span>
     </xpath>
     <!-- Remove grid images -->
     <xpath expr="//div[hasclass('o_grid_item_image')]" position="replace"/>

--- a/theme_graphene/views/customizations.xml
+++ b/theme_graphene/views/customizations.xml
@@ -4,11 +4,11 @@
 <!-- ======== COVER ======== -->
 <template id="s_cover" inherit_id="website.s_cover" name="Graphene s_cover">
     <xpath expr="//section" position="attributes">
-        <attribute name="class" add="pt160 pb192" remove="pt232 pb232 s_parallax_is_fixed s_parallax" separator=" "/>
+        <attribute name="class" add="pt160 pb192" remove="pt232 pb232 s_parallax_is_fixed" separator=" "/>
         <attribute name="data-scroll-background-ratio">0</attribute>
         <attribute name="style">background-image: url('/web/image/website.s_cover_default_image');</attribute>
     </xpath>
-    <xpath expr="//span[hasclass('s_parallax_bg')]" position="replace"/>
+    <xpath expr="//span[hasclass('s_parallax_bg_wrap')]" position="replace"/>
     <xpath expr="//h1" position="replace"/>
     <xpath expr="//p" position="replace"/>
     <xpath expr="//p" position="replace"/>
@@ -268,11 +268,13 @@
 <!-- ======== NUMBERS ======== -->
 <template id="s_numbers" inherit_id="website.s_numbers" name="Graphene s_numbers">
     <xpath expr="//section" position="attributes">
-        <attribute name="class" add="oe_img_bg o_bg_img_center pb56 pt56 s_parallax_no_overflow_hidden parallax s_parallax_is_fixed o_cc3" remove="pb80 pt80 o_cc1" separator=" "/>
+        <attribute name="class" add="oe_img_bg o_bg_img_center pb56 pt56 parallax s_parallax_is_fixed o_cc3" remove="pb80 pt80 o_cc1" separator=" "/>
         <attribute name="data-scroll-background-ratio">1</attribute>
     </xpath>
     <xpath expr="//section/div[hasclass('container')]" position="before">
-        <span class="s_parallax_bg oe_img_bg" style="background-image: url('/web/image/website.s_parallax_default_image'); background-position: 50% 75%;"/>
+        <span class="s_parallax_bg_wrap">
+            <span class="s_parallax_bg oe_img_bg" style="background-image: url('/web/image/website.s_parallax_default_image'); background-position: 50% 75%;"/>
+        </span>
         <div class="o_we_bg_filter bg-black-75"></div>
     </xpath>
 </template>
@@ -423,7 +425,7 @@
     <!-- Layout -->
     <xpath expr="//section" position="attributes">
         <attribute name="data-scroll-background-ratio"/>
-        <attribute name="class" add="o_cc o_cc2" remove="parallax s_parallax_is_fixed s_parallax_no_overflow_hidden" separator=" "/>
+        <attribute name="class" add="o_cc o_cc2" remove="parallax s_parallax_is_fixed" separator=" "/>
         <attribute name="data-oe-shape-data">{'shape':'web_editor/Airy/11_001','colors':{'c5':'rgba(0,0,0,0.25)'},'flip':[],'showOnMobile':false,'shapeAnimationSpeed':'0'}</attribute>
     </xpath>
     <xpath expr="//div[hasclass('container')]" position="before">
@@ -432,7 +434,7 @@
     <xpath expr="//div[hasclass('col-lg-8')]" position="attributes">
         <attribute name="class" remove="rounded" separator=" "/>
     </xpath>
-    <xpath expr="//span[hasclass('s_parallax_bg')]" position="replace"/>
+    <xpath expr="//span[hasclass('s_parallax_bg_wrap')]" position="replace"/>
 
     <!-- Texts -->
     <xpath expr="//h2" position="replace" mode="inner">

--- a/theme_kea/views/snippets/s_cover.xml
+++ b/theme_kea/views/snippets/s_cover.xml
@@ -13,7 +13,7 @@
         <div class="o_we_shape o_web_editor_Floats_02" style="background-image: url('/web_editor/shape/web_editor/Floats/02.svg?c1=o-color-1&amp;c2=o-color-1&amp;c3=o-color-5&amp;c4=o-color-1&amp;c5=o-color-5');"/>
     </xpath>
     <!-- Disable Parallax -->
-    <xpath expr="//span[hasclass('s_parallax_bg')]" position="replace"/>
+    <xpath expr="//span[hasclass('s_parallax_bg_wrap')]" position="replace"/>
     <!-- Title -->
     <xpath expr="//h1" position="replace" mode="inner">
         The Revolution <br/> in Virtual Reality

--- a/theme_kea/views/snippets/s_pricelist_boxed.xml
+++ b/theme_kea/views/snippets/s_pricelist_boxed.xml
@@ -5,13 +5,13 @@
     <!-- Layout -->
     <xpath expr="//section" position="attributes">
         <attribute name="data-scroll-background-ratio"/>
-        <attribute name="class" add="o_cc o_cc3" remove="parallax s_parallax_is_fixed s_parallax_no_overflow_hidden" separator=" "/>
+        <attribute name="class" add="o_cc o_cc3" remove="parallax s_parallax_is_fixed" separator=" "/>
         <attribute name="data-oe-shape-data">{'shape':'web_editor/Floats/01','colors':{'c1':'o-color-1','c2':'o-color-1','c3':'o-color-1','c4':'o-color-1','c5':'o-color-1'},'flip':[],'showOnMobile':false,'shapeAnimationSpeed':'0','animated':'true'}</attribute>
     </xpath>
     <xpath expr="//div[hasclass('container')]" position="before">
         <div class="o_we_shape o_web_editor_Floats_01 o_we_animated" style="background-image: url('/web_editor/shape/web_editor/Floats/01.svg?c1=o-color-1&amp;c2=o-color-1&amp;c3=o-color-1&amp;c4=o-color-1&amp;c5=o-color-1');"/>
     </xpath>
-    <xpath expr="//span[hasclass('s_parallax_bg')]" position="replace"/>
+    <xpath expr="//span[hasclass('s_parallax_bg_wrap')]" position="replace"/>
 
     <!-- Texts -->
     <xpath expr="//h2" position="replace" mode="inner">

--- a/theme_kiddo/views/snippets/s_pricelist_boxed.xml
+++ b/theme_kiddo/views/snippets/s_pricelist_boxed.xml
@@ -5,13 +5,13 @@
     <!-- Layout -->
     <xpath expr="//section" position="attributes">
         <attribute name="data-scroll-background-ratio"/>
-        <attribute name="class" add="o_cc o_cc2" remove="parallax s_parallax_is_fixed s_parallax_no_overflow_hidden" separator=" "/>
+        <attribute name="class" add="o_cc o_cc2" remove="parallax s_parallax_is_fixed" separator=" "/>
         <attribute name="data-oe-shape-data">{'shape':'web_editor/Rainy/06','flip':[],'showOnMobile':false,'shapeAnimationSpeed':'0'}</attribute>
     </xpath>
     <xpath expr="//div[hasclass('container')]" position="before">
         <div class="o_we_shape o_web_editor_Rainy_06"/>
     </xpath>
-    <xpath expr="//span[hasclass('s_parallax_bg')]" position="replace"/>
+    <xpath expr="//span[hasclass('s_parallax_bg_wrap')]" position="replace"/>
 
     <!-- Texts -->
     <xpath expr="//h2" position="replace" mode="inner">

--- a/theme_loftspace/views/snippets/s_title.xml
+++ b/theme_loftspace/views/snippets/s_title.xml
@@ -9,7 +9,9 @@
     </xpath>
     <!-- Parallax background & filter -->
     <xpath expr="//div[hasclass('container')]" position="before">
-        <span class="s_parallax_bg oe_img_bg" style="background-image: url('/web/image/website.s_banner_default_image'); background-position: 50% 50%;"/>
+        <span class="s_parallax_bg_wrap">
+            <span class="s_parallax_bg oe_img_bg" style="background-image: url('/web/image/website.s_banner_default_image'); background-position: 50% 50%;"/>
+        </span>
         <div class="o_we_bg_filter bg-black-50"/>
     </xpath>
     <!-- Title -->

--- a/theme_monglia/views/customizations.xml
+++ b/theme_monglia/views/customizations.xml
@@ -519,13 +519,13 @@
     <!-- Layout -->
     <xpath expr="//section" position="attributes">
         <attribute name="data-scroll-background-ratio"/>
-        <attribute name="class" add="o_cc o_cc2" remove="parallax s_parallax_is_fixed s_parallax_no_overflow_hidden" separator=" "/>
+        <attribute name="class" add="o_cc o_cc2" remove="parallax s_parallax_is_fixed" separator=" "/>
         <attribute name="data-oe-shape-data">{'shape':'web_editor/Bold/21','flip':[],'showOnMobile':false,'shapeAnimationSpeed':'0'}</attribute>
     </xpath>
     <xpath expr="//div[hasclass('container')]" position="before">
         <div class="o_we_shape o_web_editor_Bold_21"/>
     </xpath>
-    <xpath expr="//span[hasclass('s_parallax_bg')]" position="replace"/>
+    <xpath expr="//span[hasclass('s_parallax_bg_wrap')]" position="replace"/>
 
     <!-- Texts -->
     <xpath expr="//h2" position="replace" mode="inner">

--- a/theme_nano/views/snippets/s_cover.xml
+++ b/theme_nano/views/snippets/s_cover.xml
@@ -8,7 +8,7 @@
         <attribute name="data-scroll-background-ratio">0</attribute>
         <attribute name="style">background-image: url('/web/image/website.s_cover_default_image'); background-position: 50% 0;</attribute>
     </xpath>
-    <xpath expr="//*[hasclass('s_parallax_bg')]" position="replace"/>
+    <xpath expr="//*[hasclass('s_parallax_bg_wrap')]" position="replace"/>
     <!-- Title & Text -->
     <xpath expr="//h1" position="replace" mode="inner">
         Creative Studio

--- a/theme_notes/views/snippets/s_pricelist_boxed.xml
+++ b/theme_notes/views/snippets/s_pricelist_boxed.xml
@@ -5,13 +5,13 @@
     <!-- Layout -->
     <xpath expr="//section" position="attributes">
         <attribute name="data-scroll-background-ratio"/>
-        <attribute name="class" add="o_cc o_cc3" remove="parallax s_parallax_is_fixed s_parallax_no_overflow_hidden" separator=" "/>
+        <attribute name="class" add="o_cc o_cc3" remove="parallax s_parallax_is_fixed" separator=" "/>
         <attribute name="data-oe-shape-data">{'shape':'web_editor/Rainy/08_001','flip':[],'showOnMobile':false,'shapeAnimationSpeed':'0','animated':'true'}</attribute>
     </xpath>
     <xpath expr="//div[hasclass('container')]" position="before">
         <div class="o_we_shape o_web_editor_Rainy_08_001 o_we_animated"/>
     </xpath>
-    <xpath expr="//span[hasclass('s_parallax_bg')]" position="replace"/>
+    <xpath expr="//span[hasclass('s_parallax_bg_wrap')]" position="replace"/>
 
     <!-- Texts -->
     <xpath expr="//h2" position="replace" mode="inner">

--- a/theme_notes/views/snippets/s_product_catalog.xml
+++ b/theme_notes/views/snippets/s_product_catalog.xml
@@ -4,13 +4,15 @@
 <template id="s_product_catalog" inherit_id="website.s_product_catalog">
     <!-- Section -->
     <xpath expr="//section" position="attributes">
-        <attribute name="class" add="o_cc o_cc3 pb160 pt160 parallax s_parallax_is_fixed s_parallax_no_overflow_hidden o_full_screen_height" remove="pb64 pt64" separator=" "/>
+        <attribute name="class" add="o_cc o_cc3 pb160 pt160 parallax s_parallax_is_fixed o_full_screen_height" remove="pb64 pt64" separator=" "/>
         <attribute name="data-oe-shape-data">{"shape":"web_editor/Wavy/10","colors":{"c1":"o-color-2","c2":"o-color-2"},"flip":[]}</attribute>
         <attribute name="data-scroll-background-ratio">1</attribute>
     </xpath>
     <!-- Shape & Background image -->
     <xpath expr="//div[hasclass('o_we_bg_filter')]" position="replace">
-        <span class="s_parallax_bg oe_img_bg o_bg_img_center" style="background-image: url('/web/image/website.s_product_catalog_default_image');"/>
+        <span class="s_parallax_bg_wrap">
+            <span class="s_parallax_bg oe_img_bg o_bg_img_center" style="background-image: url('/web/image/website.s_product_catalog_default_image');"/>
+        </span>
         <div class="o_we_bg_filter bg-black-50"/>
         <div class="o_we_shape o_web_editor_Wavy_10" style="background-image: url('/web_editor/shape/web_editor/Wavy/10.svg?c1=o-color-2&amp;c2=o-color-2');"/>
     </xpath>

--- a/theme_odoo_experts/views/snippets/s_pricelist_boxed.xml
+++ b/theme_odoo_experts/views/snippets/s_pricelist_boxed.xml
@@ -5,13 +5,13 @@
     <!-- Layout -->
     <xpath expr="//section" position="attributes">
         <attribute name="data-scroll-background-ratio"/>
-        <attribute name="class" add="o_cc o_cc4" remove="parallax s_parallax_is_fixed s_parallax_no_overflow_hidden" separator=" "/>
+        <attribute name="class" add="o_cc o_cc4" remove="parallax s_parallax_is_fixed" separator=" "/>
         <attribute name="data-oe-shape-data">{'shape':'web_editor/Connections/20','colors':{'c5': 'o-color-3'},'flip':['y'],'showOnMobile':false,'shapeAnimationSpeed':'0'}</attribute>
     </xpath>
     <xpath expr="//div[hasclass('container')]" position="before">
         <div class="o_we_shape o_web_editor_Connections_20" style="background-image: url('/web_editor/shape/web_editor/Connections/20.svg?c5=o-color-3&amp;flip=y'); background-position: 50% 0%"/>
     </xpath>
-    <xpath expr="//span[hasclass('s_parallax_bg')]" position="replace"/>
+    <xpath expr="//span[hasclass('s_parallax_bg_wrap')]" position="replace"/>
 
     <!-- Texts -->
     <xpath expr="//h2" position="replace" mode="inner">

--- a/theme_orchid/views/snippets/s_kickoff.xml
+++ b/theme_orchid/views/snippets/s_kickoff.xml
@@ -15,7 +15,7 @@
     </xpath>
 
     <!-- Remove the parallax effect: the background image has been already set in the main <section> tag -->
-    <xpath expr="//span[hasclass('s_parallax_bg')]" position="replace"/>
+    <xpath expr="//span[hasclass('s_parallax_bg_wrap')]" position="replace"/>
 
     <!-- Text -->
     <xpath expr="//p" position="replace" mode="inner">

--- a/theme_paptic/views/customizations.xml
+++ b/theme_paptic/views/customizations.xml
@@ -496,7 +496,7 @@
     <!-- Layout -->
     <xpath expr="//section" position="attributes">
         <attribute name="data-scroll-background-ratio"/>
-        <attribute name="class" add="o_cc o_cc2" remove="parallax s_parallax_is_fixed s_parallax_no_overflow_hidden" separator=" "/>
+        <attribute name="class" add="o_cc o_cc2" remove="parallax s_parallax_is_fixed" separator=" "/>
         <attribute name="data-oe-shape-data">{'shape':'web_editor/Bold/01_001','colors':{'c5':'o-color-2'},'flip':[],'showOnMobile':false,'shapeAnimationSpeed':'0'}</attribute>
     </xpath>
     <xpath expr="//div[hasclass('container')]" position="before">
@@ -505,7 +505,7 @@
     <xpath expr="//div[hasclass('col-lg-8')]" position="attributes">
         <attribute name="class" add="o_cc4" remove="o_cc1" separator=" "/>
     </xpath>
-    <xpath expr="//span[hasclass('s_parallax_bg')]" position="replace"/>
+    <xpath expr="//span[hasclass('s_parallax_bg_wrap')]" position="replace"/>
 
     <!-- Texts -->
     <xpath expr="//h2" position="replace" mode="inner">

--- a/theme_real_estate/views/snippets/s_pricelist_boxed.xml
+++ b/theme_real_estate/views/snippets/s_pricelist_boxed.xml
@@ -5,7 +5,7 @@
     <!-- Layout -->
     <xpath expr="//section" position="attributes">
         <attribute name="data-scroll-background-ratio"/>
-        <attribute name="class" add="o_cc o_cc2" remove="parallax s_parallax_is_fixed s_parallax_no_overflow_hidden" separator=" "/>
+        <attribute name="class" add="o_cc o_cc2" remove="parallax s_parallax_is_fixed" separator=" "/>
         <attribute name="data-oe-shape-data">{'shape':'web_editor/Blocks/04','flip':[],'showOnMobile':false,'shapeAnimationSpeed':'0'}</attribute>
     </xpath>
     <xpath expr="//div[hasclass('container')]" position="before">
@@ -14,7 +14,7 @@
     <xpath expr="//div[hasclass('col-lg-8')]" position="attributes">
         <attribute name="class" remove="rounded" separator=" "/>
     </xpath>
-    <xpath expr="//span[hasclass('s_parallax_bg')]" position="replace"/>
+    <xpath expr="//span[hasclass('s_parallax_bg_wrap')]" position="replace"/>
 
     <!-- Texts -->
     <xpath expr="//h2" position="replace" mode="inner">

--- a/theme_treehouse/views/snippets/s_title.xml
+++ b/theme_treehouse/views/snippets/s_title.xml
@@ -8,7 +8,9 @@
         <attribute name="data-scroll-background-ratio">1</attribute>
     </xpath>
     <xpath expr="//section/*" position="before">
-        <span class="s_parallax_bg oe_img_bg" style="background-image: url('/web/image/website.s_parallax_default_image'); background-position: 50% 75%;"></span>
+        <span class="s_parallax_bg_wrap">
+            <span class="s_parallax_bg oe_img_bg" style="background-image: url('/web/image/website.s_parallax_default_image'); background-position: 50% 75%;"></span>
+        </span>
         <div class="o_we_bg_filter bg-black-50"/>
     </xpath>
     <!-- Title -->

--- a/theme_yes/views/snippets/s_kickoff.xml
+++ b/theme_yes/views/snippets/s_kickoff.xml
@@ -7,10 +7,10 @@
         <attribute name="data-scroll-background-ratio"/>
         <attribute name="data-oe-shape-data">{"shape":"web_editor/Connections/05",'colors':{'c5':'o-color-3'},"flip":[]}</attribute>
         <attribute name="style" add="background-image:url(/web/image/website.s_kickoff_default_image)" separator=";"/>
-        <attribute name="class" add="pt0 pb0 oe_img_bg o_bg_img_center o_full_screen_height" remove="s_parallax s_parallax_is_fixed pt232 pb88" separator=" "/>
+        <attribute name="class" add="pt0 pb0 oe_img_bg o_bg_img_center o_full_screen_height" remove="s_parallax_is_fixed pt232 pb88" separator=" "/>
     </xpath>
         <!-- Remove Parallax + shape -->
-    <xpath expr="//span[hasclass('s_parallax_bg')]" position="replace"/>
+    <xpath expr="//span[hasclass('s_parallax_bg_wrap')]" position="replace"/>
     <xpath expr="//div[hasclass('o_we_shape')]" position="replace">
         <div class="o_we_shape o_web_editor_Connections_05" style="background-image: url('/web_editor/shape/web_editor/Connections/05.svg?c5=o-color-3');"/>
     </xpath>

--- a/theme_zap/views/snippets/s_banner.xml
+++ b/theme_zap/views/snippets/s_banner.xml
@@ -8,7 +8,9 @@
         <attribute name="data-scroll-background-ratio">1</attribute>
     </xpath>
     <xpath expr="//*[hasclass('container')]" position="before">
-        <span class="s_parallax_bg oe_img_bg" style="background-image: url('/web/image/website.s_banner_default_image'); background-position: 50% 0;"/>
+        <span class="s_parallax_bg_wrap">
+            <span class="s_parallax_bg oe_img_bg" style="background-image: url('/web/image/website.s_banner_default_image'); background-position: 50% 0;"/>
+        </span>
     </xpath>
     <!-- Row - remove grid mode -->
     <xpath expr="//div[hasclass('row')]" position="attributes">

--- a/theme_zap/views/snippets/s_pricelist_boxed.xml
+++ b/theme_zap/views/snippets/s_pricelist_boxed.xml
@@ -5,13 +5,13 @@
     <!-- Layout -->
     <xpath expr="//section" position="attributes">
         <attribute name="data-scroll-background-ratio"/>
-        <attribute name="class" add="o_cc o_cc4" remove="parallax s_parallax_is_fixed s_parallax_no_overflow_hidden" separator=" "/>
+        <attribute name="class" add="o_cc o_cc4" remove="parallax s_parallax_is_fixed" separator=" "/>
         <attribute name="data-oe-shape-data">{'shape':'web_editor/Bold/01_001','colors':{'c5':'o-color-2'},'flip':[],'showOnMobile':false,'shapeAnimationSpeed':'0'}</attribute>
     </xpath>
     <xpath expr="//div[hasclass('container')]" position="before">
         <div class="o_we_shape o_web_editor_Bold_01_001" style="background-image: url('/web_editor/shape/web_editor/Bold/01_001.svg?c5=o-color-2');"/>
     </xpath>
-    <xpath expr="//span[hasclass('s_parallax_bg')]" position="replace"/>
+    <xpath expr="//span[hasclass('s_parallax_bg_wrap')]" position="replace"/>
 
     <!-- Texts -->
     <xpath expr="//h2" position="replace" mode="inner">


### PR DESCRIPTION
This commit adapts the themes to the new Parallax effect structure. We now wrap the parallax element in another element with "overflow: hidden" to avoid setting "overflow: hidden" on sections. That was causing elements like the dropdown of the search bar to be cut off and not fully visible.

task-4926420