### PR TITLE
[FIX] theme_*: restore themes dark footers

### DIFF
--- a/theme_anelusia/static/src/scss/primary_variables.scss
+++ b/theme_anelusia/static/src/scss/primary_variables.scss
@@ -32,6 +32,10 @@ $o-website-values-palettes: (
     ),
 );
 
+$default-25: map-get($o-color-palettes, 'default-25');
+$default-25: map-merge($default-25, ('footer': 5));
+$o-color-palettes: map-merge($o-color-palettes, ('default-25': $default-25));
+
 //------------------------------------------------------------------------------//
 // Fonts
 //------------------------------------------------------------------------------//

--- a/theme_artists/static/src/scss/primary_variables.scss
+++ b/theme_artists/static/src/scss/primary_variables.scss
@@ -120,6 +120,10 @@ $o-website-values-palettes: (
     ),
 );
 
+$artists-1: map-get($o-color-palettes, 'artists-1');
+$artists-1: map-merge($artists-1, ('footer': 5));
+$o-color-palettes: map-merge($o-color-palettes, ('artists-1': $artists-1));
+
 $o-selected-color-palettes-names: append($o-selected-color-palettes-names, 'artists-1');
 
 $o-color-palettes-compatibility-indexes: (

--- a/theme_avantgarde/static/src/scss/primary_variables.scss
+++ b/theme_avantgarde/static/src/scss/primary_variables.scss
@@ -186,6 +186,10 @@ $o-website-values-palettes: (
     ),
 );
 
+$default-15: map-get($o-color-palettes, 'default-15');
+$default-15: map-merge($default-15, ('footer': 5));
+$o-color-palettes: map-merge($o-color-palettes, ('default-15': $default-15));
+
 $o-color-palettes-compatibility-indexes: (
     1: 'avantgarde-1',
     2: 'avantgarde-2',

--- a/theme_aviato/static/src/scss/primary_variables.scss
+++ b/theme_aviato/static/src/scss/primary_variables.scss
@@ -47,6 +47,10 @@ $o-website-values-palettes: (
     ),
 );
 
+$default-16: map-get($o-color-palettes, 'default-16');
+$default-16: map-merge($default-16, ('footer': 5));
+$o-color-palettes: map-merge($o-color-palettes, ('default-16': $default-16));
+
 //------------------------------------------------------------------------------
 // Fonts
 //------------------------------------------------------------------------------

--- a/theme_beauty/static/src/scss/primary_variables.scss
+++ b/theme_beauty/static/src/scss/primary_variables.scss
@@ -80,6 +80,10 @@ $o-website-values-palettes: (
     ),
 );
 
+$default-light-3: map-get($o-color-palettes, 'default-light-3');
+$default-light-3: map-merge($default-light-3, ('footer': 5));
+$o-color-palettes: map-merge($o-color-palettes, ('default-light-3': $default-light-3));
+
 $o-color-palettes-compatibility-indexes: (
     1: 'beauty-1',
     2: 'beauty-2',

--- a/theme_bistro/static/src/scss/primary_variables.scss
+++ b/theme_bistro/static/src/scss/primary_variables.scss
@@ -39,6 +39,10 @@ $o-website-values-palettes: (
     ),
 );
 
+$default-22: map-get($o-color-palettes, 'default-22');
+$default-22: map-merge($default-22, ('footer': 5));
+$o-color-palettes: map-merge($o-color-palettes, ('default-22': $default-22));
+
 //------------------------------------------------------------------------------
 // Fonts
 //------------------------------------------------------------------------------

--- a/theme_bookstore/static/src/scss/primary_variables.scss
+++ b/theme_bookstore/static/src/scss/primary_variables.scss
@@ -74,6 +74,10 @@ $o-website-values-palettes: (
     ),
 );
 
+$default-26: map-get($o-color-palettes, 'default-26');
+$default-26: map-merge($default-26, ('footer': 5));
+$o-color-palettes: map-merge($o-color-palettes, ('default-26': $default-26));
+
 $o-color-palettes-compatibility-indexes: (
     1: 'bookstore-1',
     2: 'bookstore-2',

--- a/theme_buzzy/static/src/scss/primary_variables.scss
+++ b/theme_buzzy/static/src/scss/primary_variables.scss
@@ -32,6 +32,10 @@ $o-website-values-palettes: (
     ),
 );
 
+$default-24: map-get($o-color-palettes, 'default-24');
+$default-24: map-merge($default-24, ('footer': 5));
+$o-color-palettes: map-merge($o-color-palettes, ('default-24': $default-24));
+
 //------------------------------------------------------------------------------
 // Fonts
 //------------------------------------------------------------------------------

--- a/theme_cobalt/static/src/scss/primary_variables.scss
+++ b/theme_cobalt/static/src/scss/primary_variables.scss
@@ -51,6 +51,10 @@ $o-website-values-palettes: (
     ),
 );
 
+$default-8: map-get($o-color-palettes, 'default-8');
+$default-8: map-merge($default-8, ('footer': 5));
+$o-color-palettes: map-merge($o-color-palettes, ('default-8': $default-8));
+
 $o-color-palettes-compatibility-indexes: (
     1: 'cobalt-1',
     2: 'generic-1',

--- a/theme_enark/static/src/scss/primary_variables.scss
+++ b/theme_enark/static/src/scss/primary_variables.scss
@@ -156,6 +156,10 @@ $o-website-values-palettes: (
     ),
 );
 
+$default-light-12: map-get($o-color-palettes, 'default-light-12');
+$default-light-12: map-merge($default-light-12, ('footer': 5));
+$o-color-palettes: map-merge($o-color-palettes, ('default-light-12': $default-light-12));
+
 $o-color-palettes-compatibility-indexes: (
     1: 'enark-1',
     2: 'enark-2',

--- a/theme_graphene/static/src/scss/primary_variables.scss
+++ b/theme_graphene/static/src/scss/primary_variables.scss
@@ -111,6 +111,10 @@ $o-website-values-palettes: (
     ),
 );
 
+$base-1: map-get($o-color-palettes, 'base-1');
+$base-1: map-merge($base-1, ('footer': 5));
+$o-color-palettes: map-merge($o-color-palettes, ('base-1': $base-1));
+
 $o-color-palettes-compatibility-indexes: (
     1: 'graphene-1',
     2: 'graphene-2',

--- a/theme_kiddo/static/src/scss/primary_variables.scss
+++ b/theme_kiddo/static/src/scss/primary_variables.scss
@@ -139,6 +139,10 @@ $o-website-values-palettes: (
     ),
 );
 
+$default-16: map-get($o-color-palettes, 'default-16');
+$default-16: map-merge($default-16, ('footer': 5));
+$o-color-palettes: map-merge($o-color-palettes, ('default-16': $default-16));
+
 $o-color-palettes-compatibility-indexes: (
     1: 'kiddo-3',
     2: 'kiddo-2',

--- a/theme_loftspace/static/src/scss/primary_variables.scss
+++ b/theme_loftspace/static/src/scss/primary_variables.scss
@@ -139,6 +139,10 @@ $o-website-values-palettes: (
     ),
 );
 
+$graphene-2: map-get($o-color-palettes, 'graphene-2');
+$graphene-2: map-merge($graphene-2, ('footer': 5));
+$o-color-palettes: map-merge($o-color-palettes, ('graphene-2': $graphene-2));
+
 $o-selected-color-palettes-names: append($o-selected-color-palettes-names, 'graphene-2');
 
 $o-color-palettes-compatibility-indexes: (

--- a/theme_monglia/static/src/scss/primary_variables.scss
+++ b/theme_monglia/static/src/scss/primary_variables.scss
@@ -156,6 +156,10 @@ $o-website-values-palettes: (
     ),
 );
 
+$default-light-3: map-get($o-color-palettes, 'default-light-3');
+$default-light-3: map-merge($default-light-3, ('footer': 5));
+$o-color-palettes: map-merge($o-color-palettes, ('default-light-3': $default-light-3));
+
 $o-color-palettes-compatibility-indexes: (
     1: 'monglia-1',
     2: 'monglia-2',

--- a/theme_odoo_experts/static/src/scss/primary_variables.scss
+++ b/theme_odoo_experts/static/src/scss/primary_variables.scss
@@ -93,6 +93,10 @@ $o-website-values-palettes: (
     ),
 );
 
+$default-11: map-get($o-color-palettes, 'default-11');
+$default-11: map-merge($default-11, ('footer': 5));
+$o-color-palettes: map-merge($o-color-palettes, ('default-11': $default-11));
+
 $o-palette-priority-prefix: 'odoo-experts';
 
 $o-color-palettes-compatibility-indexes: (

--- a/theme_orchid/static/src/scss/primary_variables.scss
+++ b/theme_orchid/static/src/scss/primary_variables.scss
@@ -67,6 +67,10 @@ $o-website-values-palettes: (
     ),
 );
 
+$default-light-9: map-get($o-color-palettes, 'default-light-9');
+$default-light-9: map-merge($default-light-9, ('footer': 5));
+$o-color-palettes: map-merge($o-color-palettes, ('default-light-9': $default-light-9));
+
 $o-color-palettes-compatibility-indexes: (
     1: 'orchid-1',
     2: 'orchid-2',

--- a/theme_real_estate/static/src/scss/primary_variables.scss
+++ b/theme_real_estate/static/src/scss/primary_variables.scss
@@ -93,6 +93,10 @@ $o-website-values-palettes: (
     ),
 );
 
+$default-28: map-get($o-color-palettes, 'default-28');
+$default-28: map-merge($default-28, ('footer': 5));
+$o-color-palettes: map-merge($o-color-palettes, ('default-28': $default-28));
+
 $o-color-palettes-compatibility-indexes: (
     1: 'real-estate-1',
     2: 'real-estate-2',

--- a/theme_treehouse/static/src/scss/primary_variables.scss
+++ b/theme_treehouse/static/src/scss/primary_variables.scss
@@ -36,6 +36,10 @@ $o-website-values-palettes: (
     ),
 );
 
+$default-28: map-get($o-color-palettes, 'default-28');
+$default-28: map-merge($default-28, ('footer': 5));
+$o-color-palettes: map-merge($o-color-palettes, ('default-28': $default-28));
+
 //------------------------------------------------------------------------------
 // Fonts
 //------------------------------------------------------------------------------

--- a/theme_yes/static/src/scss/primary_variables.scss
+++ b/theme_yes/static/src/scss/primary_variables.scss
@@ -62,6 +62,10 @@ $o-website-values-palettes: (
     ),
 );
 
+$yes-3: map-get($o-color-palettes, 'yes-3');
+$yes-3: map-merge($yes-3, ('footer': 5));
+$o-color-palettes: map-merge($o-color-palettes, ('yes-3': $yes-3));
+
 $o-selected-color-palettes-names: append($o-selected-color-palettes-names, 'yes-3');
 
 $o-color-palettes-compatibility-indexes: (


### PR DESCRIPTION
*: anelusia, artists, avantgarde, aviato, beauty, bistro, bookstore, buzzy, cobalt, enark, graphene, kiddo, loftspace, monglia, odoo_experts, orchid, real_estate, treehouse, yes

The footer color was switched from `o_cc5` to `o_cc2` in commit [[1]](https://github.com/odoo/odoo/commit/62cad846a5c8adf52fc0450bc3f5cfd0492d0622).

Several themes relied on the footer being dark by default without having to override `o_cc5`. Since the default footer is now light, those themes were updated to explicitly use a dark preset.

task-5074919
[1]: [62cad846a5c8adf52fc0450bc3f5cfd0492d0622](https://github.com/odoo/odoo/commit/62cad846a5c8adf52fc0450bc3f5cfd0492d0622)