### PR TITLE
[IMP] theme_* : review `s_cta_badge` layout

### DIFF
--- a/theme_anelusia/views/snippets/s_empowerment.xml
+++ b/theme_anelusia/views/snippets/s_empowerment.xml
@@ -4,8 +4,11 @@
 <template id="s_empowerment" inherit_id="website.s_empowerment">
     <!-- Badge content -->
     <xpath expr="//span[hasclass('s_cta_badge')]" position="replace" mode="inner">
-        <i class="fa fa-fw fa-info-circle o_not-animable" role="img"/>&#160;&#160;Enjoy exclusive deals up to -50% ! &#160;&#160;&#160;&#160;
-        <a href="#">Shop now&#160;&#160; <i class="fa fa-long-arrow-right" role="img"/></a>
+        <i class="fa fa-fw fa-info-circle o_not-animable" role="img"/>
+        <span>
+            <span>Enjoy exclusive deals up to -50% !</span>
+            <a href="#">Shop now&#160;&#160; <i class="fa fa-long-arrow-right" role="img"/></a>
+        </span>
     </xpath>
     <!-- Title -->
     <xpath expr="//h1" position="replace" mode="inner">

--- a/theme_artists/views/snippets/s_empowerment.xml
+++ b/theme_artists/views/snippets/s_empowerment.xml
@@ -12,8 +12,11 @@
     </xpath>
     <!-- Badge content -->
     <xpath expr="//span[hasclass('s_cta_badge')]" position="replace" mode="inner">
-        <i class="fa fa-fw fa-info-circle o_not-animable" role="img"/>&#160;&#160;Don't miss the final show ! &#160;&#160;&#160;&#160;
-        <a href="#">Grab your tickets&#160;&#160; <i class="fa fa-long-arrow-right" role="img"/></a>
+        <i class="fa fa-fw fa-info-circle o_not-animable" role="img"/>
+        <span>
+            <span>Don't miss the final show !</span>
+            <a href="#">Grab your tickets&#160;&#160; <i class="fa fa-long-arrow-right" role="img"/></a>
+        </span>
     </xpath>
     <!-- Title -->
     <xpath expr="//h1" position="replace" mode="inner">

--- a/theme_avantgarde/views/customizations.xml
+++ b/theme_avantgarde/views/customizations.xml
@@ -642,8 +642,11 @@
 <template id="s_empowerment" inherit_id="website.s_empowerment">
     <!-- Badge content -->
     <xpath expr="//span[hasclass('s_cta_badge')]" position="replace" mode="inner">
-        <i class="fa fa-fw fa-info-circle o_not-animable" role="img"/>&#160;&#160;Award-Winning Designs &#160;&#160;&#160;&#160;
-        <a href="#">See Our Achievements&#160;&#160; <i class="fa fa-long-arrow-right" role="img"/></a>
+        <i class="fa fa-fw fa-info-circle o_not-animable" role="img"/>
+        <span>
+            <span>Award-Winning Designs</span>
+            <a href="#">See Our Achievements&#160;&#160; <i class="fa fa-long-arrow-right" role="img"/></a>
+        </span>
     </xpath>
     <!-- Title -->
     <xpath expr="//h1" position="replace" mode="inner">

--- a/theme_aviato/views/snippets/s_empowerment.xml
+++ b/theme_aviato/views/snippets/s_empowerment.xml
@@ -4,8 +4,11 @@
 <template id="s_empowerment" inherit_id="website.s_empowerment">
     <!-- Badge content -->
     <xpath expr="//span[hasclass('s_cta_badge')]" position="replace" mode="inner">
-        <i class="fa fa-fw fa-info-circle o_not-animable" role="img"/>&#160;&#160;Exclusive Travel Deals &#160;&#160;&#160;&#160;
-        <a href="#">View Our Offers&#160;&#160; <i class="fa fa-long-arrow-right" role="img"/></a>
+        <i class="fa fa-fw fa-info-circle o_not-animable" role="img"/>
+        <span>
+            <span>Exclusive Travel Deals</span>
+            <a href="#">View Our Offers&#160;&#160; <i class="fa fa-long-arrow-right" role="img"/></a>
+        </span>
     </xpath>
     <!-- Title -->
     <xpath expr="//h1" position="replace" mode="inner">

--- a/theme_beauty/views/snippets/s_empowerment.xml
+++ b/theme_beauty/views/snippets/s_empowerment.xml
@@ -4,8 +4,11 @@
 <template id="s_empowerment" inherit_id="website.s_empowerment">
     <!-- Badge content -->
     <xpath expr="//span[hasclass('s_cta_badge')]" position="replace" mode="inner">
-        <i class="fa fa-fw fa-info-circle o_not-animable" role="img"/>&#160;&#160;Top Beauty Picks &#160;&#160;&#160;&#160;
-        <a href="#">Explore Beauty Essentials&#160;&#160; <i class="fa fa-long-arrow-right" role="img"/></a>
+        <i class="fa fa-fw fa-info-circle o_not-animable" role="img"/>
+        <span>
+            <span>Top Beauty Picks</span>
+            <a href="#">Explore Beauty Essentials&#160;&#160; <i class="fa fa-long-arrow-right" role="img"/></a>
+        </span>
     </xpath>
     <!-- Title -->
     <xpath expr="//h1" position="replace" mode="inner">

--- a/theme_bewise/views/customizations.xml
+++ b/theme_bewise/views/customizations.xml
@@ -1113,8 +1113,11 @@
 <template id="s_empowerment" inherit_id="website.s_empowerment">
     <!-- Badge content -->
     <xpath expr="//span[hasclass('s_cta_badge')]" position="replace" mode="inner">
-        <i class="fa fa-fw fa-info-circle o_not-animable" role="img"/>&#160;&#160;Top-Ranked Programs &#160;&#160;&#160;&#160;
-        <a href="#">Discover Our Courses&#160;&#160; <i class="fa fa-long-arrow-right" role="img"/></a>
+        <i class="fa fa-fw fa-info-circle o_not-animable" role="img"/>
+        <span>
+            <span>Top-Ranked Programs</span>
+            <a href="#">Discover Our Courses&#160;&#160; <i class="fa fa-long-arrow-right" role="img"/></a>
+        </span>
     </xpath>
     <!-- Title -->
     <xpath expr="//h1" position="replace" mode="inner">

--- a/theme_bistro/views/snippets/s_empowerment.xml
+++ b/theme_bistro/views/snippets/s_empowerment.xml
@@ -4,8 +4,11 @@
 <template id="s_empowerment" inherit_id="website.s_empowerment">
     <!-- Badge content -->
     <xpath expr="//span[hasclass('s_cta_badge')]" position="replace" mode="inner">
-        <i class="fa fa-fw fa-info-circle o_not-animable" role="img"/>&#160;&#160;Explore our signature dishes&#160;&#160;&#160;&#160;
-        <a href="#">View Our Menu&#160;&#160; <i class="fa fa-long-arrow-right" role="img"/></a>
+        <i class="fa fa-fw fa-info-circle o_not-animable" role="img"/>
+        <span>
+            <span>Explore our signature dishes</span>
+            <a href="#">View Our Menu&#160;&#160; <i class="fa fa-long-arrow-right" role="img"/></a>
+        </span>
     </xpath>
     <!-- Title -->
     <xpath expr="//h1" position="replace" mode="inner">

--- a/theme_bookstore/views/snippets/s_empowerment.xml
+++ b/theme_bookstore/views/snippets/s_empowerment.xml
@@ -4,8 +4,11 @@
 <template id="s_empowerment" inherit_id="website.s_empowerment">
     <!-- Badge content -->
     <xpath expr="//span[hasclass('s_cta_badge')]" position="replace" mode="inner">
-        <i class="fa fa-fw fa-info-circle o_not-animable" role="img"/>&#160;&#160;Bestselling Titles&#160;&#160;&#160;&#160;
-        <a href="#">Explore new releases&#160;&#160; <i class="fa fa-long-arrow-right" role="img"/></a>
+        <i class="fa fa-fw fa-info-circle o_not-animable" role="img"/>
+        <span>
+            <span>Bestselling Titles</span>
+            <a href="#">Explore new releases&#160;&#160; <i class="fa fa-long-arrow-right" role="img"/></a>
+        </span>
     </xpath>
     <!-- Title -->
     <xpath expr="//h1" position="replace" mode="inner">

--- a/theme_buzzy/views/snippets/s_empowerment.xml
+++ b/theme_buzzy/views/snippets/s_empowerment.xml
@@ -4,8 +4,11 @@
 <template id="s_empowerment" inherit_id="website.s_empowerment">
     <!-- Badge content -->
     <xpath expr="//span[hasclass('s_cta_badge')]" position="replace" mode="inner">
-        <i class="fa fa-fw fa-info-circle o_not-animable" role="img"/>&#160;&#160;Industry Leaders&#160;&#160;&#160;&#160;
-        <a href="#">See our Success Stories&#160;&#160; <i class="fa fa-long-arrow-right" role="img"/></a>
+        <i class="fa fa-fw fa-info-circle o_not-animable" role="img"/>
+        <span>
+            <span>Industry Leaders</span>
+            <a href="#">See our Success Stories&#160;&#160; <i class="fa fa-long-arrow-right" role="img"/></a>
+        </span>
     </xpath>
     <!-- Title -->
     <xpath expr="//h1" position="replace" mode="inner">

--- a/theme_clean/views/snippets/s_empowerment.xml
+++ b/theme_clean/views/snippets/s_empowerment.xml
@@ -4,8 +4,11 @@
 <template id="s_empowerment" inherit_id="website.s_empowerment">
     <!-- Badge content -->
     <xpath expr="//span[hasclass('s_cta_badge')]" position="replace" mode="inner">
-        <i class="fa fa-fw fa-info-circle o_not-animable" role="img"/>&#160;&#160;Trusted expertise&#160;&#160;&#160;&#160;
-        <a href="#">Read client testimonials&#160;&#160; <i class="fa fa-long-arrow-right" role="img"/></a>
+        <i class="fa fa-fw fa-info-circle o_not-animable" role="img"/>
+        <span>
+            <span>Trusted expertise</span>
+            <a href="#">Read client testimonials&#160;&#160; <i class="fa fa-long-arrow-right" role="img"/></a>
+        </span>
     </xpath>
     <!-- Title -->
     <xpath expr="//h1" position="replace" mode="inner">

--- a/theme_cobalt/views/customizations.xml
+++ b/theme_cobalt/views/customizations.xml
@@ -644,8 +644,11 @@
 <template id="s_empowerment" inherit_id="website.s_empowerment">
     <!-- Badge content -->
     <xpath expr="//span[hasclass('s_cta_badge')]" position="replace" mode="inner">
-        <i class="fa fa-fw fa-info-circle o_not-animable" role="img"/>&#160;&#160;Innovative solutions&#160;&#160;&#160;&#160;
-        <a href="#">See our projects&#160;&#160; <i class="fa fa-long-arrow-right" role="img"/></a>
+        <i class="fa fa-fw fa-info-circle o_not-animable" role="img"/>
+        <span>
+            <span>Innovative solutions</span>
+            <a href="#">See our projects&#160;&#160; <i class="fa fa-long-arrow-right" role="img"/></a>
+        </span>
     </xpath>
     <!-- Title -->
     <xpath expr="//h1" position="replace" mode="inner">

--- a/theme_enark/views/snippets/s_empowerment.xml
+++ b/theme_enark/views/snippets/s_empowerment.xml
@@ -4,8 +4,11 @@
 <template id="s_empowerment" inherit_id="website.s_empowerment">
     <!-- Badge content -->
     <xpath expr="//span[hasclass('s_cta_badge')]" position="replace" mode="inner">
-        <i class="fa fa-fw fa-info-circle o_not-animable" role="img"/>&#160;&#160;Award-winning designs&#160;&#160;&#160;&#160;
-        <a href="#">View our portfolio&#160;&#160; <i class="fa fa-long-arrow-right" role="img"/></a>
+        <i class="fa fa-fw fa-info-circle o_not-animable" role="img"/>
+        <span>
+            <span>Award-winning designs</span>
+            <a href="#">View our portfolio&#160;&#160; <i class="fa fa-long-arrow-right" role="img"/></a>
+        </span>
     </xpath>
     <!-- Title -->
     <xpath expr="//h1" position="replace" mode="inner">

--- a/theme_graphene/views/customizations.xml
+++ b/theme_graphene/views/customizations.xml
@@ -624,8 +624,11 @@
 <template id="s_empowerment" inherit_id="website.s_empowerment">
     <!-- Badge content -->
     <xpath expr="//span[hasclass('s_cta_badge')]" position="replace" mode="inner">
-        <i class="fa fa-fw fa-info-circle o_not-animable" role="img"/>&#160;&#160;Customer-first approach&#160;&#160;&#160;&#160;
-        <a href="#">Read our reviews&#160;&#160; <i class="fa fa-long-arrow-right" role="img"/></a>
+        <i class="fa fa-fw fa-info-circle o_not-animable" role="img"/>
+        <span>
+            <span>Customer-first approach</span>
+            <a href="#">Read our reviews&#160;&#160; <i class="fa fa-long-arrow-right" role="img"/></a>
+        </span>
     </xpath>
     <!-- Title -->
     <xpath expr="//h1" position="replace" mode="inner">

--- a/theme_kea/views/snippets/s_empowerment.xml
+++ b/theme_kea/views/snippets/s_empowerment.xml
@@ -4,8 +4,11 @@
 <template id="s_empowerment" inherit_id="website.s_empowerment">
     <!-- Badge content -->
     <xpath expr="//span[hasclass('s_cta_badge')]" position="replace" mode="inner">
-        <i class="fa fa-fw fa-info-circle o_not-animable" role="img"/>&#160;&#160;Cutting-edge innovation&#160;&#160;&#160;&#160;
-        <a href="#">Explore our tech solution&#160;&#160; <i class="fa fa-long-arrow-right" role="img"/></a>
+        <i class="fa fa-fw fa-info-circle o_not-animable" role="img"/>
+        <span>
+            <span>Cutting-edge innovation</span>
+            <a href="#">Explore our tech solution&#160;&#160; <i class="fa fa-long-arrow-right" role="img"/></a>
+        </span>
     </xpath>
     <!-- Title -->
     <xpath expr="//h1" position="replace" mode="inner">

--- a/theme_kiddo/views/snippets/s_empowerment.xml
+++ b/theme_kiddo/views/snippets/s_empowerment.xml
@@ -4,8 +4,11 @@
 <template id="s_empowerment" inherit_id="website.s_empowerment">
     <!-- Badge content -->
     <xpath expr="//span[hasclass('s_cta_badge')]" position="replace" mode="inner">
-        <i class="fa fa-fw fa-info-circle o_not-animable" role="img"/>&#160;&#160;Caring hands&#160;&#160;&#160;&#160;
-        <a href="#">Learn about our approach&#160;&#160; <i class="fa fa-long-arrow-right" role="img"/></a>
+        <i class="fa fa-fw fa-info-circle o_not-animable" role="img"/>
+        <span>
+            <span>Caring hands</span>
+            <a href="#">Learn about our approach&#160;&#160; <i class="fa fa-long-arrow-right" role="img"/></a>
+        </span>
     </xpath>
     <!-- Title -->
     <xpath expr="//h1" position="replace" mode="inner">

--- a/theme_loftspace/views/snippets/s_empowerment.xml
+++ b/theme_loftspace/views/snippets/s_empowerment.xml
@@ -4,8 +4,11 @@
 <template id="s_empowerment" inherit_id="website.s_empowerment">
     <!-- Badge content -->
     <xpath expr="//span[hasclass('s_cta_badge')]" position="replace" mode="inner">
-        <i class="fa fa-fw fa-info-circle o_not-animable" role="img"/>&#160;&#160;Stylish and durable&#160;&#160;&#160;&#160;
-        <a href="#">Browse our collection&#160;&#160; <i class="fa fa-long-arrow-right" role="img"/></a>
+        <i class="fa fa-fw fa-info-circle o_not-animable" role="img"/>
+        <span>
+            <span>Stylish and durable</span>
+            <a href="#">Browse our collection&#160;&#160; <i class="fa fa-long-arrow-right" role="img"/></a>
+        </span>
     </xpath>
     <!-- Title -->
     <xpath expr="//h1" position="replace" mode="inner">

--- a/theme_monglia/views/customizations.xml
+++ b/theme_monglia/views/customizations.xml
@@ -913,8 +913,11 @@
 <template id="s_empowerment" inherit_id="website.s_empowerment">
     <!-- Badge content -->
     <xpath expr="//span[hasclass('s_cta_badge')]" position="replace" mode="inner">
-        <i class="fa fa-fw fa-info-circle o_not-animable" role="img"/>&#160;&#160;Memorable experiences&#160;&#160;&#160;&#160;
-        <a href="#">See our event highlights&#160;&#160; <i class="fa fa-long-arrow-right" role="img"/></a>
+        <i class="fa fa-fw fa-info-circle o_not-animable" role="img"/>
+        <span>
+            <span>Memorable experiences</span>
+            <a href="#">See our event highlights&#160;&#160; <i class="fa fa-long-arrow-right" role="img"/></a>
+        </span>
     </xpath>
     <!-- Title -->
     <xpath expr="//h1" position="replace" mode="inner">

--- a/theme_nano/views/snippets/s_discovery.xml
+++ b/theme_nano/views/snippets/s_discovery.xml
@@ -11,7 +11,8 @@
         <attribute name="class" add="o_cc5" remove="o_cc1" separator=" "/>
     </xpath>
     <xpath expr="//span[hasclass('s_cta_badge')]" position="replace" mode="inner">
-        <i class="fa fa-fw fa-circle text-success o_not-animable" aria-hidden="true"/><span class="o_small-fs">&#160;&#160;AVAILABLE FOR NEW PROJECTS</span>
+        <i class="fa fa-fw fa-circle text-success o_not-animable" aria-hidden="true"/><span class="o_small-fs">&#160;&#160;</span>
+        <span class="o_small-fs">AVAILABLE FOR NEW PROJECTS</span>
     </xpath>
 
     <xpath expr="//h1" position="replace">
@@ -29,7 +30,11 @@
 <template id="configurator_s_discovery" inherit_id="website.configurator_s_discovery">
     <!-- CTA -->
     <xpath expr="//span[hasclass('s_cta_badge')]" position="replace" mode="inner">
-        <i class="fa fa-circle text-success" aria-hidden="true"/>&#160;&#160;AVAILABLE FOR NEW PROJECTS&#160;&#160;&#160;&#160;<a href="#">Contact us&#160;&#160;<i class="fa fa-long-arrow-right" aria-hidden="true"/></a>
+        <i class="fa fa-circle text-success" aria-hidden="true"/>
+        <span>
+            <span>AVAILABLE FOR NEW PROJECTS</span>
+            <a href="#">Contact us&#160;&#160; <i class="fa fa-long-arrow-right" role="img"/></a>
+        </span>
     </xpath>
 </template>
 

--- a/theme_nano/views/snippets/s_empowerment.xml
+++ b/theme_nano/views/snippets/s_empowerment.xml
@@ -4,8 +4,11 @@
 <template id="s_empowerment" inherit_id="website.s_empowerment">
     <!-- Badge content -->
     <xpath expr="//span[hasclass('s_cta_badge')]" position="replace" mode="inner">
-        <i class="fa fa-fw fa-info-circle o_not-animable" role="img"/>&#160;&#160;Creative solutions&#160;&#160;&#160;&#160;
-        <a href="#">See our work&#160;&#160; <i class="fa fa-long-arrow-right" role="img"/></a>
+        <i class="fa fa-fw fa-info-circle o_not-animable" role="img"/>
+        <span>
+            <span>Creative solutions</span>
+            <a href="#">See our work&#160;&#160; <i class="fa fa-long-arrow-right" role="img"/></a>
+        </span>
     </xpath>
     <!-- Title -->
     <xpath expr="//h1" position="replace" mode="inner">

--- a/theme_notes/views/snippets/s_empowerment.xml
+++ b/theme_notes/views/snippets/s_empowerment.xml
@@ -4,8 +4,11 @@
 <template id="s_empowerment" inherit_id="website.s_empowerment">
     <!-- Badge content -->
     <xpath expr="//span[hasclass('s_cta_badge')]" position="replace" mode="inner">
-        <i class="fa fa-fw fa-info-circle o_not-animable" role="img"/>&#160;&#160;High-energy performances&#160;&#160;&#160;&#160;
-        <a href="#">Listen to our latest tracks&#160;&#160; <i class="fa fa-long-arrow-right" role="img"/></a>
+        <i class="fa fa-fw fa-info-circle o_not-animable" role="img"/>
+        <span>
+            <span>High-energy performances</span>
+            <a href="#">Listen to our latest tracks&#160;&#160; <i class="fa fa-long-arrow-right" role="img"/></a>
+        </span>
     </xpath>
     <!-- Title -->
     <xpath expr="//h1" position="replace" mode="inner">

--- a/theme_odoo_experts/views/snippets/s_empowerment.xml
+++ b/theme_odoo_experts/views/snippets/s_empowerment.xml
@@ -4,8 +4,11 @@
 <template id="s_empowerment" inherit_id="website.s_empowerment">
     <!-- Badge content -->
     <xpath expr="//span[hasclass('s_cta_badge')]" position="replace" mode="inner">
-        <i class="fa fa-fw fa-info-circle o_not-animable" role="img"/>&#160;&#160;Trusted guidance&#160;&#160;&#160;&#160;
-        <a href="#">Read our client success stories&#160;&#160; <i class="fa fa-long-arrow-right" role="img"/></a>
+        <i class="fa fa-fw fa-info-circle o_not-animable" role="img"/>
+        <span>
+            <span>Trusted guidance</span>
+            <a href="#">Read our client success stories&#160;&#160; <i class="fa fa-long-arrow-right" role="img"/></a>
+        </span>
     </xpath>
     <!-- Title -->
     <xpath expr="//h1" position="replace" mode="inner">

--- a/theme_orchid/views/snippets/s_empowerment.xml
+++ b/theme_orchid/views/snippets/s_empowerment.xml
@@ -4,8 +4,11 @@
 <template id="s_empowerment" inherit_id="website.s_empowerment">
     <!-- Badge content -->
     <xpath expr="//span[hasclass('s_cta_badge')]" position="replace" mode="inner">
-        <i class="fa fa-fw fa-info-circle o_not-animable" role="img"/>&#160;&#160;Fresh and beautiful&#160;&#160;&#160;&#160;
-        <a href="#">Browse our floral arrangements&#160;&#160; <i class="fa fa-long-arrow-right" role="img"/></a>
+        <i class="fa fa-fw fa-info-circle o_not-animable" role="img"/>
+        <span>
+            <span>Fresh and beautiful</span>
+            <a href="#">Browse our floral arrangements&#160;&#160; <i class="fa fa-long-arrow-right" role="img"/></a>
+        </span>
     </xpath>
     <!-- Title -->
     <xpath expr="//h1" position="replace" mode="inner">

--- a/theme_paptic/views/customizations.xml
+++ b/theme_paptic/views/customizations.xml
@@ -725,8 +725,11 @@
 <template id="s_empowerment" inherit_id="website.s_empowerment">
     <!-- Badge content -->
     <xpath expr="//span[hasclass('s_cta_badge')]" position="replace" mode="inner">
-        <i class="fa fa-fw fa-info-circle o_not-animable" role="img"/>&#160;&#160;Strategic insights&#160;&#160;&#160;&#160;
-        <a href="#">Explore our case studies&#160;&#160; <i class="fa fa-long-arrow-right" role="img"/></a>
+        <i class="fa fa-fw fa-info-circle o_not-animable" role="img"/>
+        <span>
+            <span>Strategic insights</span>
+            <a href="#">Explore our case studies&#160;&#160; <i class="fa fa-long-arrow-right" role="img"/></a>
+        </span>
     </xpath>
     <!-- Title -->
     <xpath expr="//h1" position="replace" mode="inner">

--- a/theme_real_estate/views/snippets/s_empowerment.xml
+++ b/theme_real_estate/views/snippets/s_empowerment.xml
@@ -4,8 +4,11 @@
 <template id="s_empowerment" inherit_id="website.s_empowerment">
     <!-- Badge content -->
     <xpath expr="//span[hasclass('s_cta_badge')]" position="replace" mode="inner">
-        <i class="fa fa-fw fa-info-circle o_not-animable" role="img"/>&#160;&#160;Prime properties&#160;&#160;&#160;&#160;
-        <a href="#">View our listings&#160;&#160; <i class="fa fa-long-arrow-right" role="img"/></a>
+        <i class="fa fa-fw fa-info-circle o_not-animable" role="img"/>
+        <span>
+            <span>Prime properties</span>
+            <a href="#">View our listings&#160;&#160; <i class="fa fa-long-arrow-right" role="img"/></a>
+        </span>
     </xpath>
     <!-- Title -->
     <xpath expr="//h1" position="replace" mode="inner">

--- a/theme_treehouse/views/snippets/s_empowerment.xml
+++ b/theme_treehouse/views/snippets/s_empowerment.xml
@@ -4,8 +4,11 @@
 <template id="s_empowerment" inherit_id="website.s_empowerment">
     <!-- Badge content -->
     <xpath expr="//span[hasclass('s_cta_badge')]" position="replace" mode="inner">
-        <i class="fa fa-fw fa-info-circle o_not-animable" role="img"/>&#160;&#160;Eco-friendly retreats&#160;&#160;&#160;&#160;
-        <a href="#">Discover our natural escapes&#160;&#160; <i class="fa fa-long-arrow-right" role="img"/></a>
+        <i class="fa fa-fw fa-info-circle o_not-animable" role="img"/>
+        <span>
+            <span>Eco-friendly retreats</span>
+            <a href="#">Discover our natural escapes&#160;&#160; <i class="fa fa-long-arrow-right" role="img"/></a>
+        </span>
     </xpath>
     <!-- Title -->
     <xpath expr="//h1" position="replace" mode="inner">

--- a/theme_vehicle/views/customizations.xml
+++ b/theme_vehicle/views/customizations.xml
@@ -867,8 +867,11 @@
 <template id="s_empowerment" inherit_id="website.s_empowerment">
     <!-- Badge content -->
     <xpath expr="//span[hasclass('s_cta_badge')]" position="replace" mode="inner">
-        <i class="fa fa-fw fa-info-circle o_not-animable" role="img"/>&#160;&#160;Top-rated vehicles&#160;&#160;&#160;&#160;
-        <a href="#">Browse our inventory&#160;&#160; <i class="fa fa-long-arrow-right" role="img"/></a>
+        <i class="fa fa-fw fa-info-circle o_not-animable" role="img"/>
+        <span>
+            <span>Top-rated vehicles</span>
+            <a href="#">Browse our inventory&#160;&#160; <i class="fa fa-long-arrow-right" role="img"/></a>
+        </span>
     </xpath>
     <!-- Title -->
     <xpath expr="//h1" position="replace" mode="inner">

--- a/theme_yes/views/snippets/s_empowerment.xml
+++ b/theme_yes/views/snippets/s_empowerment.xml
@@ -4,8 +4,11 @@
 <template id="s_empowerment" inherit_id="website.s_empowerment">
     <!-- Badge content -->
     <xpath expr="//span[hasclass('s_cta_badge')]" position="replace" mode="inner">
-        <i class="fa fa-fw fa-info-circle o_not-animable" role="img"/>&#160;&#160;Dream weddings&#160;&#160;&#160;&#160;
-        <a href="#">See our wedding galleries&#160;&#160; <i class="fa fa-long-arrow-right" role="img"/></a>
+        <i class="fa fa-fw fa-info-circle o_not-animable" role="img"/>
+        <span>
+            <span>Dream weddings</span>
+            <a href="#">See our wedding galleries&#160;&#160; <i class="fa fa-long-arrow-right" role="img"/></a>
+        </span>
     </xpath>
     <!-- Title -->
     <xpath expr="//h1" position="replace" mode="inner">

--- a/theme_zap/views/snippets/s_discovery.xml
+++ b/theme_zap/views/snippets/s_discovery.xml
@@ -15,7 +15,11 @@
     </xpath>
     <!-- CTA -->
     <xpath expr="//span[hasclass('s_cta_badge')]" position="replace" mode="inner">
-        <i class="fa fa-circle text-success" role="presentation"/>&#160;&#160;We're hiring now!&#160;&#160;&#160;&#160;<a href="#">See more&#160;&#160;<i class="fa fa-long-arrow-right" role="presentation"/></a>
+        <i class="fa fa-circle text-success" role="presentation"/>
+        <span>
+            <span>We're hiring now!</span>
+            <a href="#">See more&#160;&#160; <i class="fa fa-long-arrow-right" role="img"/></a>
+        </span>
     </xpath>
     <xpath expr="//span[hasclass('s_cta_badge')]" position="attributes">
         <attribute name="class" remove="border" separator=" "/>

--- a/theme_zap/views/snippets/s_empowerment.xml
+++ b/theme_zap/views/snippets/s_empowerment.xml
@@ -4,8 +4,11 @@
 <template id="s_empowerment" inherit_id="website.s_empowerment">
     <!-- Badge content -->
     <xpath expr="//span[hasclass('s_cta_badge')]" position="replace" mode="inner">
-        <i class="fa fa-fw fa-info-circle o_not-animable" role="img"/>&#160;&#160;Innovative solutions&#160;&#160;&#160;&#160;
-        <a href="#">See our projects&#160;&#160; <i class="fa fa-long-arrow-right" role="img"/></a>
+        <i class="fa fa-fw fa-info-circle o_not-animable" role="img"/>
+        <span>
+            <span>Innovative solutions</span>
+            <a href="#">See our projects&#160;&#160; <i class="fa fa-long-arrow-right" role="img"/></a>
+        </span>
     </xpath>
     <!-- Title -->
     <xpath expr="//h1" position="replace" mode="inner">


### PR DESCRIPTION
*: anelusia, artists, avantgarde, aviato, beauty, bewise, bistro, bookstore, buzzy, clean, cobalt, enark, graphene, kea, kiddo, loftspace, monglia, nano, notes, odoo_experts, orchid, paptic, real_estate, treehouse, vehicle, yes, zap

This PR adapts the occurrences of `s_cta_badge` across themes as the layout was changed to be more flexible.

task-4942904