### PR TITLE
[IMP] theme_[*]: update s_cover xpath in design themes

### DIFF
--- a/theme_anelusia/views/new_page_template.xml
+++ b/theme_anelusia/views/new_page_template.xml
@@ -72,8 +72,8 @@
 <!-- Snippet customization Landing Pages -->
 
 <template id="new_page_template_landing_0_s_cover" inherit_id="website.new_page_template_landing_0_s_cover">
-    <xpath expr="//section" position="attributes">
-        <attribute name="class" remove="pt128 pb128" separator=" "/>
+    <xpath expr="//div[hasclass('col-lg-12')]" position="attributes">
+        <attribute name="class" remove="pt184 pb184" separator=" "/>
     </xpath>
 </template>
 
@@ -81,6 +81,9 @@
     <xpath expr="//section" position="attributes">
         <!-- Added by both theme and new page template -->
         <attribute name="class" add="o_three_quarter_height" remove="o_three_quarter_height" separator=" "/>
+    </xpath>
+    <xpath expr="//div[hasclass('col-lg-12')]" position="attributes">
+        <attribute name="class" remove="pt40 pb40" separator=" "/>
     </xpath>
 </template>
 

--- a/theme_anelusia/views/snippets/s_cover.xml
+++ b/theme_anelusia/views/snippets/s_cover.xml
@@ -4,7 +4,11 @@
 <template id="s_cover" inherit_id="website.s_cover">
     <!-- Section -->
     <xpath expr="//section" position="attributes">
-        <attribute name="class" add="o_three_quarter_height pt128 pb128" remove="pt232 pb232" separator=" "/>
+        <attribute name="class" add="o_three_quarter_height" separator=" "/>
+    </xpath>
+    <!-- Column -->
+    <xpath expr="//div[hasclass('col-lg-12')]" position="attributes">
+        <attribute name="class" add="pt32 pb32" remove="pt160 pb160" separator=" "/>
     </xpath>
     <!-- Title -->
     <xpath expr="//h1" position="replace" mode="inner">

--- a/theme_artists/views/new_page_template.xml
+++ b/theme_artists/views/new_page_template.xml
@@ -103,7 +103,16 @@
 
 <template id="new_page_template_about_s_cover" inherit_id="website.new_page_template_about_s_cover">
     <xpath expr="//section" position="attributes">
-        <attribute name="class" add="o_three_quarter_height" remove="o_full_screen_height pt40 pb40" separator=" "/>
+        <attribute name="class" add="o_three_quarter_height" remove="o_full_screen_height" separator=" "/>
+    </xpath>
+    <xpath expr="//div[hasclass('col-lg-12')]" position="attributes">
+        <attribute name="class" add="pt56 pb32" remove="pt152 pb128" separator=" "/>
+    </xpath>
+</template>
+
+<template id="new_page_template_landing_4_s_cover" inherit_id="website.new_page_template_landing_4_s_cover">
+    <xpath expr="//div[hasclass('col-lg-12')]" position="attributes">
+        <attribute name="class" add="pt56 pb32" remove="pt40 pb40 pt152 pb128" separator=" "/>
     </xpath>
 </template>
 
@@ -158,8 +167,8 @@
 </template>
 
 <template id="new_page_template_landing_0_s_cover" inherit_id="website.new_page_template_landing_0_s_cover">
-    <xpath expr="//section" position="attributes">
-        <attribute name="class" remove="pt224 pb200" separator=" "/>
+    <xpath expr="//div[hasclass('col-lg-12')]" position="attributes">
+        <attribute name="class" add="pt160" remove="pt184 pt152 pb128" separator=" "/>
     </xpath>
 </template>
 

--- a/theme_artists/views/snippets/s_cover.xml
+++ b/theme_artists/views/snippets/s_cover.xml
@@ -4,7 +4,7 @@
 <template id="s_cover" inherit_id="website.s_cover">
     <!-- Section -->
     <xpath expr="//section" position="attributes">
-        <attribute name="class" add="pt224 pb200" remove="pt232 pb232 parallax s_parallax_is_fixed bg-black-50" separator=" "/>
+        <attribute name="class" remove="parallax s_parallax_is_fixed bg-black-50" separator=" "/>
         <attribute name="data-oe-shape-data">{'shape':'html_builder/Connections/20','colors':{'c5': 'o-color-1'},'flip':['y'], 'showOnMobile':true}</attribute>
     </xpath>
     <!-- Shape -->
@@ -14,6 +14,10 @@
     <!-- Remove filter & parallax -->
     <xpath expr="//div[hasclass('o_we_bg_filter')]" position="replace"/>
     <xpath expr="//span[hasclass('s_parallax_bg_wrap')]" position="replace"/>
+    <!-- Column -->
+    <xpath expr="//div[hasclass('col-lg-12')]" position="attributes">
+        <attribute name="class" add="pt152 pb128" remove="pt160 pb160" separator=" "/>
+    </xpath>
     <!-- Title -->
     <xpath expr="//h1" position="replace" mode="inner">
         Emotions <br/>through the colors

--- a/theme_aviato/views/new_page_template.xml
+++ b/theme_aviato/views/new_page_template.xml
@@ -41,8 +41,8 @@
 </template>
 
 <template id="new_page_template_about_mini_s_cover" inherit_id="website.new_page_template_about_mini_s_cover">
-    <xpath expr="//section" position="attributes">
-        <attribute name="class" remove="pb40 pt40" separator=" "/>
+    <xpath expr="//div[hasclass('col-lg-12')]" position="attributes">
+        <attribute name="class" add="pt152 pb152" remove="pt120 pb120" separator=" "/>
     </xpath>
 </template>
 
@@ -55,8 +55,8 @@
 <!-- Snippet customization Landing Pages -->
 
 <template id="new_page_template_landing_0_s_cover" inherit_id="website.new_page_template_landing_0_s_cover">
-    <xpath expr="//section" position="attributes">
-        <attribute name="class" remove="pt192 pb192" separator=" "/>
+    <xpath expr="//div[hasclass('col-lg-12')]" position="attributes">
+        <attribute name="class" remove="pt120 pb120" separator=" "/>
     </xpath>
 </template>
 
@@ -67,6 +67,9 @@
     </xpath>
     <xpath expr="//div[hasclass('container')]" position="before">
         <div class="o_we_shape o_html_builder_Connections_09" style="background-image: url('/html_editor/shape/html_builder/Connections/09.svg?c5=o-color-4');"/>
+    </xpath>
+    <xpath expr="//div[hasclass('col-lg-12')]" position="attributes">
+        <attribute name="class" add="pt48 pb48" remove="pt120 pb120" separator=" "/>
     </xpath>
 </template>
 
@@ -88,6 +91,9 @@
     </xpath>
     <xpath expr="//div[hasclass('container')]" position="before">
         <div class="o_we_shape o_html_builder_Connections_09" style="background-image: url('/html_editor/shape/html_builder/Connections/09.svg?c5=o-color-4');"/>
+    </xpath>
+    <xpath expr="//div[hasclass('col-lg-12')]" position="attributes">
+        <attribute name="class" add="pt48 pb48" remove="pt40 pb40 pt120 pb120" separator=" "/>
     </xpath>
 </template>
 

--- a/theme_aviato/views/snippets/s_cover.xml
+++ b/theme_aviato/views/snippets/s_cover.xml
@@ -4,10 +4,14 @@
 <template id="s_cover" inherit_id="website.s_cover">
     <!-- Section -->
     <xpath expr="//section" position="attributes">
-        <attribute name="class" add="pt192 pb192" remove="pt232 pb232 s_parallax_is_fixed" separator=" "/>
+        <attribute name="class" remove="s_parallax_is_fixed" separator=" "/>
     </xpath>
     <xpath expr="//span[hasclass('s_parallax_bg')]" position="replace">
         <span class="s_parallax_bg oe_img_bg" style="background-image: url('/web/image/website.s_cover_default_image'); background-position: 50% 50%;"/>
+    </xpath>
+    <!-- Column -->
+    <xpath expr="//div[hasclass('col-lg-12')]" position="attributes">
+        <attribute name="class" add="pt120 pb120" remove="pt160 pb160" separator=" "/>
     </xpath>
     <!-- Title -->
     <xpath expr="//h1" position="replace" mode="inner">

--- a/theme_bewise/views/customizations.xml
+++ b/theme_bewise/views/customizations.xml
@@ -4,7 +4,7 @@
 <!-- ======== COVER ======== -->
 <template id="s_cover" inherit_id="website.s_cover" name="Be Wise s_cover">
     <xpath expr="//section" position="attributes">
-        <attribute name="class" add="pt200 pb200 oe_img_bg o_bg_img_center" remove="bg-black-50 s_parallax_is_fixed parallax pt232 pb232" separator=" "/>
+        <attribute name="class" add="oe_img_bg o_bg_img_center" remove="parallax s_parallax_is_fixed bg-black-50" separator=" "/>
         <attribute name="style">background-image: url('/web/image/website.s_cover_default_image'); background-position: 50% 50%;</attribute>
         <attribute name="data-oe-shape-data">{"shape":"html_builder/Rainy/08_001","flip":[]}</attribute>
         <attribute name="data-scroll-background-ratio">0</attribute>
@@ -15,6 +15,10 @@
     </xpath>
     <!-- Remove the background image for parallax -->
     <xpath expr="//span[hasclass('s_parallax_bg_wrap')]" position="replace"/>
+    <!-- Column -->
+    <xpath expr="//div[hasclass('col-lg-12')]" position="attributes">
+        <attribute name="class" add="pt128 pb128" remove="pt160 pb160" separator=" "/>
+    </xpath>
     <!-- Title -->
     <xpath expr="//h1" position="replace" mode="inner">
         Always at the top

--- a/theme_bewise/views/new_page_template.xml
+++ b/theme_bewise/views/new_page_template.xml
@@ -60,8 +60,8 @@
 </template>
 
 <template id="new_page_template_about_mini_s_cover" inherit_id="website.new_page_template_about_mini_s_cover">
-    <xpath expr="//section" position="attributes">
-        <attribute name="class" remove="pt40 pb40" separator=" "/>
+    <xpath expr="//div[hasclass('col-lg-12')]" position="attributes">
+        <attribute name="class" add="pt48 pb48" remove="pt128 pb128" separator=" "/>
     </xpath>
 </template>
 
@@ -79,8 +79,14 @@
 <!-- Snippet customization Landing Pages -->
 
 <template id="new_page_template_landing_0_s_cover" inherit_id="website.new_page_template_landing_0_s_cover">
-    <xpath expr="//section" position="attributes">
-        <attribute name="class" remove="pt200 pb200" separator=" "/>
+    <xpath expr="//div[hasclass('col-lg-12')]" position="attributes">
+        <attribute name="class" remove="pt128 pb128" separator=" "/>
+    </xpath>
+</template>
+
+<template id="new_page_template_landing_4_s_cover" inherit_id="website.new_page_template_landing_4_s_cover">
+    <xpath expr="//div[hasclass('col-lg-12')]" position="attributes">
+        <attribute name="class" add="pt48 pb48" remove="pt40 pb40 pt128 pb128" separator=" "/>
     </xpath>
 </template>
 
@@ -100,6 +106,9 @@
     <xpath expr="//section" position="attributes">
         <attribute name="class" add="o_three_quarter_height" remove="o_full_screen_height" separator=" "/>
     </xpath>
+    <xpath expr="//div[hasclass('col-lg-12')]" position="attributes">
+        <attribute name="class" add="pt48 pb48" remove="pt128 pb128" separator=" "/>
+    </xpath>
 </template>
 
 <!-- Snippet customization Gallery Pages -->
@@ -107,6 +116,9 @@
 <template id="new_page_template_gallery_s_cover" inherit_id="website.new_page_template_gallery_s_cover">
     <xpath expr="//section" position="attributes">
         <attribute name="class" add="o_three_quarter_height" remove="o_full_screen_height" separator=" "/>
+    </xpath>
+    <xpath expr="//div[hasclass('col-lg-12')]" position="attributes">
+        <attribute name="class" add="pt48 pb48" remove="pt128 pb128" separator=" "/>
     </xpath>
 </template>
 
@@ -123,6 +135,9 @@
 <template id="new_page_template_pricing_s_cover" inherit_id="website.new_page_template_pricing_s_cover">
     <xpath expr="//section" position="attributes">
         <attribute name="class" add="o_three_quarter_height" remove="o_full_screen_height" separator=" "/>
+    </xpath>
+    <xpath expr="//div[hasclass('col-lg-12')]" position="attributes">
+        <attribute name="class" add="pt48 pb48" remove="pt128 pb128" separator=" "/>
     </xpath>
 </template>
 

--- a/theme_buzzy/views/new_page_template.xml
+++ b/theme_buzzy/views/new_page_template.xml
@@ -177,8 +177,8 @@
 </template>
 
 <template id="new_page_template_about_mini_s_cover" inherit_id="website.new_page_template_about_mini_s_cover">
-    <xpath expr="//section" position="attributes">
-        <attribute name="class" remove="pt40 pb40" separator=" "/>
+    <xpath expr="//div[hasclass('col-lg-12')]" position="attributes">
+        <attribute name="class" add="pt72 pb72" remove="pt40 pb40" separator=" "/>
     </xpath>
 </template>
 
@@ -242,11 +242,14 @@
 <template id="new_page_template_landing_0_s_cover" inherit_id="website.new_page_template_landing_0_s_cover">
     <!-- Remove shape option -->
     <xpath expr="//section" position="attributes">
-        <attribute name="class" remove="pt112 pb112" separator=" "/>
         <attribute name="data-oe-shape-data"/>
     </xpath>
     <!-- Remove shape -->
     <xpath expr="//div[hasclass('o_we_shape')]" position="replace"/>
+    <!-- Column -->
+    <xpath expr="//div[hasclass('col-lg-12')]" position="attributes">
+        <attribute name="class" remove="pt40 pb40" separator=" "/>
+    </xpath>
 </template>
 
 <template id="new_page_template_landing_2_s_cover" inherit_id="website.new_page_template_landing_2_s_cover">
@@ -277,6 +280,10 @@
     </xpath>
     <!-- Remove shape -->
     <xpath expr="//div[hasclass('o_we_shape')]" position="replace"/>
+    <!-- Column -->
+    <xpath expr="//div[hasclass('col-lg-12')]" position="attributes">
+        <attribute name="class" add="pt32 pb32" remove="pt40 pb40" separator=" "/>
+    </xpath>
 </template>
 
 <!-- Snippet customization Gallery Pages -->

--- a/theme_buzzy/views/snippets/s_cover.xml
+++ b/theme_buzzy/views/snippets/s_cover.xml
@@ -4,7 +4,7 @@
 <template id="s_cover" inherit_id="website.s_cover">
     <!-- Section -->
     <xpath expr="//section" position="attributes">
-        <attribute name="class" add="pt112 pb112" remove="pt232 pb232 bg-black-50" separator=" "/>
+        <attribute name="class" remove="bg-black-50" separator=" "/>
         <attribute name="data-oe-shape-data">{"shape":"html_builder/Airy/12_002","colors":{"c5":"rgba(255,255,255,0.25)","c3":"rgba(255,255,255,0)"},"flip":[]}</attribute>
     </xpath>
     <!-- Filter -->
@@ -14,6 +14,10 @@
     <!-- Shape -->
     <xpath expr="//div[hasclass('o_we_bg_filter')]" position="after">
         <div class="o_we_shape o_html_builder_Airy_12_002 o_we_animated" style="background-image: url('/html_editor/shape/html_builder/Airy/12_002.svg?c5=rgba(255,255,255,0.25)&amp;c3=rgba(255,255,255,0)');"/>
+    </xpath>
+    <!-- Column -->
+    <xpath expr="//div[hasclass('col-lg-12')]" position="attributes">
+        <attribute name="class" add="pt40 pb40" remove="pt160 pb160" separator=" "/>
     </xpath>
     <!-- Title -->
     <xpath expr="//h1" position="replace" mode="inner">

--- a/theme_graphene/views/customizations.xml
+++ b/theme_graphene/views/customizations.xml
@@ -4,41 +4,39 @@
 <!-- ======== COVER ======== -->
 <template id="s_cover" inherit_id="website.s_cover" name="Graphene s_cover">
     <xpath expr="//section" position="attributes">
-        <attribute name="class" add="pt160 pb160" remove="pt232 pb232 s_parallax_is_fixed" separator=" "/>
+        <attribute name="class" remove="s_parallax_is_fixed" separator=" "/>
         <attribute name="data-scroll-background-ratio">0</attribute>
         <attribute name="style">background-image: url('/web/image/website.s_cover_default_image');</attribute>
     </xpath>
     <xpath expr="//span[hasclass('s_parallax_bg_wrap')]" position="replace"/>
-    <xpath expr="//h1" position="replace"/>
-    <xpath expr="//p" position="replace"/>
-    <xpath expr="//p" position="replace"/>
-    <xpath expr="//section/div[hasclass('container')]" position="inside">
-        <div class="row">
-            <div class="col col-lg-7">
-                <h1>
-                    Making the difference.
-                </h1>
-                <p class="lead">
-                    Our mission is to give customers the best experience.<br/>Extensive documentation &amp; guides, an active community,<br/>24/7 support make it a pleasure to work with us.
-                </p>
-                <p>
-                    <a t-att-href="cta_btn_href" class="btn btn-primary btn-lg o_translate_inline"><t t-out="cta_btn_text">Contact us</t></a>
-                </p>
-            </div>
-        </div>
+    <xpath expr="//div[hasclass('col-lg-12')]" position="attributes">
+        <attribute name="class" add="col-lg-7 pt88 pb88" remove="col-lg-12 pt160 pb160" separator=" "/>
+    </xpath>
+    <xpath expr="//h1" position="replace">
+        <h1>Making the difference.</h1>
+    </xpath>
+    <xpath expr="//p" position="replace">
+        <p class="lead">
+            Our mission is to give customers the best experience.<br/>Extensive documentation &amp; guides, an active community,<br/>24/7 support make it a pleasure to work with us.
+        </p>
+    </xpath>
+    <xpath expr="//p[2]" position="replace">
+        <p>
+            <a t-att-href="cta_btn_href" class="btn btn-primary btn-lg o_translate_inline"><t t-out="cta_btn_text">Contact us</t></a>
+        </p>
     </xpath>
 </template>
 
 <template id="configurator_s_cover" inherit_id="website.configurator_s_cover" name="Graphene s_cover">
     <xpath expr="//section" position="attributes">
-        <attribute name="class" add="pt96 pb48" remove="pt160 pb160" separator=" "/>
+        <attribute name="class" add="pt96 pb48" remove="pt72 pb72" separator=" "/>
         <attribute name="data-oe-shape-data">{"shape":"html_builder/Connections/01","colors":{"c5": "o-color-3"},"flip":[]}</attribute>
     </xpath>
     <xpath expr="//section/div[hasclass('container')]" position="before">
         <div class="o_we_shape o_html_builder_Connections_01" style="background-image: url('/html_editor/shape/html_builder/Connections/01.svg?c5=o-color-3');"/>
     </xpath>
     <xpath expr="//div[hasclass('col-lg-7')]" position="attributes">
-        <attribute name="class" add="pb56" separator=" "/>
+        <attribute name="class" add="pb56" remove="pt88 pb88" separator=" "/>
     </xpath>
 </template>
 

--- a/theme_graphene/views/new_page_template.xml
+++ b/theme_graphene/views/new_page_template.xml
@@ -79,8 +79,8 @@
 </template>
 
 <template id="new_page_template_about_mini_s_cover" inherit_id="website.new_page_template_about_mini_s_cover">
-    <xpath expr="//section" position="attributes">
-        <attribute name="class" remove="pt40 pb40" separator=" "/>
+    <xpath expr="//div[hasclass('col-lg-7')]" position="attributes">
+        <attribute name="class" add="pt120 pb120" remove="pt88 pb88" separator=" "/>
     </xpath>
 </template>
 
@@ -131,8 +131,8 @@
 </template>
 
 <template id="new_page_template_landing_0_s_cover" inherit_id="website.new_page_template_landing_0_s_cover">
-    <xpath expr="//section" position="attributes">
-        <attribute name="class" remove="pt160 pb160" separator=" "/>
+    <xpath expr="//div[hasclass('col-lg-7')]" position="attributes">
+        <attribute name="class" remove="pt88 pb88" separator=" "/>
     </xpath>
 </template>
 
@@ -142,6 +142,12 @@
     </xpath>
     <xpath expr="//section/div[hasclass('container')]" position="before">
         <div class="o_we_shape o_html_builder_Bold_13" style="background-image: url('/html_editor/shape/html_builder/Bold/13.svg?c5=o-color-3');"/>
+    </xpath>
+</template>
+
+<template id="new_page_template_landing_4_s_cover" inherit_id="website.new_page_template_landing_4_s_cover">
+    <xpath expr="//div[hasclass('col-lg-7')]" position="attributes">
+        <attribute name="class" remove="pt88 pb88" separator=" "/>
     </xpath>
 </template>
 

--- a/theme_loftspace/views/new_page_template.xml
+++ b/theme_loftspace/views/new_page_template.xml
@@ -198,8 +198,8 @@
 </template>
 
 <template id="new_page_template_landing_0_s_cover" inherit_id="website.new_page_template_landing_0_s_cover">
-    <xpath expr="//section" position="attributes">
-        <attribute name="class" remove="pt232" separator=" "/>
+    <xpath expr="//div[hasclass('col-lg-12')]" position="attributes">
+        <attribute name="class" remove="pt184 pb184" separator=" "/>
     </xpath>
 </template>
 
@@ -207,6 +207,12 @@
     <!-- Section -->
     <xpath expr="//section" position="attributes">
         <attribute name="class" add="o_three_quarter_height" remove="o_full_screen_height" separator=" "/>
+    </xpath>
+</template>
+
+<template id="new_page_template_landing_4_s_cover" inherit_id="website.new_page_template_landing_4_s_cover">
+    <xpath expr="//div[hasclass('col-lg-12')]" position="attributes">
+        <attribute name="class" remove="pt40 pb40" separator=" "/>
     </xpath>
 </template>
 

--- a/theme_loftspace/views/snippets/s_cover.xml
+++ b/theme_loftspace/views/snippets/s_cover.xml
@@ -6,6 +6,10 @@
     <xpath expr="//section" position="attributes">
         <attribute name="class" add="o_full_screen_height" separator=" "/>
     </xpath>
+    <!-- Column -->
+    <xpath expr="//div[hasclass('col-lg-12')]" position="attributes">
+        <attribute name="class" add="pt40 pb40" remove="pt160 pb160" separator=" "/>
+    </xpath>
     <!-- Title -->
     <xpath expr="//h1" position="replace" mode="inner">
         Bringing life to your interior

--- a/theme_nano/views/new_page_template.xml
+++ b/theme_nano/views/new_page_template.xml
@@ -162,8 +162,8 @@
 </template>
 
 <template id="new_page_template_about_mini_s_cover" inherit_id="website.new_page_template_about_mini_s_cover">
-    <xpath expr="//section" position="attributes">
-        <attribute name="class" remove="pt40 pb40" separator=" "/>
+    <xpath expr="//div[hasclass('col-lg-12')]" position="attributes">
+        <attribute name="class" add="pt120 pb120" remove="pt128 pb128" separator=" "/>
     </xpath>
 </template>
 
@@ -227,11 +227,14 @@
 <template id="new_page_template_landing_0_s_cover" inherit_id="website.new_page_template_landing_0_s_cover">
     <!-- Shape option -->
     <xpath expr="//section" position="attributes">
-        <attribute name="class" remove="pt200 pb200" separator=" "/>
         <attribute name="data-oe-shape-data">{"shape":"html_builder/Bold/25","flip":["x"]}</attribute>
     </xpath>
     <xpath expr="//*[hasclass('container')]" position="before">
         <div class="o_we_shape o_html_builder_Bold_25" style="background-image: url('/html_editor/shape/html_builder/Bold/25.svg?c5=o-color-5&amp;flip=x'); background-position: 50% 50%;"/>
+    </xpath>
+    <!-- Column -->
+    <xpath expr="//div[hasclass('col-lg-12')]" position="attributes">
+        <attribute name="class" remove="pt128 pb128" separator=" "/>
     </xpath>
 </template>
 
@@ -243,6 +246,10 @@
     </xpath>
     <xpath expr="//*[hasclass('container')]" position="before">
         <div class="o_we_shape o_html_builder_Bold_25" style="background-image: url('/html_editor/shape/html_builder/Bold/25.svg?c5=o-color-5&amp;flip=x'); background-position: 50% 50%;"/>
+    </xpath>
+    <!-- Column -->
+    <xpath expr="//div[hasclass('col-lg-12')]" position="attributes">
+        <attribute name="class" add="pt48 pb48" remove="pt128 pb128" separator=" "/>
     </xpath>
 </template>
 
@@ -266,6 +273,10 @@
     <xpath expr="//*[hasclass('container')]" position="before">
         <div class="o_we_shape o_html_builder_Bold_25" style="background-image: url('/html_editor/shape/html_builder/Bold/25.svg?c5=o-color-5&amp;flip=x'); background-position: 50% 50%;"/>
     </xpath>
+    <!-- Column -->
+    <xpath expr="//div[hasclass('col-lg-12')]" position="attributes">
+        <attribute name="class" add="pt48 pb48" remove="pt40 pb40 pt128 pb128" separator=" "/>
+    </xpath>
 </template>
 
 <template id="new_page_template_landing_4_s_text_block_h2" inherit_id="website.new_page_template_landing_4_s_text_block_h2">
@@ -284,6 +295,10 @@
     </xpath>
     <xpath expr="//*[hasclass('container')]" position="before">
         <div class="o_we_shape o_html_builder_Bold_25" style="background-image: url('/html_editor/shape/html_builder/Bold/25.svg?c5=o-color-5&amp;flip=x'); background-position: 50% 50%;"/>
+    </xpath>
+    <!-- Column -->
+    <xpath expr="//div[hasclass('col-lg-12')]" position="attributes">
+        <attribute name="class" add="pt48 pb48" remove="pt128 pb128" separator=" "/>
     </xpath>
 </template>
 
@@ -348,6 +363,10 @@
     </xpath>
     <xpath expr="//*[hasclass('container')]" position="before">
         <div class="o_we_shape o_html_builder_Bold_25" style="background-image: url('/html_editor/shape/html_builder/Bold/25.svg?c5=o-color-5&amp;flip=x'); background-position: 50% 50%;"/>
+    </xpath>
+    <!-- Column -->
+    <xpath expr="//div[hasclass('col-lg-12')]" position="attributes">
+        <attribute name="class" add="pt48 pb48" remove="pt128 pb128" separator=" "/>
     </xpath>
 </template>
 

--- a/theme_nano/views/snippets/s_cover.xml
+++ b/theme_nano/views/snippets/s_cover.xml
@@ -4,11 +4,15 @@
 <template id="s_cover" inherit_id="website.s_cover">
     <!-- Section -->
     <xpath expr="//section" position="attributes">
-        <attribute name="class" add="pt200 pb200" remove="parallax s_parallax_is_fixed bg-black-50 pt232 pb232" separator=" "/>
+        <attribute name="class" remove="parallax s_parallax_is_fixed bg-black-50" separator=" "/>
         <attribute name="data-scroll-background-ratio">0</attribute>
         <attribute name="style">background-image: url('/web/image/website.s_cover_default_image'); background-position: 50% 0;</attribute>
     </xpath>
     <xpath expr="//*[hasclass('s_parallax_bg_wrap')]" position="replace"/>
+    <!-- Column -->
+    <xpath expr="//div[hasclass('col-lg-12')]" position="attributes">
+        <attribute name="class" add="pt128 pb128" remove="pt160 pb160" separator=" "/>
+    </xpath>
     <!-- Title & Text -->
     <xpath expr="//h1" position="replace" mode="inner">
         Creative Studio

--- a/theme_paptic/views/customizations.xml
+++ b/theme_paptic/views/customizations.xml
@@ -16,7 +16,7 @@
 <template id="s_cover" inherit_id="website.s_cover" name="Paptic s_cover">
     <!-- Section -->
     <xpath expr="//section" position="attributes">
-        <attribute name="class" add="o_cc1 pt80 pb56" remove="o_cc5 pt232 pb232" separator=" "/>
+        <attribute name="class" add="o_cc1 pt80 pb56" remove="o_cc5 pt72 pb72" separator=" "/>
     </xpath>
 
     <!-- Remove the parallax background -->
@@ -40,18 +40,13 @@
     </xpath>
 
     <!-- Create Structure -->
-    <xpath expr="//div[hasclass('container')]" position="inside">
-        <div class="row">
-            <div class="o_colored_level col-lg-5 pt32"/>
-            <div class="o_colored_level col-lg-6 offset-lg-1">
-                <img class="img img-fluid" src="/html_editor/shape/theme_paptic/s_cover.svg?c1=o-color-1&amp;c2=o-color-2"/>
-            </div>
-        </div>
+    <xpath expr="//div[hasclass('container')]//div[hasclass('col-lg-12')]" position="attributes">
+        <attribute name="class" add="o_colored_level col-lg-5 pt32" remove="col-lg-12 pt160 pb160" separator=" "/>
     </xpath>
-    <xpath expr="//div[hasclass('col-lg-5')]" position="inside">
-        <xpath expr="//div[hasclass('container')]/h1" position="move"/>
-        <xpath expr="//div[hasclass('container')]/p"  position="move"/>
-        <xpath expr="//div[hasclass('container')]/p"  position="move"/>
+    <xpath expr="//div[hasclass('col-lg-5')]" position="after">
+        <div class="o_colored_level col-lg-6 offset-lg-1">
+            <img class="img img-fluid" src="/html_editor/shape/theme_paptic/s_cover.svg?c1=o-color-1&amp;c2=o-color-2"/>
+        </div>
     </xpath>
 </template>
 

--- a/theme_paptic/views/new_page_template.xml
+++ b/theme_paptic/views/new_page_template.xml
@@ -113,8 +113,14 @@
 </template>
 
 <template id="new_page_template_landing_0_s_cover" inherit_id="website.new_page_template_landing_0_s_cover">
-    <xpath expr="//section" position="attributes">
-        <attribute name="class" remove="pt256 pb256" separator=" "/>
+    <xpath expr="//div[hasclass('col-lg-5')]" position="attributes">
+        <attribute name="class" remove="pt184 pb184" separator=" "/>
+    </xpath>
+</template>
+
+<template id="new_page_template_landing_4_s_cover" inherit_id="website.new_page_template_landing_4_s_cover">
+    <xpath expr="//div[hasclass('row')]/div" position="attributes">
+        <attribute name="class" remove="pt40 pb40" separator=" "/>
     </xpath>
 </template>
 

--- a/theme_real_estate/views/new_page_template.xml
+++ b/theme_real_estate/views/new_page_template.xml
@@ -110,8 +110,8 @@
 </template>
 
 <template id="new_page_template_s_cover" inherit_id="website.new_page_template_s_cover">
-    <xpath expr="//section" position="attributes">
-        <attribute name="class" remove="pt176 pb176" separator=" "/>
+    <xpath expr="//div[hasclass('col-lg-12')]" position="attributes">
+        <attribute name="class" remove="pt104 pb104" separator=" "/>
     </xpath>
 </template>
 

--- a/theme_real_estate/views/snippets/s_cover.xml
+++ b/theme_real_estate/views/snippets/s_cover.xml
@@ -3,11 +3,12 @@
 
 <template id="s_cover" inherit_id="website.s_cover">
     <!-- Section -->
-    <xpath expr="//section" position="attributes">
-        <attribute name="class" remove="pt232 pb232" add="pt176 pb176" separator=" "/>
-    </xpath>
         <xpath expr="//div[hasclass('o_we_bg_filter')]" position="attributes">
         <attribute name="class" add="bg-black-15" remove="bg-black-50" separator=" "/>
+    </xpath>
+    <!-- Column -->
+    <xpath expr="//div[hasclass('col-lg-12')]" position="attributes">
+        <attribute name="class" add="pt104 pb104" remove="pt160 pb160" separator=" "/>
     </xpath>
     <!-- Title -->
     <xpath expr="//h1" position="replace">

--- a/theme_treehouse/views/new_page_template.xml
+++ b/theme_treehouse/views/new_page_template.xml
@@ -53,8 +53,8 @@
 </template>
 
 <template id="new_page_template_about_mini_s_cover" inherit_id="website.new_page_template_about_mini_s_cover">
-    <xpath expr="//section" position="attributes">
-        <attribute name="class" remove="pt40 pb40" separator=" "/>
+    <xpath expr="//div[hasclass('col-lg-12')]" position="attributes">
+        <attribute name="class" add="pt40 pb40" remove="pt88 pb88" separator=" "/>
     </xpath>
 </template>
 
@@ -68,14 +68,23 @@
 </template>
 
 <template id="new_page_template_landing_0_s_cover" inherit_id="website.new_page_template_landing_0_s_cover">
-    <xpath expr="//section" position="attributes">
-        <attribute name="class" remove="pt160 pb160" separator=" "/>
+    <xpath expr="//div[hasclass('col-lg-12')]" position="attributes">
+        <attribute name="class" remove="pt88 pb88" separator=" "/>
     </xpath>
 </template>
 
 <template id="new_page_template_landing_2_s_cover" inherit_id="website.new_page_template_landing_2_s_cover">
     <xpath expr="//section" position="attributes">
         <attribute name="class" add="o_three_quarter_height" remove="o_full_screen_height" separator=" "/>
+    </xpath>
+    <xpath expr="//div[hasclass('col-lg-12')]" position="attributes">
+        <attribute name="class" add="pt40 pb40" remove="pt88 pb88" separator=" "/>
+    </xpath>
+</template>
+
+<template id="new_page_template_landing_4_s_cover" inherit_id="website.new_page_template_landing_4_s_cover">
+    <xpath expr="//div[hasclass('col-lg-12')]" position="attributes">
+        <attribute name="class" remove="pt88 pb88" separator=" "/>
     </xpath>
 </template>
 
@@ -106,6 +115,9 @@
     <xpath expr="//section" position="attributes">
         <attribute name="class" add="o_three_quarter_height" remove="o_full_screen_height" separator=" "/>
     </xpath>
+    <xpath expr="//div[hasclass('col-lg-12')]" position="attributes">
+        <attribute name="class" add="pt40 pb40" remove="pt88 pb88" separator=" "/>
+    </xpath>
 </template>
 
 <template id="new_page_template_gallery_s_image_text_2nd" inherit_id="website.new_page_template_gallery_s_image_text_2nd">
@@ -134,6 +146,9 @@
 <template id="new_page_template_pricing_s_cover" inherit_id="website.new_page_template_pricing_s_cover">
     <xpath expr="//section" position="attributes">
         <attribute name="class" add="o_three_quarter_height" remove="o_full_screen_height" separator=" "/>
+    </xpath>
+    <xpath expr="//div[hasclass('col-lg-12')]" position="attributes">
+        <attribute name="class" add="pt40 pb40" remove="pt88 pb88" separator=" "/>
     </xpath>
 </template>
 

--- a/theme_treehouse/views/snippets/s_cover.xml
+++ b/theme_treehouse/views/snippets/s_cover.xml
@@ -2,9 +2,9 @@
 <odoo>
 
 <template id="s_cover" inherit_id="website.s_cover">
-    <!-- Section -->
-    <xpath expr="section" position="attributes">
-        <attribute name="class" add="pt160 pb160" remove="pt232 pb232" separator=" "/>
+    <!-- Column -->
+    <xpath expr="//div[hasclass('col-lg-12')]" position="attributes">
+        <attribute name="class" add="pt88 pb88" remove="pt160 pb160" separator=" "/>
     </xpath>
     <!-- Title -->
     <xpath expr="//h1" position="before">

--- a/theme_vehicle/views/customizations.xml
+++ b/theme_vehicle/views/customizations.xml
@@ -4,8 +4,11 @@
 <!-- ======== COVER ======== -->
 <template id="s_cover" inherit_id="website.s_cover" name="Vehicle s_cover">
     <xpath expr="section" position="attributes">
-        <attribute name="class" remove="s_parallax_is_fixed o_full_screen_height pt232 pb232" add="o_three_quarter_height pt0 pb0" separator=" "/>
+        <attribute name="class" remove="s_parallax_is_fixed o_full_screen_height pt72 pb72" add="o_three_quarter_height pt0 pb0" separator=" "/>
         <attribute name="data-scroll-background-ratio">1.5</attribute>
+    </xpath>
+    <xpath expr="//div[hasclass('col-lg-12')]" position="attributes">
+        <attribute name="class" remove="pt160 pb160" separator=" "/>
     </xpath>
     <xpath expr="//h1" position="replace">
         <h1 style="text-align: center;">The New KORAN X</h1>

--- a/theme_vehicle/views/new_page_template.xml
+++ b/theme_vehicle/views/new_page_template.xml
@@ -122,7 +122,10 @@
 <template id="new_page_template_landing_0_s_cover" inherit_id="website.new_page_template_landing_0_s_cover">
     <xpath expr="//section" position="attributes">
         <!-- pb256 is defined in both theme and new page template -->
-        <attribute name="class" add="pb80 pt80" remove="pt256 pb256 pt0 pb0" separator=" "/>
+        <attribute name="class" add="pb80 pt80" remove="pt0 pb0" separator=" "/>
+    </xpath>
+    <xpath expr="//div[hasclass('col-lg-12')]" position="attributes">
+        <attribute name="class" remove="pt184 pb184" separator=" "/>
     </xpath>
 </template>
 
@@ -135,6 +138,12 @@
 <template id="new_page_template_landing_2_s_cover" inherit_id="website.new_page_template_landing_2_s_cover">
     <xpath expr="//section" position="attributes">
         <attribute name="class" add="o_full_screen_height" remove="o_three_quarter_height" separator=" "/>
+    </xpath>
+</template>
+
+<template id="new_page_template_landing_4_s_cover" inherit_id="website.new_page_template_landing_4_s_cover">
+    <xpath expr="//div[hasclass('col-lg-12')]" position="attributes">
+        <attribute name="class" remove="pt40 pb40" separator=" "/>
     </xpath>
 </template>
 

--- a/theme_yes/views/new_page_template.xml
+++ b/theme_yes/views/new_page_template.xml
@@ -121,7 +121,7 @@
 <template id="new_page_template_about_mini_s_cover" inherit_id="website.new_page_template_about_mini_s_cover">
     <xpath expr="//section" position="attributes">
         <!-- Defined in both theme and new page template -->
-        <attribute name="class" add="o_three_quarter_height" remove="pt40 pb40 o_three_quarter_height" separator=" "/>
+        <attribute name="class" add="o_three_quarter_height" remove="o_three_quarter_height" separator=" "/>
     </xpath>
 </template>
 
@@ -146,9 +146,8 @@
 </template>
 
 <template id="new_page_template_landing_0_s_cover" inherit_id="website.new_page_template_landing_0_s_cover">
-    <xpath expr="//section" position="attributes">
-        <!-- pb256 is defined by both theme and new page template -->
-        <attribute name="class" add="pb256" remove="pt208 pb256" separator=" "/>
+    <xpath expr="//div[hasclass('col-lg-12')]" position="attributes">
+        <attribute name="class" add="pt64 pb64" remove="pt56 pb104 pt184 pb184" separator=" "/>
     </xpath>
 </template>
 
@@ -196,6 +195,10 @@
     <!-- Shape -->
     <xpath expr="//*[hasclass('container')]" position="before">
         <div class="o_we_shape o_html_builder_Connections_06" style="background-image: url('/html_editor/shape/html_builder/Connections/06.svg?c5=o-color-4');"/>
+    </xpath>
+    <!-- Column -->
+    <xpath expr="//div[hasclass('col-lg-12')]" position="attributes">
+        <attribute name="class" remove="pt40 pb40" separator=" "/>
     </xpath>
 </template>
 

--- a/theme_yes/views/snippets/s_cover.xml
+++ b/theme_yes/views/snippets/s_cover.xml
@@ -4,11 +4,15 @@
 <template id="s_cover" inherit_id="website.s_cover">
     <!-- Section -->
     <xpath expr="//section" position="attributes">
-        <attribute name="class" add="o_three_quarter_height pt208 pb256" remove="pt232 pb232" separator=" "/>
+        <attribute name="class" add="o_three_quarter_height" separator=" "/>
     </xpath>
     <!-- Filter -->
     <xpath expr="//*[hasclass('container')]" position="before">
         <div class="o_we_bg_filter" style="background-color: rgba(25, 41, 37, 0.55) !important;"/>
+    </xpath>
+    <!-- Column -->
+    <xpath expr="//div[hasclass('col-lg-12')]" position="attributes">
+        <attribute name="class" add="pt56 pb104" remove="pt160 pb160" separator=" "/>
     </xpath>
     <!-- Title -->
     <xpath expr="//h1" position="attributes">


### PR DESCRIPTION
*: anelusia, artists, aviato, bewise, buzzy, graphene, loftspace, nano,
   paptic, real_estate, treehouse, vehicle, yes

Following the change in s_cover's base structure (section padding moved
from `pt232/pb232` to `pt72/pb72` + a new column with `pt160/pb160`), the
xpaths in design themes were updated to apply each theme's custom
spacing on the column instead of the section.

The section padding is now consistently set to `pt72/pb72` across all
themes. The remaining spacing is distributed to the column inside as
follows:

- For snippets with the `o_three_quarter_height` class: `3/4th` of the
  original section padding is applied to the column, as the section
  height is constrained and full padding would shrink the content area.
- For all others: `72` is subtracted from the original section padding
  and the remainder is applied to the column.
    
task-[5346415](https://www.odoo.com/odoo/project/974/tasks/5346415)
Community PR: https://github.com/odoo/odoo/pull/242024 