### PR TITLE
[FIX] theme_graphene, *: fix background customizations

### DIFF
--- a/theme_graphene/views/customizations.xml
+++ b/theme_graphene/views/customizations.xml
@@ -4,7 +4,7 @@
 <!-- ======== COVER ======== -->
 <template id="s_cover" inherit_id="website.s_cover" name="Graphene s_cover">
     <xpath expr="//section" position="attributes">
-        <attribute name="class" add="pt160 pb192" remove="pt232 pb232 s_parallax_is_fixed s_parallax" separator=" "/>
+        <attribute name="class" add="oe_img_bg pt160 pb192" remove="pt232 pb232 s_parallax_is_fixed s_parallax" separator=" "/>
         <attribute name="data-scroll-background-ratio">0</attribute>
         <attribute name="style">background-image: url('/web/image/website.s_cover_default_image');</attribute>
     </xpath>

--- a/theme_nano/views/snippets/s_cover.xml
+++ b/theme_nano/views/snippets/s_cover.xml
@@ -4,7 +4,7 @@
 <template id="s_cover" inherit_id="website.s_cover">
     <!-- Section -->
     <xpath expr="//section" position="attributes">
-        <attribute name="class" add="pt200 pb200" remove="parallax s_parallax_is_fixed bg-black-50 pt232 pb232" separator=" "/>
+        <attribute name="class" add="oe_img_bg pt200 pb200" remove="parallax s_parallax_is_fixed bg-black-50 pt232 pb232" separator=" "/>
         <attribute name="data-scroll-background-ratio">0</attribute>
         <attribute name="style">background-image: url('/web/image/website.s_cover_default_image'); background-position: 50% 0;</attribute>
     </xpath>


### PR DESCRIPTION
*: theme_nano

Steps to reproduce:

- Install the "Graphene" theme through the configurator.
- Once on the homepage, you can see that the "Cover" snippet does not have the "oe_img_bg" class on its section. Because of this, its background image repeats.

This commit fixes this case, and a similar one in the "Nano" theme, by adding the "oe_img_bg" class where those snippets are modified with XPath.