### PR TITLE
[FIX] theme_test_custo: fix website_theme_preview tour

### DIFF
--- a/theme_test_custo/static/tests/tours/website_theme_preview.js
+++ b/theme_test_custo/static/tests/tours/website_theme_preview.js
@@ -15,6 +15,7 @@ registry.category("web_tour.tours").add("website_theme_preview", {
     content: "Validate the website creation modal",
     trigger: ".modal button.btn-primary",
     run: "click",
+    expectUnloadPage: true,
 },
 // Configurator first screen
 {


### PR DESCRIPTION
### Issue:
`website_theme_preview` tour was failing on steps that trigger a page
unload because `expectUnloadPage: true` was not set.

### Fix:
Added `expectUnloadPage: true` to the steps that trigger a page unload,
ensuring the tour no longer fails.

runbot-[232988](https://runbot.odoo.com/odoo/runbot.build.error/232988)
