### PR TITLE
[IMP] theme_anelusia: adapt to new img indicators for gallery

### DIFF
--- a/theme_anelusia/views/snippets/s_image_gallery.xml
+++ b/theme_anelusia/views/snippets/s_image_gallery.xml
@@ -18,8 +18,8 @@
         <attribute name="class" add="s_image_gallery_indicators_hidden pt64 pb64" remove="s_image_gallery_indicators_dots s_image_gallery_controllers_outside s_image_gallery_controllers_outside_arrows_right pt24 pb24" separator=" "/>
     </xpath>
     <!-- Item #2 - Indicator -->
-    <xpath expr="//div[hasclass('carousel-indicators')]//button[3]" position="attributes">
-        <attribute name="style">background-image: url(/web/image/website.library_image_16)</attribute>
+    <xpath expr="//div[hasclass('carousel-indicators')]//button[2]//img" position="attributes">
+        <attribute name="src">/web/image/website.library_image_16</attribute>
     </xpath>
 </template>
 


### PR DESCRIPTION
Now, the gallery indicators are `img` tags instead of using background images. This is done to allow the translation of the indicator images.

task-3626918