### PR TITLE
[FIX] * : remove live_preview_url

### DIFF
--- a/theme_anelusia/__manifest__.py
+++ b/theme_anelusia/__manifest__.py
@@ -53,7 +53,6 @@
         '_': ['s_comparisons'],
     },
     'license': 'LGPL-3',
-    'live_test_url': 'https://theme-anelusia.odoo.com',
     'assets': {
         'website.assets_editor': [
             'theme_anelusia/static/src/js/tour.js',

--- a/theme_artists/__manifest__.py
+++ b/theme_artists/__manifest__.py
@@ -59,7 +59,6 @@
         '_': ['s_parallax', 's_numbers', 's_image_text', 's_product_catalog', 's_quotes_carousel'],
     },
     'license': 'LGPL-3',
-    'live_test_url': 'https://theme-artists.odoo.com',
     'assets': {
         'website.assets_editor': [
             'theme_artists/static/src/js/tour.js',

--- a/theme_avantgarde/__manifest__.py
+++ b/theme_avantgarde/__manifest__.py
@@ -29,7 +29,6 @@
     },
     'depends': ['theme_common'],
     'license': 'LGPL-3',
-    'live_test_url': 'https://theme-avantgarde.odoo.com',
     'assets': {
         'website.assets_editor': [
             'theme_avantgarde/static/src/js/tour.js',

--- a/theme_aviato/__manifest__.py
+++ b/theme_aviato/__manifest__.py
@@ -37,7 +37,6 @@
         'homepage': ['s_cover', 's_text_image', 's_image_text', 's_title', 's_three_columns', 's_picture'],
     },
     'license': 'LGPL-3',
-    'live_test_url': 'https://theme-aviato.odoo.com',
 
     'assets': {
         'website.assets_editor': [

--- a/theme_beauty/__manifest__.py
+++ b/theme_beauty/__manifest__.py
@@ -45,7 +45,6 @@
         'homepage': ['s_cover', 's_text_image', 's_title', 's_product_list', 's_company_team', 's_call_to_action'],
     },
     'license': 'LGPL-3',
-    'live_test_url': 'https://theme-beauty.odoo.com',
     'assets': {
         'website.assets_editor': [
             'theme_beauty/static/src/js/tour.js',

--- a/theme_bewise/__manifest__.py
+++ b/theme_bewise/__manifest__.py
@@ -31,7 +31,6 @@
         '_': ['s_company_team'],
     },
     'license': 'LGPL-3',
-    'live_test_url': 'https://theme-bewise.odoo.com',
     'assets': {
         'website.assets_editor': [
             'theme_bewise/static/src/js/tour.js',

--- a/theme_bistro/__manifest__.py
+++ b/theme_bistro/__manifest__.py
@@ -45,7 +45,6 @@
         '_': ['s_banner'],
     },
     'license': 'LGPL-3',
-    'live_test_url': 'https://theme-bistro.odoo.com',
     'assets': {
         'website.assets_editor': [
             'theme_bistro/static/src/js/tour.js',

--- a/theme_bookstore/__manifest__.py
+++ b/theme_bookstore/__manifest__.py
@@ -63,7 +63,6 @@
         },
     },
     'license': 'LGPL-3',
-    'live_test_url': 'https://theme-bookstore.odoo.com',
     'assets': {
         'website.assets_editor': [
             'theme_bookstore/static/src/js/tour.js',

--- a/theme_buzzy/__manifest__.py
+++ b/theme_buzzy/__manifest__.py
@@ -65,7 +65,6 @@
         },
     },
     'license': 'LGPL-3',
-    'live_test_url': 'https://theme-buzzy.odoo.com',
     'assets': {
         'website.assets_editor': [
             'theme_buzzy/static/src/js/tour.js',

--- a/theme_clean/__manifest__.py
+++ b/theme_clean/__manifest__.py
@@ -46,7 +46,6 @@
         '_': ['s_comparisons'],
     },
     'license': 'LGPL-3',
-    'live_test_url': 'https://theme-clean.odoo.com',
     'assets': {
         'website.assets_editor': [
             'theme_clean/static/src/js/tour.js',

--- a/theme_cobalt/__manifest__.py
+++ b/theme_cobalt/__manifest__.py
@@ -31,7 +31,6 @@
         '_': ['s_image_text', 's_three_columns', 's_picture'],
     },
     'license': 'LGPL-3',
-    'live_test_url': 'https://theme-cobalt.odoo.com',
     'assets': {
         'website.assets_editor': [
             'theme_cobalt/static/src/js/tour.js',

--- a/theme_enark/__manifest__.py
+++ b/theme_enark/__manifest__.py
@@ -55,7 +55,6 @@
         },
     },
     'license': 'LGPL-3',
-    'live_test_url': 'https://theme-enark.odoo.com',
     'assets': {
         'website.assets_editor': [
             'theme_enark/static/src/js/tour.js',

--- a/theme_graphene/__manifest__.py
+++ b/theme_graphene/__manifest__.py
@@ -34,7 +34,6 @@
     },
     'depends': ['theme_common'],
     'license': 'LGPL-3',
-    'live_test_url': 'https://theme-graphene.odoo.com',
     'assets': {
         'website.assets_editor': [
             'theme_graphene/static/src/js/tour.js',

--- a/theme_kea/__manifest__.py
+++ b/theme_kea/__manifest__.py
@@ -49,7 +49,6 @@
         },
     },
     'license': 'LGPL-3',
-    'live_test_url': 'https://theme-kea.odoo.com',
     'assets': {
         'website.assets_editor': [
             'theme_kea/static/src/js/tour.js',

--- a/theme_kiddo/__manifest__.py
+++ b/theme_kiddo/__manifest__.py
@@ -45,7 +45,6 @@
         },
     },
     'license': 'LGPL-3',
-    'live_test_url': 'https://theme-kiddo.odoo.com',
     'assets': {
         'website.assets_editor': [
             'theme_kiddo/static/src/js/tour.js',

--- a/theme_loftspace/__manifest__.py
+++ b/theme_loftspace/__manifest__.py
@@ -54,7 +54,6 @@
         },
     },
     'license': 'LGPL-3',
-    'live_test_url': 'https://theme-loftspace.odoo.com',
     'assets': {
         'website.assets_editor': [
             'theme_loftspace/static/src/js/tour.js',

--- a/theme_monglia/__manifest__.py
+++ b/theme_monglia/__manifest__.py
@@ -43,7 +43,6 @@
         },
     },
     'license': 'LGPL-3',
-    'live_test_url': 'https://theme-monglia.odoo.com',
     'assets': {
         'website.assets_editor': [
             'theme_monglia/static/src/js/tour.js',

--- a/theme_nano/__manifest__.py
+++ b/theme_nano/__manifest__.py
@@ -61,7 +61,6 @@
         },
     },
     'license': 'LGPL-3',
-    'live_test_url': 'https://theme-nano.odoo.com',
     'assets': {
         'website.assets_editor': [
             'theme_nano/static/src/js/tour.js',

--- a/theme_notes/__manifest__.py
+++ b/theme_notes/__manifest__.py
@@ -56,7 +56,6 @@
         },
     },
     'license': 'LGPL-3',
-    'live_test_url': 'https://theme-notes.odoo.com',
     'assets': {
         'website.assets_editor': [
             'theme_notes/static/src/js/tour.js',

--- a/theme_odoo_experts/__manifest__.py
+++ b/theme_odoo_experts/__manifest__.py
@@ -51,7 +51,6 @@
         },
     },
     'license': 'LGPL-3',
-    'live_test_url': 'https://theme-odoo-experts.odoo.com',
     'assets': {
         'website.assets_editor': [
             'theme_odoo_experts/static/src/js/tour.js',

--- a/theme_orchid/__manifest__.py
+++ b/theme_orchid/__manifest__.py
@@ -51,7 +51,6 @@
         },
     },
     'license': 'LGPL-3',
-    'live_test_url': 'https://theme-orchid.odoo.com',
     'assets': {
         'website.assets_editor': [
             'theme_orchid/static/src/js/tour.js',

--- a/theme_paptic/__manifest__.py
+++ b/theme_paptic/__manifest__.py
@@ -33,7 +33,6 @@
         },
     },
     'license': 'LGPL-3',
-    'live_test_url': 'https://theme-paptic.odoo.com',
     'assets': {
         'website.assets_editor': [
             'theme_paptic/static/src/js/tour.js',

--- a/theme_real_estate/__manifest__.py
+++ b/theme_real_estate/__manifest__.py
@@ -49,7 +49,6 @@
         },
     },
     'license': 'LGPL-3',
-    'live_test_url': 'https://theme-real-estate.odoo.com',
     'assets': {
         'website.assets_editor': [
             'theme_real_estate/static/src/js/tour.js',

--- a/theme_treehouse/__manifest__.py
+++ b/theme_treehouse/__manifest__.py
@@ -51,7 +51,6 @@
         },
     },
     'license': 'LGPL-3',
-    'live_test_url': 'https://theme-treehouse.odoo.com',
     'assets': {
         'website.assets_editor': [
             'theme_treehouse/static/src/js/tour.js',

--- a/theme_vehicle/__manifest__.py
+++ b/theme_vehicle/__manifest__.py
@@ -39,7 +39,6 @@
         },
     },
     'license': 'LGPL-3',
-    'live_test_url': 'https://theme-vehicle.odoo.com',
     'assets': {
         'website.assets_editor': [
             'theme_vehicle/static/src/js/tour.js',

--- a/theme_yes/__manifest__.py
+++ b/theme_yes/__manifest__.py
@@ -55,7 +55,6 @@
         },
     },
     'license': 'LGPL-3',
-    'live_test_url': 'https://theme-yes.odoo.com',
     'assets': {
         'website.assets_editor': [
             'theme_yes/static/src/js/tour.js',

--- a/theme_zap/__manifest__.py
+++ b/theme_zap/__manifest__.py
@@ -46,7 +46,6 @@
         },
     },
     'license': 'LGPL-3',
-    'live_test_url': 'https://theme-zap.odoo.com',
     'assets': {
         'website.assets_editor': [
             'theme_zap/static/src/js/tour.js',


### PR DESCRIPTION
Since task-3454790, live preview urls got deprecated, but they are still available on apps.odoo.com. This confused some customers as they could click the live preview and get redirected to a blank page.

opw-5023137