### PR TITLE
[FIX] theme_anelusia, *: 'web_editor' to 'html_builder' in shapeId

### DIFF
--- a/theme_anelusia/views/snippets/s_accordion_image.xml
+++ b/theme_anelusia/views/snippets/s_accordion_image.xml
@@ -7,7 +7,7 @@
     </xpath>
     <xpath expr="//img" position="attributes">
         <attribute name="src">/web_editor/image_shape/website.s_accordion_image_default_image/web_editor/solid/solid_square_1.svg?c2=o-color-1</attribute>
-        <attribute name="data-shape">web_editor/solid/solid_square_1</attribute>
+        <attribute name="data-shape">html_builder/solid/solid_square_1</attribute>
         <attribute name="data-format-mimetype">image/webp</attribute>
         <attribute name="data-file-name">s_accordion_image_default_image.svg</attribute>
         <attribute name="data-shape-colors">;o-color-1;;;</attribute>

--- a/theme_anelusia/views/snippets/s_company_team.xml
+++ b/theme_anelusia/views/snippets/s_company_team.xml
@@ -26,7 +26,7 @@
     <!-- Team #01 - Img -->
     <xpath expr="//img" position="attributes">
         <attribute name="src">/web_editor/image_shape/website.s_company_team_image_1/web_editor/geometric/geo_square_1.svg</attribute>
-        <attribute name="data-shape">web_editor/geometric/geo_square_1</attribute>
+        <attribute name="data-shape">html_builder/geometric/geo_square_1</attribute>
         <attribute name="data-format-mimetype">image/webp</attribute>
         <attribute name="data-file-name">uiface_1.svg</attribute>
         <attribute name="data-shape-colors">;;;;</attribute>
@@ -52,7 +52,7 @@
     <!-- Team #02 - Img -->
     <xpath expr="(//img)[2]" position="attributes">
         <attribute name="src">/web_editor/image_shape/website.s_company_team_image_2/web_editor/geometric/geo_square_2.svg</attribute>
-        <attribute name="data-shape">web_editor/geometric/geo_square_2</attribute>
+        <attribute name="data-shape">html_builder/geometric/geo_square_2</attribute>
         <attribute name="data-format-mimetype">image/webp</attribute>
         <attribute name="data-file-name">uiface_2.svg</attribute>
         <attribute name="data-shape-colors">;;;;</attribute>
@@ -77,7 +77,7 @@
     <!-- Team #03 - Img -->
     <xpath expr="(//img)[3]" position="attributes">
         <attribute name="src">/web_editor/image_shape/website.s_company_team_image_3/web_editor/geometric/geo_square_3.svg</attribute>
-        <attribute name="data-shape">web_editor/geometric/geo_square_3</attribute>
+        <attribute name="data-shape">html_builder/geometric/geo_square_3</attribute>
         <attribute name="data-format-mimetype">image/webp</attribute>
         <attribute name="data-file-name">uiface_3.svg</attribute>
         <attribute name="data-shape-colors">;;;;</attribute>
@@ -102,7 +102,7 @@
     <!-- Team #04 - Img -->
     <xpath expr="(//img)[4]" position="attributes">
         <attribute name="src">/web_editor/image_shape/website.s_company_team_image_4/web_editor/geometric/geo_square_1.svg</attribute>
-        <attribute name="data-shape">web_editor/geometric/geo_square_1</attribute>
+        <attribute name="data-shape">html_builder/geometric/geo_square_1</attribute>
         <attribute name="data-format-mimetype">image/webp</attribute>
         <attribute name="data-file-name">uiface_4.svg</attribute>
         <attribute name="data-shape-colors">;;;;</attribute>

--- a/theme_anelusia/views/snippets/s_company_team_basic.xml
+++ b/theme_anelusia/views/snippets/s_company_team_basic.xml
@@ -14,7 +14,7 @@
     <xpath expr="(//img)[1]" position="attributes">
         <attribute name="class" remove="rounded-circle" separator=" "/>
         <attribute name="src">/web_editor/image_shape/website.s_company_team_image_1/web_editor/geometric/geo_square_6.svg</attribute>
-        <attribute name="data-shape">web_editor/geometric/geo_square_6</attribute>
+        <attribute name="data-shape">html_builder/geometric/geo_square_6</attribute>
         <attribute name="data-format-mimetype">image/webp</attribute>
         <attribute name="data-file-name">uiface_1.svg</attribute>
         <attribute name="data-shape-colors">;;;;</attribute>
@@ -32,7 +32,7 @@
     <xpath expr="(//img)[2]" position="attributes">
         <attribute name="class" remove="rounded-circle" separator=" "/>
         <attribute name="src">/web_editor/image_shape/website.s_company_team_image_2/web_editor/geometric/geo_square_4.svg</attribute>
-        <attribute name="data-shape">web_editor/geometric/geo_square_4</attribute>
+        <attribute name="data-shape">html_builder/geometric/geo_square_4</attribute>
         <attribute name="data-format-mimetype">image/webp</attribute>
         <attribute name="data-file-name">uiface_2.svg</attribute>
         <attribute name="data-shape-colors">;;;;</attribute>
@@ -50,7 +50,7 @@
     <xpath expr="(//img)[3]" position="attributes">
         <attribute name="class" remove="rounded-circle" separator=" "/>
         <attribute name="src">/web_editor/image_shape/website.s_company_team_image_3/web_editor/geometric/geo_square_3.svg</attribute>
-        <attribute name="data-shape">web_editor/geometric/geo_square_3</attribute>
+        <attribute name="data-shape">html_builder/geometric/geo_square_3</attribute>
         <attribute name="data-format-mimetype">image/webp</attribute>
         <attribute name="data-file-name">uiface_3.svg</attribute>
         <attribute name="data-shape-colors">;;;;</attribute>
@@ -68,7 +68,7 @@
     <xpath expr="(//img)[4]" position="attributes">
         <attribute name="class" remove="rounded-circle" separator=" "/>
         <attribute name="src">/web_editor/image_shape/website.s_company_team_image_4/web_editor/geometric/geo_square_5.svg</attribute>
-        <attribute name="data-shape">web_editor/geometric/geo_square_5</attribute>
+        <attribute name="data-shape">html_builder/geometric/geo_square_5</attribute>
         <attribute name="data-format-mimetype">image/webp</attribute>
         <attribute name="data-file-name">uiface_4.svg</attribute>
         <attribute name="data-shape-colors">;;;;</attribute>

--- a/theme_anelusia/views/snippets/s_image_text.xml
+++ b/theme_anelusia/views/snippets/s_image_text.xml
@@ -5,7 +5,7 @@
     <!-- Img -->
     <xpath expr="//img" position="attributes">
         <attribute name="src">/web_editor/image_shape/website.s_image_text_default_image/web_editor/composition/composition_square_1.svg?c1=o-color-1&amp;c2=o-color-3</attribute>
-        <attribute name="data-shape">web_editor/composition/composition_square_1</attribute>
+        <attribute name="data-shape">html_builder/composition/composition_square_1</attribute>
         <attribute name="data-format-mimetype">image/webp</attribute>
         <attribute name="data-file-name">s_image_text.svg</attribute>
         <attribute name="data-shape-colors">o-color-1;o-color-3;;;</attribute>

--- a/theme_anelusia/views/snippets/s_key_images.xml
+++ b/theme_anelusia/views/snippets/s_key_images.xml
@@ -8,14 +8,14 @@
     </xpath>
     <xpath expr="//img" position="attributes">
         <attribute name="src">/web_editor/image_shape/website.s_key_images_default_image_1/web_editor/geometric/geo_square_6.svg</attribute>
-        <attribute name="data-shape">web_editor/geometric/geo_square_6</attribute>
+        <attribute name="data-shape">html_builder/geometric/geo_square_6</attribute>
         <attribute name="data-format-mimetype">image/webp</attribute>
         <attribute name="data-file-name">s_key_images_default_image_1.svg</attribute>
         <attribute name="data-shape-colors">;;;;</attribute>
     </xpath>
     <xpath expr="(//img)[4]" position="attributes">
         <attribute name="src">/web_editor/image_shape/website.s_key_images_default_image_4/web_editor/geometric/geo_square_5.svg</attribute>
-        <attribute name="data-shape">web_editor/geometric/geo_square_5</attribute>
+        <attribute name="data-shape">html_builder/geometric/geo_square_5</attribute>
         <attribute name="data-format-mimetype">image/webp</attribute>
         <attribute name="data-file-name">s_key_images_default_image_4.svg</attribute>
         <attribute name="data-shape-colors">;;;;</attribute>

--- a/theme_anelusia/views/snippets/s_media_list.xml
+++ b/theme_anelusia/views/snippets/s_media_list.xml
@@ -18,7 +18,7 @@
     <!-- Media #01 - Img -->
     <xpath expr="//div[hasclass('s_media_list_img_wrapper')]//img" position="attributes">
         <attribute name="src">/web_editor/image_shape/website.s_media_list_default_image_1/web_editor/composition/composition_square_1.svg?c1=o-color-4&amp;c2=o-color-2</attribute>
-        <attribute name="data-shape">web_editor/composition/composition_square_1</attribute>
+        <attribute name="data-shape">html_builder/composition/composition_square_1</attribute>
         <attribute name="data-format-mimetype">image/webp</attribute>
         <attribute name="data-file-name">s_media_list_1.svg</attribute>
         <attribute name="data-shape-colors">o-color-4;o-color-2;;;</attribute>
@@ -47,7 +47,7 @@
     <!-- Media #02 - Img -->
     <xpath expr="(//div[hasclass('s_media_list_img_wrapper')])[2]//img" position="attributes">
         <attribute name="src">/web_editor/image_shape/website.s_media_list_default_image_2/web_editor/composition/composition_square_3.svg?c1=o-color-1&amp;c5=o-color-2</attribute>
-        <attribute name="data-shape">web_editor/composition/composition_square_3</attribute>
+        <attribute name="data-shape">html_builder/composition/composition_square_3</attribute>
         <attribute name="data-format-mimetype">image/webp</attribute>
         <attribute name="data-file-name">s_media_list_2.svg</attribute>
         <attribute name="data-shape-colors">o-color-1;;;;o-color-2</attribute>

--- a/theme_anelusia/views/snippets/s_product_list.xml
+++ b/theme_anelusia/views/snippets/s_product_list.xml
@@ -28,7 +28,7 @@
     <!-- Item #1 - Img -->
     <xpath expr="//img" position="attributes">
         <attribute name="src">/web_editor/image_shape/website.s_product_list_default_image_1/web_editor/geometric/geo_square_1.svg</attribute>
-        <attribute name="data-shape">web_editor/geometric/geo_square_1</attribute>
+        <attribute name="data-shape">html_builder/geometric/geo_square_1</attribute>
         <attribute name="data-format-mimetype">image/webp</attribute>
         <attribute name="data-file-name">s_product_1.svg</attribute>
         <attribute name="data-shape-colors">;;;;</attribute>
@@ -36,7 +36,7 @@
     <!-- Item #2 - Img -->
     <xpath expr="(//img)[2]" position="attributes">
         <attribute name="src">/web_editor/image_shape/website.s_product_list_default_image_2/web_editor/geometric/geo_square_3.svg</attribute>
-        <attribute name="data-shape">web_editor/geometric/geo_square_3</attribute>
+        <attribute name="data-shape">html_builder/geometric/geo_square_3</attribute>
         <attribute name="data-format-mimetype">image/webp</attribute>
         <attribute name="data-file-name">s_product_2.svg</attribute>
         <attribute name="data-shape-colors">;;;;</attribute>
@@ -44,7 +44,7 @@
     <!-- Item #3 - Img -->
     <xpath expr="(//img)[3]" position="attributes">
         <attribute name="src">/web_editor/image_shape/website.s_product_list_default_image_3/web_editor/geometric/geo_square_2.svg</attribute>
-        <attribute name="data-shape">web_editor/geometric/geo_square_2</attribute>
+        <attribute name="data-shape">html_builder/geometric/geo_square_2</attribute>
         <attribute name="data-format-mimetype">image/webp</attribute>
         <attribute name="data-file-name">s_product_3.svg</attribute>
         <attribute name="data-shape-colors">;;;;</attribute>
@@ -52,7 +52,7 @@
     <!-- Item #4 - Img -->
     <xpath expr="(//img)[4]" position="attributes">
         <attribute name="src">/web_editor/image_shape/website.s_product_list_default_image_4/web_editor/geometric/geo_square_1.svg</attribute>
-        <attribute name="data-shape">web_editor/geometric/geo_square_1</attribute>
+        <attribute name="data-shape">html_builder/geometric/geo_square_1</attribute>
         <attribute name="data-format-mimetype">image/webp</attribute>
         <attribute name="data-file-name">s_product_4.svg</attribute>
         <attribute name="data-shape-colors">;;;;</attribute>
@@ -60,7 +60,7 @@
     <!-- Item #5 - Img -->
     <xpath expr="(//img)[5]" position="attributes">
         <attribute name="src">/web_editor/image_shape/website.s_product_list_default_image_5/web_editor/geometric/geo_square_2.svg</attribute>
-        <attribute name="data-shape">web_editor/geometric/geo_square_2</attribute>
+        <attribute name="data-shape">html_builder/geometric/geo_square_2</attribute>
         <attribute name="data-format-mimetype">image/webp</attribute>
         <attribute name="data-file-name">s_product_5.svg</attribute>
         <attribute name="data-shape-colors">;;;;</attribute>
@@ -68,7 +68,7 @@
     <!-- Item #6 - Img -->
     <xpath expr="(//img)[6]" position="attributes">
         <attribute name="src">/web_editor/image_shape/website.s_product_list_default_image_6/web_editor/geometric/geo_square_3.svg</attribute>
-        <attribute name="data-shape">web_editor/geometric/geo_square_3</attribute>
+        <attribute name="data-shape">html_builder/geometric/geo_square_3</attribute>
         <attribute name="data-format-mimetype">image/webp</attribute>
         <attribute name="data-file-name">s_product_6.svg</attribute>
         <attribute name="data-shape-colors">;;;;</attribute>

--- a/theme_anelusia/views/snippets/s_text_image.xml
+++ b/theme_anelusia/views/snippets/s_text_image.xml
@@ -9,7 +9,7 @@
     <!-- Img -->
     <xpath expr="//img" position="attributes">
         <attribute name="src">/web_editor/image_shape/website.s_text_image_default_image/web_editor/composition/composition_square_3.svg?c1=o-color-2&amp;c5=o-color-1</attribute>
-        <attribute name="data-shape">web_editor/composition/composition_square_3</attribute>
+        <attribute name="data-shape">html_builder/composition/composition_square_3</attribute>
         <attribute name="data-format-mimetype">image/webp</attribute>
         <attribute name="data-file-name">s_text_image.svg</attribute>
         <attribute name="data-shape-colors">o-color-2;;;;o-color-1</attribute>

--- a/theme_anelusia/views/snippets/s_wavy_grid.xml
+++ b/theme_anelusia/views/snippets/s_wavy_grid.xml
@@ -10,14 +10,14 @@
     <xpath expr="//div[hasclass('o_we_shape')]" position="replace"/>
     <xpath expr="//img" position="attributes">
         <attribute name="src">/web_editor/image_shape/website.s_wavy_grid_default_image_1/web_editor/geometric/geo_square_3.svg</attribute>
-        <attribute name="data-shape">web_editor/geometric/geo_square_3</attribute>
+        <attribute name="data-shape">html_builder/geometric/geo_square_3</attribute>
         <attribute name="data-format-mimetype">image/webp</attribute>
         <attribute name="data-file-name">s_wavy_grid_default_image_1.svg</attribute>
         <attribute name="data-shape-colors">;;;;</attribute>
     </xpath>
     <xpath expr="(//img)[4]" position="attributes">
         <attribute name="src">/web_editor/image_shape/website.s_wavy_grid_default_image_4/web_editor/geometric/geo_square_6.svg</attribute>
-        <attribute name="data-shape">web_editor/geometric/geo_square_6</attribute>
+        <attribute name="data-shape">html_builder/geometric/geo_square_6</attribute>
         <attribute name="data-format-mimetype">image/webp</attribute>
         <attribute name="data-file-name">s_wavy_grid_default_image_4.svg</attribute>
         <attribute name="data-shape-colors">;;;;</attribute>

--- a/theme_artists/views/snippets/s_accordion_image.xml
+++ b/theme_artists/views/snippets/s_accordion_image.xml
@@ -7,7 +7,7 @@
     </xpath>
     <xpath expr="//img" position="attributes">
         <attribute name="src">/web_editor/image_shape/website.s_accordion_image_default_image/web_editor/geometric/geo_square_3.svg</attribute>
-        <attribute name="data-shape">web_editor/geometric/geo_square_3</attribute>
+        <attribute name="data-shape">html_builder/geometric/geo_square_3</attribute>
         <attribute name="data-format-mimetype">image/webp</attribute>
         <attribute name="data-file-name">s_accordion_image_default_image.svg</attribute>
         <attribute name="data-shape-colors">;;;;</attribute>

--- a/theme_artists/views/snippets/s_image_text.xml
+++ b/theme_artists/views/snippets/s_image_text.xml
@@ -16,7 +16,7 @@
     <!-- Picture -->
     <xpath expr="//img" position="attributes">
         <attribute name="src">/web_editor/image_shape/website.s_image_text_default_image/web_editor/geometric/geo_square_3.svg</attribute>
-        <attribute name="data-shape">web_editor/geometric/geo_square_3</attribute>
+        <attribute name="data-shape">html_builder/geometric/geo_square_3</attribute>
         <attribute name="data-format-mimetype">image/webp</attribute>
         <attribute name="data-file-name">s_image_text.svg</attribute>
         <attribute name="data-shape-colors">;;;;</attribute>

--- a/theme_artists/views/snippets/s_text_image.xml
+++ b/theme_artists/views/snippets/s_text_image.xml
@@ -23,7 +23,7 @@
     </xpath>
     <xpath expr="//img" position="attributes">
         <attribute name="src">/web_editor/image_shape/website.s_text_image_default_image/web_editor/geometric/geo_square_2.svg</attribute>
-        <attribute name="data-shape">web_editor/geometric/geo_square_2</attribute>
+        <attribute name="data-shape">html_builder/geometric/geo_square_2</attribute>
         <attribute name="data-format-mimetype">image/webp</attribute>
         <attribute name="data-file-name">s_text_image.svg</attribute>
         <attribute name="data-shape-colors">;;;;</attribute>

--- a/theme_avantgarde/views/customizations.xml
+++ b/theme_avantgarde/views/customizations.xml
@@ -125,7 +125,7 @@
     </xpath>
     <xpath expr="//img" position="attributes">
         <attribute name="src">/web_editor/image_shape/website.s_picture_default_image/web_editor/panel/panel_duo_step.svg</attribute>
-        <attribute name="data-shape">web_editor/panel/panel_duo_step</attribute>
+        <attribute name="data-shape">html_builder/panel/panel_duo_step</attribute>
         <attribute name="data-format-mimetype">image/webp</attribute>
         <attribute name="data-file-name">bg_image_14.svg</attribute>
     </xpath>
@@ -210,7 +210,7 @@
     </xpath>
     <xpath expr="//img" position="attributes">
         <attribute name="src">/web_editor/image_shape/website.s_text_image_default_image/web_editor/panel/panel_trio_out_r.svg</attribute>
-        <attribute name="data-shape">web_editor/panel/panel_trio_out_r</attribute>
+        <attribute name="data-shape">html_builder/panel/panel_trio_out_r</attribute>
         <attribute name="data-format-mimetype">image/webp</attribute>
         <attribute name="data-file-name">bg_image_13.svg</attribute>
     </xpath>
@@ -811,7 +811,7 @@
     </xpath>
     <xpath expr="//img" position="attributes">
         <attribute name="src">/web_editor/image_shape/website.s_company_team_image_1/web_editor/geometric_round/geo_round_gem.svg</attribute>
-        <attribute name="data-shape">web_editor/geometric_round/geo_round_gem</attribute>
+        <attribute name="data-shape">html_builder/geometric_round/geo_round_gem</attribute>
         <attribute name="data-format-mimetype">image/jpeg</attribute>
         <attribute name="data-file-name">uiface_1.svg</attribute>
         <attribute name="data-shape-colors">;;;;</attribute>
@@ -822,7 +822,7 @@
     </xpath>
     <xpath expr="(//img)[2]" position="attributes">
         <attribute name="src">/web_editor/image_shape/website.s_company_team_image_2/web_editor/geometric_round/geo_round_gem.svg</attribute>
-        <attribute name="data-shape">web_editor/geometric_round/geo_round_gem</attribute>
+        <attribute name="data-shape">html_builder/geometric_round/geo_round_gem</attribute>
         <attribute name="data-shape-rotate">90</attribute>
         <attribute name="data-format-mimetype">image/jpeg</attribute>
         <attribute name="data-file-name">uiface_1.svg</attribute>
@@ -834,7 +834,7 @@
     </xpath>
     <xpath expr="(//img)[3]" position="attributes">
         <attribute name="src">/web_editor/image_shape/website.s_company_team_image_3/web_editor/geometric_round/geo_round_gem.svg</attribute>
-        <attribute name="data-shape">web_editor/geometric_round/geo_round_gem</attribute>
+        <attribute name="data-shape">html_builder/geometric_round/geo_round_gem</attribute>
         <attribute name="data-shape-flip">x</attribute>
         <attribute name="data-format-mimetype">image/jpeg</attribute>
         <attribute name="data-file-name">uiface_1.svg</attribute>
@@ -846,7 +846,7 @@
     </xpath>
     <xpath expr="(//img)[4]" position="attributes">
         <attribute name="src">/web_editor/image_shape/website.s_company_team_image_4/web_editor/geometric_round/geo_round_gem.svg</attribute>
-        <attribute name="data-shape">web_editor/geometric_round/geo_round_gem</attribute>
+        <attribute name="data-shape">html_builder/geometric_round/geo_round_gem</attribute>
         <attribute name="data-shape-flip">y</attribute>
         <attribute name="data-format-mimetype">image/jpeg</attribute>
         <attribute name="data-file-name">uiface_1.svg</attribute>
@@ -858,7 +858,7 @@
     </xpath>
     <xpath expr="(//img)[5]" position="attributes">
         <attribute name="src">/web_editor/image_shape/website.s_company_team_image_5/web_editor/geometric_round/geo_round_gem.svg</attribute>
-        <attribute name="data-shape">web_editor/geometric_round/geo_round_gem</attribute>
+        <attribute name="data-shape">html_builder/geometric_round/geo_round_gem</attribute>
         <attribute name="data-format-mimetype">image/jpeg</attribute>
         <attribute name="data-file-name">uiface_1.svg</attribute>
         <attribute name="data-shape-colors">;;;;</attribute>
@@ -869,7 +869,7 @@
     </xpath>
     <xpath expr="(//img)[6]" position="attributes">
         <attribute name="src">/web_editor/image_shape/website.s_company_team_image_6/web_editor/geometric_round/geo_round_gem.svg</attribute>
-        <attribute name="data-shape">web_editor/geometric_round/geo_round_gem</attribute>
+        <attribute name="data-shape">html_builder/geometric_round/geo_round_gem</attribute>
         <attribute name="data-shape-flip">xy</attribute>
         <attribute name="data-format-mimetype">image/jpeg</attribute>
         <attribute name="data-file-name">uiface_1.svg</attribute>

--- a/theme_beauty/views/snippets/s_accordion_image.xml
+++ b/theme_beauty/views/snippets/s_accordion_image.xml
@@ -7,7 +7,7 @@
     </xpath>
     <xpath expr="//img" position="attributes">
         <attribute name="src">/web_editor/image_shape/website.s_accordion_image_default_image/web_editor/geometric_round/geo_round_blob_soft.svg</attribute>
-        <attribute name="data-shape">web_editor/geometric_round/geo_round_blob_soft</attribute>
+        <attribute name="data-shape">html_builder/geometric_round/geo_round_blob_soft</attribute>
         <attribute name="data-format-mimetype">image/webp</attribute>
         <attribute name="data-file-name">s_accordion_image_default_image.svg</attribute>
         <attribute name="data-shape-colors">;;;;</attribute>

--- a/theme_beauty/views/snippets/s_image_text.xml
+++ b/theme_beauty/views/snippets/s_image_text.xml
@@ -5,7 +5,7 @@
     <!-- Img -->
     <xpath expr="//img" position="attributes">
         <attribute name="src">/web_editor/image_shape/website.s_image_text_default_image/web_editor/pattern/pattern_wave_3.svg?c1=o-color-1&amp;c3=o-color-4</attribute>
-        <attribute name="data-shape">web_editor/pattern/pattern_wave_3</attribute>
+        <attribute name="data-shape">html_builder/pattern/pattern_wave_3</attribute>
         <attribute name="data-format-mimetype">image/webp</attribute>
         <attribute name="data-file-name">s_image_text.svg</attribute>
         <attribute name="data-shape-colors">o-color-1;;o-color-4;;</attribute>

--- a/theme_beauty/views/snippets/s_media_list.xml
+++ b/theme_beauty/views/snippets/s_media_list.xml
@@ -9,7 +9,7 @@
     <!-- Item #1 - img -->
     <xpath expr="//img" position="attributes">
         <attribute name="src">/web_editor/image_shape/website.s_media_list_default_image_1/web_editor/composition/composition_line_2.svg?c1=o-color-1</attribute>
-        <attribute name="data-shape">web_editor/composition/composition_line_2</attribute>
+        <attribute name="data-shape">html_builder/composition/composition_line_2</attribute>
         <attribute name="data-format-mimetype">image/webp</attribute>
         <attribute name="data-file-name">s_media_list_1.svg</attribute>
         <attribute name="data-shape-colors">o-color-1;;;;</attribute>
@@ -17,7 +17,7 @@
     <!-- Item #2 - img -->
     <xpath expr="(//img)[2]" position="attributes">
         <attribute name="src">/web_editor/image_shape/website.s_media_list_default_image_2/web_editor/composition/composition_line_3.svg?c1=o-color-1&amp;c2=o-color-2&amp;c5=o-color-3</attribute>
-        <attribute name="data-shape">web_editor/composition/composition_line_3</attribute>
+        <attribute name="data-shape">html_builder/composition/composition_line_3</attribute>
         <attribute name="data-format-mimetype">image/webp</attribute>
         <attribute name="data-file-name">s_media_list_2.svg</attribute>
         <attribute name="data-shape-colors">o-color-1;o-color-2;;;o-color-3</attribute>
@@ -25,7 +25,7 @@
     <!-- Item #3 - img -->
     <xpath expr="(//img)[3]" position="attributes">
         <attribute name="src">/web_editor/image_shape/website.s_media_list_default_image_3/web_editor/composition/composition_line_2.svg?c2=o-color-2</attribute>
-        <attribute name="data-shape">web_editor/composition/composition_line_2</attribute>
+        <attribute name="data-shape">html_builder/composition/composition_line_2</attribute>
         <attribute name="data-format-mimetype">image/webp</attribute>
         <attribute name="data-file-name">s_media_list_3.svg</attribute>
         <attribute name="data-shape-colors">;o-color-2;;;</attribute>

--- a/theme_beauty/views/snippets/s_text_image.xml
+++ b/theme_beauty/views/snippets/s_text_image.xml
@@ -19,7 +19,7 @@
     <!-- Img -->
     <xpath expr="//img" position="attributes">
         <attribute name="src">/web_editor/image_shape/website.s_text_image_default_image/web_editor/pattern/pattern_wave_4.svg?c1=o-color-1&amp;c2=o-color-2&amp;c3=o-color-3&amp;c5=o-color-1</attribute>
-        <attribute name="data-shape">web_editor/pattern/pattern_wave_4</attribute>
+        <attribute name="data-shape">html_builder/pattern/pattern_wave_4</attribute>
         <attribute name="data-format-mimetype">image/webp</attribute>
         <attribute name="data-file-name">s_text_image.svg</attribute>
         <attribute name="data-shape-colors">o-color-1;o-color-2;o-color-3;;o-color-1</attribute>

--- a/theme_bistro/views/snippets/s_text_image.xml
+++ b/theme_bistro/views/snippets/s_text_image.xml
@@ -6,7 +6,7 @@
     <xpath expr="//img" position="attributes">
         <attribute name="src">/web_editor/image_shape/website.s_text_image_default_image/web_editor/geometric_round/geo_round_square_2.svg</attribute>
         <attribute name="data-file-name">text_image.svg</attribute>
-        <attribute name="data-shape">web_editor/geometric_round/geo_round_square_2</attribute>
+        <attribute name="data-shape">html_builder/geometric_round/geo_round_square_2</attribute>
         <attribute name="data-shape-colors">;;;;</attribute>
     </xpath>
 </template>

--- a/theme_buzzy/views/snippets/s_image_punchy.xml
+++ b/theme_buzzy/views/snippets/s_image_punchy.xml
@@ -4,7 +4,7 @@
 <template id="s_image_punchy" inherit_id="website.s_image_punchy">
     <xpath expr="//img" position="attributes">
         <attribute name="src">/web_editor/image_shape/website.s_image_punchy_default_image/web_editor/geometric/geo_slanted.svg</attribute>
-        <attribute name="data-shape">web_editor/geometric/geo_slanted</attribute>
+        <attribute name="data-shape">html_builder/geometric/geo_slanted</attribute>
         <attribute name="data-format-mimetype">image/webp</attribute>
         <attribute name="data-file-name">s_image_punchy_default_image.svg</attribute>
         <attribute name="data-shape-colors">;;;;</attribute>

--- a/theme_clean/views/snippets/s_banner.xml
+++ b/theme_clean/views/snippets/s_banner.xml
@@ -17,7 +17,7 @@
     <!-- Img -->
     <xpath expr="//img" position="attributes">
         <attribute name="src">/web_editor/image_shape/website.s_banner_default_image_2/web_editor/composition/composition_oval_line.svg?c2=o-color-2</attribute>
-        <attribute name="data-shape">web_editor/composition/composition_oval_line</attribute>
+        <attribute name="data-shape">html_builder/composition/composition_oval_line</attribute>
         <attribute name="data-format-mimetype">image/webp</attribute>
         <attribute name="data-file-name">s_banner_2.svg</attribute>
         <attribute name="data-shape-colors">;#34495E;;;</attribute>

--- a/theme_clean/views/snippets/s_image_text.xml
+++ b/theme_clean/views/snippets/s_image_text.xml
@@ -13,7 +13,7 @@
     <!-- Image -->
     <xpath expr="//img" position="attributes">
         <attribute name="src">/web_editor/image_shape/website.s_image_text_default_image/web_editor/pattern/pattern_labyrinth.svg?c1=o-color-3&amp;c2=o-color-5&amp;c4=o-color-1</attribute>
-        <attribute name="data-shape">web_editor/pattern/pattern_labyrinth</attribute>
+        <attribute name="data-shape">html_builder/pattern/pattern_labyrinth</attribute>
         <attribute name="data-format-mimetype">image/webp</attribute>
         <attribute name="data-file-name">image_content_20.svg</attribute>
         <attribute name="data-shape-colors">o-color-3;o-color-5;;o-color-1;</attribute>

--- a/theme_clean/views/snippets/s_text_image.xml
+++ b/theme_clean/views/snippets/s_text_image.xml
@@ -19,7 +19,7 @@
     <!-- Image -->
     <xpath expr="//img" position="attributes">
         <attribute name="src">/web_editor/image_shape/website.s_text_image_default_image/web_editor/pattern/pattern_point.svg?c1=o-color-1</attribute>
-        <attribute name="data-shape">web_editor/pattern/pattern_point</attribute>
+        <attribute name="data-shape">html_builder/pattern/pattern_point</attribute>
         <attribute name="data-format-mimetype">image/webp</attribute>
         <attribute name="data-file-name">image_content_19.svg</attribute>
         <attribute name="data-shape-colors">o-color-1;;;;</attribute>

--- a/theme_graphene/views/customizations.xml
+++ b/theme_graphene/views/customizations.xml
@@ -59,7 +59,7 @@
     </xpath>
     <xpath expr="//img" position="attributes">
         <attribute name="src">/web_editor/image_shape/website.s_image_text_device_perspective/web_editor/devices/iphone_3d_portrait_02.svg</attribute>
-        <attribute name="data-shape">web_editor/devices/iphone_3d_portrait_02</attribute>
+        <attribute name="data-shape">html_builder/devices/iphone_3d_portrait_02</attribute>
     </xpath>
     <xpath expr="//p[1]" position="replace" mode="inner">
         Users are looking to consume engaging content.<br/>We empowers our teams to create the most relevant content.

--- a/theme_kea/views/snippets/s_image_hexagonal.xml
+++ b/theme_kea/views/snippets/s_image_hexagonal.xml
@@ -5,7 +5,7 @@
     <!-- Images -->
     <xpath expr="//img" position="attributes">
         <attribute name="src">/web_editor/image_shape/website.s_media_list_default_image_1/web_editor/composition/composition_mixed_1.svg</attribute>
-        <attribute name="data-shape">web_editor/composition/composition_mixed_1</attribute>
+        <attribute name="data-shape">html_builder/composition/composition_mixed_1</attribute>
     </xpath>
     <xpath expr="(//img)[2]" position="attributes">
         <attribute name="src">/web/image/website.s_carousel_default_image_1</attribute>

--- a/theme_kea/views/snippets/s_media_list.xml
+++ b/theme_kea/views/snippets/s_media_list.xml
@@ -23,7 +23,7 @@
     </xpath>
     <xpath expr="(//img)" position="attributes">
         <attribute name="src">/web_editor/image_shape/website.s_media_list_default_image_3/web_editor/geometric_round/geo_round_blob_medium.svg</attribute>
-        <attribute name="data-shape">web_editor/geometric_round/geo_round_blob_medium</attribute>
+        <attribute name="data-shape">html_builder/geometric_round/geo_round_blob_medium</attribute>
         <attribute name="data-format-mimetype">image/webp</attribute>
         <attribute name="data-file-name">s_media_list_3.svg</attribute>
         <attribute name="data-shape-colors">;;;;</attribute>
@@ -40,7 +40,7 @@
     </xpath>
     <xpath expr="(//img)[2]" position="attributes">
         <attribute name="src">/web_editor/image_shape/website.s_media_list_default_image_2/web_editor/geometric_round/geo_round_blob_medium.svg</attribute>
-        <attribute name="data-shape">web_editor/geometric_round/geo_round_blob_medium</attribute>
+        <attribute name="data-shape">html_builder/geometric_round/geo_round_blob_medium</attribute>
         <attribute name="data-format-mimetype">image/webp</attribute>
         <attribute name="data-file-name">s_media_list_2.svg</attribute>
         <attribute name="data-shape-colors">;;;;</attribute>
@@ -57,7 +57,7 @@
     </xpath>
     <xpath expr="(//img)[3]" position="attributes">
         <attribute name="src">/web_editor/image_shape/website.s_media_list_default_image_1/web_editor/geometric_round/geo_round_blob_medium.svg</attribute>
-        <attribute name="data-shape">web_editor/geometric_round/geo_round_blob_medium</attribute>
+        <attribute name="data-shape">html_builder/geometric_round/geo_round_blob_medium</attribute>
         <attribute name="data-format-mimetype">image/webp</attribute>
         <attribute name="data-file-name">s_media_list_1.svg</attribute>
         <attribute name="data-shape-colors">;;;;</attribute>

--- a/theme_kea/views/snippets/s_picture.xml
+++ b/theme_kea/views/snippets/s_picture.xml
@@ -14,7 +14,7 @@
     <xpath expr="//img" position="attributes">
         <attribute name="style">width: 100%;</attribute>
         <attribute name="src">/web_editor/image_shape/website.s_media_list_default_image_1/web_editor/geometric_round/geo_round_blob_medium.svg</attribute>
-        <attribute name="data-shape">web_editor/geometric_round/geo_round_blob_medium</attribute>
+        <attribute name="data-shape">html_builder/geometric_round/geo_round_blob_medium</attribute>
         <attribute name="data-format-mimetype">image/webp</attribute>
         <attribute name="data-file-name">s_media_list_1.svg</attribute>
         <attribute name="data-shape-colors">;;;;</attribute>

--- a/theme_kiddo/views/snippets/s_accordion_image.xml
+++ b/theme_kiddo/views/snippets/s_accordion_image.xml
@@ -4,7 +4,7 @@
 <template id="s_accordion_image" inherit_id="website.s_accordion_image">
     <xpath expr="//img" position="attributes">
         <attribute name="src">/web_editor/image_shape/website.s_accordion_image_default_image/web_editor/geometric_round/geo_round_blob_medium.svg</attribute>
-        <attribute name="data-shape">web_editor/geometric_round/geo_round_blob_medium</attribute>
+        <attribute name="data-shape">html_builder/geometric_round/geo_round_blob_medium</attribute>
         <attribute name="data-format-mimetype">image/webp</attribute>
         <attribute name="data-file-name">s_accordion_image_default_image.svg</attribute>
         <attribute name="data-shape-colors">;;;;</attribute>

--- a/theme_kiddo/views/snippets/s_image_hexagonal.xml
+++ b/theme_kiddo/views/snippets/s_image_hexagonal.xml
@@ -14,7 +14,7 @@
     <!-- Images -->
     <xpath expr="//img" position="attributes">
         <attribute name="src">/web_editor/image_shape/website.library_image_05/web_editor/composition/composition_mixed_1.svg</attribute>
-        <attribute name="data-shape">web_editor/composition/composition_mixed_1</attribute>
+        <attribute name="data-shape">html_builder/composition/composition_mixed_1</attribute>
     </xpath>
     <xpath expr="(//img)[2]" position="attributes">
         <attribute name="src">/web/image/website.s_cover_default_image</attribute>

--- a/theme_kiddo/views/snippets/s_image_text.xml
+++ b/theme_kiddo/views/snippets/s_image_text.xml
@@ -35,7 +35,7 @@
     <!-- Img -->
     <xpath expr="//img" position="attributes">
         <attribute name="src">/web_editor/image_shape/website.s_image_text_default_image/web_editor/geometric_round/geo_round_square_2.svg</attribute>
-        <attribute name="data-shape">web_editor/geometric_round/geo_round_square_2</attribute>
+        <attribute name="data-shape">html_builder/geometric_round/geo_round_square_2</attribute>
         <attribute name="data-format-mimetype">image/webp</attribute>
         <attribute name="data-file-name">s_image_text.svg</attribute>
         <attribute name="data-shape-colors">;;;;</attribute>

--- a/theme_kiddo/views/snippets/s_text_image.xml
+++ b/theme_kiddo/views/snippets/s_text_image.xml
@@ -23,7 +23,7 @@
     <!-- Img -->
     <xpath expr="//img" position="attributes">
         <attribute name="src">/web_editor/image_shape/website.s_text_image_default_image/web_editor/geometric_round/geo_round_square_1.svg</attribute>
-        <attribute name="data-shape">web_editor/geometric_round/geo_round_square_1</attribute>
+        <attribute name="data-shape">html_builder/geometric_round/geo_round_square_1</attribute>
         <attribute name="data-format-mimetype">image/webp</attribute>
         <attribute name="data-file-name">content_img_13.svg</attribute>
         <attribute name="data-shape-colors">;;;;</attribute>

--- a/theme_kiddo/views/snippets/s_three_columns.xml
+++ b/theme_kiddo/views/snippets/s_three_columns.xml
@@ -13,7 +13,7 @@
     </xpath>
     <xpath expr="//img" position="attributes">
         <attribute name="src">/web_editor/image_shape/website.s_three_columns_default_image_1/web_editor/solid/solid_blob_1.svg?c2=o-color-1</attribute>
-        <attribute name="data-shape">web_editor/solid/solid_blob_1</attribute>
+        <attribute name="data-shape">html_builder/solid/solid_blob_1</attribute>
         <attribute name="data-format-mimetype">image/webp</attribute>
         <attribute name="data-file-name">s_three_columns_default_image_1.svg</attribute>
         <attribute name="data-shape-colors">;o-color-1;;;</attribute>
@@ -50,7 +50,7 @@
     </xpath>
     <xpath expr="(//img)[2]" position="attributes">
         <attribute name="src">/web_editor/image_shape/website.s_three_columns_default_image_2/web_editor/composition/composition_organic_line.svg?c2=o-color-3</attribute>
-        <attribute name="data-shape">web_editor/composition/composition_organic_line</attribute>
+        <attribute name="data-shape">html_builder/composition/composition_organic_line</attribute>
         <attribute name="data-format-mimetype">image/webp</attribute>
         <attribute name="data-file-name">s_three_columns_default_image_2.svg</attribute>
         <attribute name="data-shape-colors">;o-color-3;;;</attribute>
@@ -87,7 +87,7 @@
     </xpath>
     <xpath expr="(//img)[3]" position="attributes">
         <attribute name="src">/web_editor/image_shape/website.s_three_columns_default_image_3/web_editor/solid/solid_blob_3.svg?c5=o-color-2</attribute>
-        <attribute name="data-shape">web_editor/solid/solid_blob_3</attribute>
+        <attribute name="data-shape">html_builder/solid/solid_blob_3</attribute>
         <attribute name="data-format-mimetype">image/webp</attribute>
         <attribute name="data-file-name">s_three_columns_default_image_3.svg</attribute>
         <attribute name="data-shape-colors">;;;;o-color-2</attribute>

--- a/theme_monglia/views/customizations.xml
+++ b/theme_monglia/views/customizations.xml
@@ -168,7 +168,7 @@
     </xpath>
     <xpath expr="//img" position="attributes">
         <attribute name="src">/web_editor/image_shape/website.s_text_image_default_image/web_editor/geometric/geo_square_3.svg</attribute>
-        <attribute name="data-shape">web_editor/geometric/geo_square_3</attribute>
+        <attribute name="data-shape">html_builder/geometric/geo_square_3</attribute>
         <attribute name="data-format-mimetype">image/webp</attribute>
         <attribute name="data-file-name">s_text_image.svg</attribute>
         <attribute name="data-shape-colors">;;;;</attribute>
@@ -199,7 +199,7 @@
     <xpath expr="//p[2]" position="replace"/>
     <xpath expr="//img" position="attributes">
         <attribute name="src">/web_editor/image_shape/website.s_image_text_default_image/web_editor/geometric/geo_square_6.svg</attribute>
-        <attribute name="data-shape">web_editor/geometric/geo_square_6</attribute>
+        <attribute name="data-shape">html_builder/geometric/geo_square_6</attribute>
         <attribute name="data-format-mimetype">image/webp</attribute>
         <attribute name="data-file-name">s_image_text.svg</attribute>
         <attribute name="data-shape-colors">;;;;</attribute>
@@ -883,7 +883,7 @@
     <!-- Image -->
     <xpath expr="//img" position="attributes">
         <attribute name="src">/web_editor/image_shape/website.s_masonry_block_default_image_1/web_editor/panel/panel_duo_step.svg</attribute>
-        <attribute name="data-shape">web_editor/panel/panel_duo_step</attribute>
+        <attribute name="data-shape">html_builder/panel/panel_duo_step</attribute>
         <attribute name="data-format-mimetype">image/webp</attribute>
         <attribute name="data-file-name">s_masonry_block_default_image_1.webp</attribute>
         <attribute name="data-shape-colors">;;;;</attribute>
@@ -951,7 +951,7 @@
     </xpath>
     <xpath expr="//img" position="attributes">
         <attribute name="src">/web_editor/image_shape/website.s_company_team_image_1/web_editor/geometric_round/geo_round_diamond.svg</attribute>
-        <attribute name="data-shape">web_editor/geometric_round/geo_round_diamond</attribute>
+        <attribute name="data-shape">html_builder/geometric_round/geo_round_diamond</attribute>
         <attribute name="data-format-mimetype">image/webp</attribute>
         <attribute name="data-file-name">uiface_1.svg</attribute>
         <attribute name="data-shape-colors">;;;;</attribute>
@@ -963,7 +963,7 @@
 
     <xpath expr="(//img)[2]" position="attributes">
         <attribute name="src">/web_editor/image_shape/website.s_company_team_image_2/web_editor/geometric_round/geo_round_diamond.svg</attribute>
-        <attribute name="data-shape">web_editor/geometric_round/geo_round_diamond</attribute>
+        <attribute name="data-shape">html_builder/geometric_round/geo_round_diamond</attribute>
         <attribute name="data-format-mimetype">image/webp</attribute>
         <attribute name="data-file-name">uiface_2.svg</attribute>
         <attribute name="data-shape-colors">;;;;</attribute>
@@ -974,7 +974,7 @@
     </xpath>
     <xpath expr="(//img)[3]" position="attributes">
         <attribute name="src">/web_editor/image_shape/website.s_company_team_image_3/web_editor/geometric_round/geo_round_diamond.svg</attribute>
-        <attribute name="data-shape">web_editor/geometric_round/geo_round_diamond</attribute>
+        <attribute name="data-shape">html_builder/geometric_round/geo_round_diamond</attribute>
         <attribute name="data-format-mimetype">image/webp</attribute>
         <attribute name="data-file-name">uiface_3.svg</attribute>
         <attribute name="data-shape-colors">;;;;</attribute>
@@ -985,7 +985,7 @@
     </xpath>
     <xpath expr="(//img)[4]" position="attributes">
         <attribute name="src">/web_editor/image_shape/website.s_company_team_image_4/web_editor/geometric_round/geo_round_diamond.svg</attribute>
-        <attribute name="data-shape">web_editor/geometric_round/geo_round_diamond</attribute>
+        <attribute name="data-shape">html_builder/geometric_round/geo_round_diamond</attribute>
         <attribute name="data-format-mimetype">image/webp</attribute>
         <attribute name="data-file-name">uiface_4.svg</attribute>
         <attribute name="data-shape-colors">;;;;</attribute>
@@ -996,7 +996,7 @@
     </xpath>
     <xpath expr="(//img)[5]" position="attributes">
         <attribute name="src">/web_editor/image_shape/website.s_company_team_image_5/web_editor/geometric_round/geo_round_diamond.svg</attribute>
-        <attribute name="data-shape">web_editor/geometric_round/geo_round_diamond</attribute>
+        <attribute name="data-shape">html_builder/geometric_round/geo_round_diamond</attribute>
         <attribute name="data-format-mimetype">image/webp</attribute>
         <attribute name="data-file-name">uiface_5.svg</attribute>
         <attribute name="data-shape-colors">;;;;</attribute>
@@ -1007,7 +1007,7 @@
     </xpath>
     <xpath expr="(//img)[6]" position="attributes">
         <attribute name="src">/web_editor/image_shape/website.s_company_team_image_6/web_editor/geometric_round/geo_round_diamond.svg</attribute>
-        <attribute name="data-shape">web_editor/geometric_round/geo_round_diamond</attribute>
+        <attribute name="data-shape">html_builder/geometric_round/geo_round_diamond</attribute>
         <attribute name="data-format-mimetype">image/webp</attribute>
         <attribute name="data-file-name">uiface_6.svg</attribute>
         <attribute name="data-shape-colors">;;;;</attribute>

--- a/theme_nano/views/snippets/s_image_text.xml
+++ b/theme_nano/views/snippets/s_image_text.xml
@@ -13,7 +13,7 @@
     <xpath expr="//img" position="attributes">
         <attribute name="src">/web_editor/image_shape/website.s_image_text_default_image/web_editor/composition/composition_planet_2.svg</attribute>
         <attribute name="data-file-name">s_image_text.svg</attribute>
-        <attribute name="data-shape">web_editor/composition/composition_planet_2</attribute>
+        <attribute name="data-shape">html_builder/composition/composition_planet_2</attribute>
         <attribute name="data-shape-colors">;;;;</attribute>
     </xpath>
     <!-- Column #02 -->

--- a/theme_nano/views/snippets/s_text_image.xml
+++ b/theme_nano/views/snippets/s_text_image.xml
@@ -13,7 +13,7 @@
     <xpath expr="//img" position="attributes">
         <attribute name="src">/web_editor/image_shape/website.s_text_image_default_image/web_editor/pattern/pattern_point.svg</attribute>
             <attribute name="data-file-name">s_text_image.svg</attribute>
-        <attribute name="data-shape">web_editor/pattern/pattern_point</attribute>
+        <attribute name="data-shape">html_builder/pattern/pattern_point</attribute>
         <attribute name="data-shape-colors">;;;;</attribute>
     </xpath>
 </template>

--- a/theme_odoo_experts/views/snippets/s_image_text.xml
+++ b/theme_odoo_experts/views/snippets/s_image_text.xml
@@ -26,7 +26,7 @@
     <!-- Image -->
     <xpath expr="//img" position="attributes">
         <attribute name="src">/web_editor/image_shape/website.s_image_text_default_image/web_editor/devices/browser_03.svg?</attribute>
-        <attribute name="data-shape">web_editor/devices/browser_03</attribute>
+        <attribute name="data-shape">html_builder/devices/browser_03</attribute>
         <attribute name="data-format-mimetype">image/webp</attribute>
         <attribute name="data-file-name">s_image_text.svg</attribute>
         <attribute name="class" add="shadow" separator=" "/>

--- a/theme_odoo_experts/views/snippets/s_mockup_image.xml
+++ b/theme_odoo_experts/views/snippets/s_mockup_image.xml
@@ -27,7 +27,7 @@
     <!-- Image -->
     <xpath expr="//img" position="attributes">
         <attribute name="src">/web_editor/image_shape/website.s_image_text_device_perspective/web_editor/devices/iphone_3d_portrait_02.svg?c5=o-color-5</attribute>
-        <attribute name="data-shape">web_editor/devices/iphone_3d_portrait_02</attribute>
+        <attribute name="data-shape">html_builder/devices/iphone_3d_portrait_02</attribute>
         <attribute name="data-format-mimetype">image/webp</attribute>
         <attribute name="data-file-name">s_image_text_device_perspective.svg</attribute>
         <attribute name="data-shape-colors">;;;;o-color-5</attribute>

--- a/theme_odoo_experts/views/snippets/s_picture.xml
+++ b/theme_odoo_experts/views/snippets/s_picture.xml
@@ -34,7 +34,7 @@
     <!-- Image -->
     <xpath expr="//div[hasclass('col-lg-12')]//img" position="attributes">
         <attribute name="src">/web_editor/image_shape/website.s_picture_default_image/web_editor/devices/macbook_front.svg?c3=o-color-3</attribute>
-        <attribute name="data-shape">web_editor/devices/macbook_front</attribute>
+        <attribute name="data-shape">html_builder/devices/macbook_front</attribute>
         <attribute name="data-format-mimetype">image/webp</attribute>
         <attribute name="data-file-name">s_picture.svg</attribute>
         <attribute name="data-shape-colors">;;o-color-3;;</attribute>

--- a/theme_odoo_experts/views/snippets/s_showcase.xml
+++ b/theme_odoo_experts/views/snippets/s_showcase.xml
@@ -45,7 +45,7 @@
     <!-- Image -->
     <xpath expr="//img" position="attributes">
         <attribute name="src">/web_editor/image_shape/website.s_showcase_default_image/web_editor/devices/macbook_front.svg?</attribute>
-        <attribute name="data-shape">web_editor/devices/macbook_front</attribute>
+        <attribute name="data-shape">html_builder/devices/macbook_front</attribute>
         <attribute name="data-format-mimetype">image/webp</attribute>
         <attribute name="data-file-name">s_showcase_default_image.svg</attribute>
         <attribute name="class" remove="rounded" separator=" "/>

--- a/theme_odoo_experts/views/snippets/s_text_image.xml
+++ b/theme_odoo_experts/views/snippets/s_text_image.xml
@@ -26,7 +26,7 @@
     <!-- Image -->
     <xpath expr="//img" position="attributes">
         <attribute name="src">/web_editor/image_shape/website.s_text_image_default_image/web_editor/devices/ipad_front_landscape.svg</attribute>
-        <attribute name="data-shape">web_editor/devices/ipad_front_landscape</attribute>
+        <attribute name="data-shape">html_builder/devices/ipad_front_landscape</attribute>
         <attribute name="data-format-mimetype">image/webp</attribute>
         <attribute name="data-file-name">s_text_image.svg</attribute>
         <attribute name="class" remove="rounded" separator=" "/>

--- a/theme_orchid/views/snippets/s_image_hexagonal.xml
+++ b/theme_orchid/views/snippets/s_image_hexagonal.xml
@@ -13,7 +13,7 @@
     <!-- Images -->
     <xpath expr="//img" position="attributes">
         <attribute name="src">/web_editor/image_shape/website.s_masonry_block_default_image_1/web_editor/composition/composition_square_1.svg</attribute>
-        <attribute name="data-shape">web_editor/composition/composition_square_1</attribute>
+        <attribute name="data-shape">html_builder/composition/composition_square_1</attribute>
     </xpath>
     <xpath expr="(//img)[2]" position="attributes">
         <attribute name="src">/web/image/website.s_cover_default_image</attribute>

--- a/theme_orchid/views/snippets/s_image_text.xml
+++ b/theme_orchid/views/snippets/s_image_text.xml
@@ -20,7 +20,7 @@
     <!-- Img -->
     <xpath expr="//img" position="attributes">
         <attribute name="src">/web_editor/image_shape/website.s_image_text_default_image/web_editor/composition/composition_mixed_1.svg?c1=o-color-2&amp;c2=o-color-2&amp;c5=o-color-5</attribute>
-        <attribute name="data-shape">web_editor/composition/composition_mixed_1</attribute>
+        <attribute name="data-shape">html_builder/composition/composition_mixed_1</attribute>
         <attribute name="data-format-mimetype">image/webp</attribute>
         <attribute name="data-file-name">s_carousel_2.svg</attribute>
         <attribute name="data-shape-colors">o-color-2;o-color-2;;;o-color-5</attribute>

--- a/theme_orchid/views/snippets/s_text_image.xml
+++ b/theme_orchid/views/snippets/s_text_image.xml
@@ -33,7 +33,7 @@
     <!-- Img -->
     <xpath expr="//img" position="attributes">
         <attribute name="src">/web_editor/image_shape/website.s_text_image_default_image/web_editor/solid/solid_blob_shadow_2.svg?c2=o-color-2</attribute>
-        <attribute name="data-shape">web_editor/solid/solid_blob_shadow_2</attribute>
+        <attribute name="data-shape">html_builder/solid/solid_blob_shadow_2</attribute>
         <attribute name="data-format-mimetype">image/webp</attribute>
         <attribute name="data-file-name">s_media_list_3.svg</attribute>
         <attribute name="data-shape-colors">;o-color-2;;;</attribute>

--- a/theme_real_estate/views/snippets/s_image_text.xml
+++ b/theme_real_estate/views/snippets/s_image_text.xml
@@ -21,7 +21,7 @@
     <!-- Image -->
     <xpath expr="//img" position="attributes">
         <attribute name="src">/web_editor/image_shape/website.s_image_text_default_image/web_editor/panel/panel_duo_step.svg</attribute>
-        <attribute name="data-shape">web_editor/panel/panel_duo_step</attribute>
+        <attribute name="data-shape">html_builder/panel/panel_duo_step</attribute>
         <attribute name="data-format-mimetype">image/webp</attribute>
         <attribute name="data-file-name">s_image_text.svg</attribute>
         <attribute name="data-shape-colors">;;;;</attribute>

--- a/theme_real_estate/views/snippets/s_text_image.xml
+++ b/theme_real_estate/views/snippets/s_text_image.xml
@@ -16,7 +16,7 @@
     <!-- Image -->
     <xpath expr="//img" position="attributes">
         <attribute name="src">/web_editor/image_shape/website.s_text_image_default_image/web_editor/panel/panel_duo_step.svg</attribute>
-        <attribute name="data-shape">web_editor/panel/panel_duo_step</attribute>
+        <attribute name="data-shape">html_builder/panel/panel_duo_step</attribute>
         <attribute name="data-format-mimetype">image/webp</attribute>
         <attribute name="data-file-name">s_text_image.svg</attribute>
         <attribute name="data-shape-colors">;;;;</attribute>

--- a/theme_treehouse/views/snippets/s_picture.xml
+++ b/theme_treehouse/views/snippets/s_picture.xml
@@ -10,7 +10,7 @@
     <xpath expr="//img" position="attributes">
         <attribute name="src">/web_editor/image_shape/website.s_picture_default_image/web_editor/special/special_filter.svg</attribute>
         <attribute name="data-file-name">01.svg</attribute>
-        <attribute name="data-shape">web_editor/special/special_filter</attribute>
+        <attribute name="data-shape">html_builder/special/special_filter</attribute>
         <attribute name="data-shape-colors">;#046380;;;</attribute>
     </xpath>
 </template>

--- a/theme_treehouse/views/snippets/s_text_image.xml
+++ b/theme_treehouse/views/snippets/s_text_image.xml
@@ -18,7 +18,7 @@
     <xpath expr="//img" position="attributes">
         <attribute name="src">/web_editor/image_shape/website.s_text_image_default_image/web_editor/geometric_round/geo_round_blob_medium.svg</attribute>
         <attribute name="data-file-name">text_image.svg</attribute>
-        <attribute name="data-shape">web_editor/geometric_round/geo_round_blob_medium</attribute>
+        <attribute name="data-shape">html_builder/geometric_round/geo_round_blob_medium</attribute>
         <attribute name="data-shape-colors">;;;;</attribute>
     </xpath>
     <!-- Subtitle -->

--- a/theme_vehicle/views/customizations.xml
+++ b/theme_vehicle/views/customizations.xml
@@ -61,7 +61,7 @@
     </xpath>
     <xpath expr="//img" position="attributes">
         <attribute name="src">/web_editor/image_shape/website.s_text_image_default_image/web_editor/composition/composition_square_3.svg?c1=o-color-1&amp;c5=o-color-5</attribute>
-        <attribute name="data-shape">web_editor/composition/composition_square_3</attribute>
+        <attribute name="data-shape">html_builder/composition/composition_square_3</attribute>
         <attribute name="data-format-mimetype">image/webp</attribute>
         <attribute name="data-file-name">s_text_image.svg</attribute>
         <attribute name="data-shape-colors">o-color-1;;;;o-color-5</attribute>
@@ -90,7 +90,7 @@
     </xpath>
     <xpath expr="//img" position="attributes">
         <attribute name="src">/web_editor/image_shape/website.s_image_text_default_image/web_editor/composition/composition_square_2.svg?c2=o-color-1&amp;c5=o-color-5</attribute>
-        <attribute name="data-shape">web_editor/composition/composition_square_2</attribute>
+        <attribute name="data-shape">html_builder/composition/composition_square_2</attribute>
         <attribute name="data-format-mimetype">image/webp</attribute>
         <attribute name="data-file-name">s_image_text.svg</attribute>
         <attribute name="data-shape-colors">;o-color-1;;;o-color-5</attribute>

--- a/theme_zap/views/snippets/s_striped.xml
+++ b/theme_zap/views/snippets/s_striped.xml
@@ -17,7 +17,7 @@
     <!-- Image -->
     <xpath expr="//img" position="attributes">
         <attribute name="src">/web_editor/image_shape/website.s_text_cover_default_image/web_editor/geometric/geo_square_5.svg</attribute>
-        <attribute name="data-shape">web_editor/geometric/geo_square_5</attribute>
+        <attribute name="data-shape">html_builder/geometric/geo_square_5</attribute>
         <attribute name="data-format-mimetype">image/webp</attribute>
         <attribute name="data-file-name">s_striped_default_image.svg</attribute>
         <attribute name="data-shape-colors">;;;;</attribute>


### PR DESCRIPTION
*theme_artists, theme_avantgarde, theme_beauty, theme_bistro, theme_buzzy, theme_clean, theme_graphene, theme_kea, theme_kiddo, theme_monglia, theme_nano, theme_odoo_experts, theme_orchid, theme_real_estate, theme_treehouse, theme_vehicle, theme_zap

**Problem**
Some snippets contain shapes whose ID starts with `web_editor` instead of `html_builder`. These IDs are not listed in `imageShapeDefinitions`, and this generates a traceback when trying to apply shape tranformations.

**How to reproduce**
1. Insert the snippet `s_images_constellation`
2. Click on the bottom left image having the "Double Pill" shape
3. Click on any "Transform" button under the "Shape" row in the "Image" section
4. Problem: traceback pops up

**Solution**
This commit replaces `web_editor` with `html_builder` in themes. See also the changes made to snippets [1] and the migration script [2].

[1]: https://github.com/odoo/odoo/pull/218837
[2]: https://github.com/odoo/upgrade/pull/8076

task-4367641