### PR TITLE
[IMP] website: Introduce high-level cache for website pages

### DIFF
--- a/test_themes/tests/test_crawl.py
+++ b/test_themes/tests/test_crawl.py
@@ -49,4 +49,11 @@ class Crawler(HttpCase):
         Website = self.env['website']
         websites_themes = Website.get_test_themes_websites()
         for website in websites_themes:
+            # TODO: remove this invalidation and invalidation in theme feature.
+            # They are missing invalidations of template ormcache and others.
+            # The configurator_apply method and various methods used for theme
+            # added on `ir.module.module` from website write directly on
+            # `ir.model.data` and update attachments, views, xmlids.
+            self.env.registry.clear_cache('templates')
+
             self.start_tour(f"/web?fw={website.id}", 'homepage', login='admin')


### PR DESCRIPTION
ormcache invalidation in test_02_homepage_tour_every_theme test.

The configurator_apply method and various methods used for theme added
on `ir.module.module` from website write directely on `ir.model.data`
and update attachments, views, xmlids. They are missing invalidations
of template ormcache and others.

Adding a high-level cache revealed the problem, but this issue
already exists, it impacts all template caches such as `website.page`
and `ir.qweb`.

see https://github.com/odoo/odoo/pull/224487
see https://github.com/odoo/odoo/pull/88276