### PR TITLE
[FIX] website: use the correct cache key for _get_page_info

### DIFF
--- a/test_themes/tests/test_crawl.py
+++ b/test_themes/tests/test_crawl.py
@@ -49,11 +49,4 @@ class Crawler(HttpCase):
         Website = self.env['website']
         websites_themes = Website.get_test_themes_websites()
         for website in websites_themes:
-            # TODO: remove this invalidation and invalidation in theme feature.
-            # They are missing invalidations of template ormcache and others.
-            # The configurator_apply method and various methods used for theme
-            # added on `ir.module.module` from website write directly on
-            # `ir.model.data` and update attachments, views, xmlids.
-            self.env.registry.clear_cache('templates')
-
             self.start_tour(f"/web?fw={website.id}", 'homepage', login='admin')


### PR DESCRIPTION
Because of the changes in odoo/odoo/230509, 
we no longer need to invalidate the cache for this tour.

task-5144117