### PR TITLE
[IMP] *: migrate to Material Symbols icon system

### DIFF
--- a/test_themes/tests/test_new_page_templates.py
+++ b/test_themes/tests/test_new_page_templates.py
@@ -66,10 +66,8 @@ CONFLICTUAL_CLASSES_RE = {
     re.compile(r'^(p(x|e)-?\d+|padding-.+)$'): [],
     re.compile(r'^(p(y|t)-?\d+|padding-.+)$'): [],
     re.compile(r'^(p(y|b)?-?\d+|padding-.+)$'): [],
-    # Font awesome
-    re.compile(r'^fa-\dx$'): [],
-    # Whitelist workaround for s_social_media inner snippet Layout: None
-    re.compile(r'^fa-...+'): ['fa-stack'],
+    # Oi icons
+    re.compile(r'^oi-\dx$'): [],
     # Rounded
     re.compile(r'^rounded-.+'): [],
     # Shadow

--- a/theme_anelusia/views/snippets/s_bento_grid.xml
+++ b/theme_anelusia/views/snippets/s_bento_grid.xml
@@ -33,7 +33,7 @@
     </xpath>
     <xpath expr="(//div[hasclass('o_grid_item')])[2]" position="replace" mode="inner">
         <h2 class="h3-fs" style="text-align: center;">
-            <a t-att-href="shop_btn_href" class="o_translate_inline">See all clothing&#160;<span class="fa fa-long-arrow-right"></span></a>
+            <a t-att-href="shop_btn_href" class="o_translate_inline">See all clothing&#160;<span class="oi" data-icon="east"></span></a>
         </h2>
     </xpath>
     <!-- Third item -->

--- a/theme_avantgarde/views/customizations.xml
+++ b/theme_avantgarde/views/customizations.xml
@@ -125,7 +125,7 @@
         The Boston Public Library's exhibit features lovely bird and flower paintings, bringing together nature, art, and science.
     </xpath>
     <xpath expr="//p[hasclass('lead')]" position="after">
-        <a href="#" class="btn btn-secondary btn-lg"><i class="fa fa-ticket"/> Book your tickets</a>
+        <a href="#" class="btn btn-secondary btn-lg"><i class="oi" data-icon="confirmation_number"/> Book your tickets</a>
     </xpath>
     <!-- Feature 1 -->
     <xpath expr="(//img)[1]" position="attributes">

--- a/theme_bookstore/views/snippets/s_banner.xml
+++ b/theme_bookstore/views/snippets/s_banner.xml
@@ -16,7 +16,7 @@
     </xpath>
     <!-- Button -->
     <xpath expr="//a" position="replace" mode="inner">
-        Come Visit Us <i class="fa fa-angle-right"/>
+        Come Visit Us <i class="oi" data-icon="keyboard_arrow_right"/>
     </xpath>
     <!-- Blockquote -->
     <xpath expr="//blockquote/p" position="replace" mode="inner">

--- a/theme_bookstore/views/snippets/s_cta_box.xml
+++ b/theme_bookstore/views/snippets/s_cta_box.xml
@@ -21,7 +21,7 @@
     </xpath>
     <!-- Button -->
     <xpath expr="//a[hasclass('btn')]" position="replace">
-        <a t-att-href="cta_btn_href" class="btn btn-lg btn-secondary">Start Now<i class="fa fa-angle-right ms-2" role="img"/></a>
+        <a t-att-href="cta_btn_href" class="btn btn-lg btn-secondary">Start Now<i class="oi ms-2" data-icon="keyboard_arrow_right" role="img"/></a>
     </xpath>
 </template>
 

--- a/theme_nano/views/snippets/s_discovery.xml
+++ b/theme_nano/views/snippets/s_discovery.xml
@@ -11,7 +11,7 @@
         <attribute name="class" add="o_cc5" remove="o_cc1" separator=" "/>
     </xpath>
     <xpath expr="//span[hasclass('s_cta_badge')]" position="replace" mode="inner">
-        <i class="fa fa-circle text-success" aria-hidden="true"/> AVAILABLE FOR NEW PROJECTS&#160;<a href="#">Contact us&#160;<i class="fa fa-long-arrow-right" aria-hidden="true"/></a>
+        <i class="oi oi-filled text-success" data-icon="circle" aria-hidden="true"/> AVAILABLE FOR NEW PROJECTS&#160;<a href="#">Contact us&#160;<i class="oi" data-icon="east" aria-hidden="true"/></a>
     </xpath>
     <xpath expr="//h1" position="replace">
         <h1 style="text-align: center">

--- a/theme_odoo_experts/views/snippets/s_showcase.xml
+++ b/theme_odoo_experts/views/snippets/s_showcase.xml
@@ -16,7 +16,7 @@
 
     <xpath expr="(//div[hasclass('col-12')])[2]" position="replace">
         <div class="col-12 pt8 pb8" data-name="Feature">
-            <i class="s_showcase_icon fa fa-check me-auto rounded-circle float-start bg-o-color-3" role="img"/>
+            <i class="s_showcase_icon oi me-auto rounded-circle float-start bg-o-color-3" data-icon="check" role="img"/>
             <div class="d-flex flex-column">
                 <h3 class="s_showcase_title h5-fs">Strategic Planning</h3>
                 <p>Aligning your business objectives with forward-thinking strategies for long-term success.</p>
@@ -25,7 +25,7 @@
     </xpath>
     <xpath expr="(//div[hasclass('col-12')])[3]" position="replace">
         <div class="col-12 pt8 pb8" data-name="Feature">
-            <i class="s_showcase_icon fa fa-check me-auto rounded-circle float-start bg-o-color-3" role="img"/>
+            <i class="s_showcase_icon oi me-auto rounded-circle float-start bg-o-color-3" data-icon="check" role="img"/>
             <div class="d-flex flex-column">
                 <h3 class="s_showcase_title h5-fs">Financial Consulting</h3>
                 <p>Providing expert guidance to optimize your financial resources and maximize profitability.</p>
@@ -34,7 +34,7 @@
     </xpath>
     <xpath expr="(//div[hasclass('col-12')])[4]" position="replace">
         <div class="col-12 pt8 pb8" data-name="Feature">
-            <i class="s_showcase_icon fa fa-check me-auto rounded-circle float-start bg-o-color-3" role="img"/>
+            <i class="s_showcase_icon oi me-auto rounded-circle float-start bg-o-color-3" data-icon="check" role="img"/>
             <div class="d-flex flex-column">
                 <h3 class="s_showcase_title h5-fs">Market Analysis</h3>
                 <p>Delivering in-depth insights and market trends to keep you ahead of the competition.</p>

--- a/theme_test_custo/data/menu.xml
+++ b/theme_test_custo/data/menu.xml
@@ -37,19 +37,19 @@
             <div class="container">
                 <div class="row">
                     <div class="col-lg-3">
-                        <i class="fa fa-cube"/>
+                        <i class="oi" data-icon="deployed_code"/>
                         <p>Text</p>
                     </div>
                     <div class="col-lg-3">
-                        <i class="fa fa-cube"/>
+                        <i class="oi" data-icon="deployed_code"/>
                         <p>Text</p>
                     </div>
                     <div class="col-lg-3">
-                        <i class="fa fa-cube"/>
+                        <i class="oi" data-icon="deployed_code"/>
                         <p>Text</p>
                     </div>
                     <div class="col-lg-3">
-                        <i class="fa fa-cube"/>
+                        <i class="oi" data-icon="deployed_code"/>
                         <p>Text</p>
                     </div>
                 </div>

--- a/theme_test_custo/static/tests/tours/theme_menu_hierarchies.js
+++ b/theme_test_custo/static/tests/tours/theme_menu_hierarchies.js
@@ -10,7 +10,7 @@ wTourUtils.registerWebsitePreviewTour('theme_menu_hierarchies', {
         run: "click",
     }, {
         content: 'Check Mega Menu content',
-        trigger: ":iframe .top_menu div.o_mega_menu.show .fa-cube",
+        trigger: ":iframe .top_menu div.o_mega_menu.show [data-icon='deployed_code']",
     }, {
         content: 'Check new top level menu is correctly created',
         trigger: ':iframe .top_menu .nav-item.dropdown .dropdown-toggle:contains("Example 1")',

--- a/theme_treehouse/views/snippets/s_references.xml
+++ b/theme_treehouse/views/snippets/s_references.xml
@@ -8,7 +8,7 @@
     </xpath>
     <!-- Link -->
     <xpath expr="//a" position="replace" mode="inner">
-        More details <i class="fa fa-long-arrow-right ms-2"/>
+        More details <i class="oi ms-2" data-icon="east"/>
     </xpath>
 </template>
 

--- a/theme_yes/views/snippets/s_features.xml
+++ b/theme_yes/views/snippets/s_features.xml
@@ -12,7 +12,7 @@
     <!-- Column #01 -->
     <xpath expr="//div[hasclass('row')]/div[1]/div[hasclass('s_hr')]" position="replace"/>
     <xpath expr="//div[hasclass('row')]/div[1]/i" position="replace">
-        <i class="s_features_icon fa fa-map-o mb-3 fa-2x mx-auto d-block" role="img"/>
+        <i class="s_features_icon oi oi-2x mb-3 mx-auto d-block" data-icon="map" role="img"/>
     </xpath>
     <xpath expr="//div[hasclass('row')]/div[1]/div/h3" position="replace">
         <h3 style="text-align: center;"><span class="h5-fs">Dream venues</span></h3>
@@ -23,7 +23,7 @@
     <!-- Column #02 -->
     <xpath expr="//div[hasclass('row')]/div[2]/div[hasclass('s_hr')]" position="replace"/>
     <xpath expr="//div[hasclass('row')]/div[2]/i" position="replace">
-        <i class="s_features_icon fa fa-file-text-o mb-3 fa-2x mx-auto d-block" role="img"/>
+        <i class="s_features_icon oi oi-2x mb-3 mx-auto d-block" data-icon="article" role="img"/>
     </xpath>
     <xpath expr="//div[hasclass('row')]/div[2]/div/h3" position="replace">
         <h3 style="text-align: center;"><span class="h5-fs">Curating the finest menu</span></h3>
@@ -34,7 +34,7 @@
     <!-- Column #03 -->
     <xpath expr="//div[hasclass('row')]/div[3]/div[hasclass('s_hr')]" position="replace"/>
     <xpath expr="//div[hasclass('row')]/div[3]/i" position="replace">
-        <i class="s_features_icon fa fa-diamond mb-3 fa-2x mx-auto d-block" role="img"/>
+        <i class="s_features_icon oi oi-2x mb-3 mx-auto d-block" data-icon="diamond" role="img"/>
     </xpath>
     <xpath expr="//div[hasclass('row')]/div[3]/div/h3" position="replace">
         <h3 style="text-align: center;"><span class="h5-fs">Capturing the moment</span></h3>

--- a/theme_zap/views/snippets/s_discovery.xml
+++ b/theme_zap/views/snippets/s_discovery.xml
@@ -15,7 +15,7 @@
     </xpath>
     <!-- CTA -->
     <xpath expr="//span[hasclass('s_cta_badge')]" position="replace" mode="inner">
-        <i class="fa fa-circle text-success" role="presentation"/> We're hiring now!&#160;<a href="#">See more&#160;<i class="fa fa-long-arrow-right" role="presentation"/></a>
+        <i class="oi oi-filled text-success" data-icon="circle" role="presentation"/> We're hiring now!&#160;<a href="#">See more&#160;<i class="oi" data-icon="east" role="presentation"/></a>
     </xpath>
     <xpath expr="//span[hasclass('s_cta_badge')]" position="attributes">
         <attribute name="class" remove="border" separator=" "/>


### PR DESCRIPTION
##  Apply new icon implementation globally
This PR applies the new icon implementation across the entire codebase, replacing almost all legacy icon usages.

Previous patterns such as `class="oi oi-fw oi-arrow-left"` or `class="fa fa-fw fa-arrow-left"` are migrated to the new format using `class="oi oi-fw"` with the data-icon attribute (e.g., `data-icon="west"`), ensuring consistency with the Material Symbols-based system.

Requires:
- https://github.com/odoo/odoo/pull/256840
- https://github.com/odoo/enterprise/pull/112607
- https://github.com/odoo/documentation/pull/17278
- https://github.com/odoo/upgrade/pull/10081