### PR TITLE
[IMP] theme_*: refine theme desc for AI-based theme selection

### DIFF
--- a/theme_anelusia/__manifest__.py
+++ b/theme_anelusia/__manifest__.py
@@ -1,6 +1,6 @@
 {
     'name': 'Anelusia Theme',
-    'description': 'Anelusia Fashion Theme',
+    'description': 'Shaped-container splash hero with a hamburger nav leads into a scrolling announcement strip and a fashion-category bento grid, then an e-commerce category showcase, a reviews wall, and a CTA. Image-forward and e-commerce-driven / suited for fashion, sportswear, footwear, and lifestyle retail brands',
     'category': 'Theme/Retail',
     'summary': 'Diversity, Fashions, Trends, Clothes, Shoes, Sports, Fitness, Stores',
     'sequence': 180,

--- a/theme_artists/__manifest__.py
+++ b/theme_artists/__manifest__.py
@@ -1,6 +1,6 @@
 {
     'name': 'Artists Theme',
-    'description': 'Artists Theme - Art Galleries, Photography, Painting',
+    'description': 'Vertical sidebar navigation flanks an asymmetric side-grid layout, building toward image walls and gallery-style catalogs through framed and shape-cropped artwork. Image-forward with sparse copy / suited for art galleries, photographers, painters, and creative shows',
     'category': 'Theme/Creative',
     'summary': 'Artist, Arts, Galleries, Creative, Paintings, Photography, Shows, Stores',
     'sequence': 310,

--- a/theme_avantgarde/__manifest__.py
+++ b/theme_avantgarde/__manifest__.py
@@ -1,6 +1,6 @@
 {
     'name': 'Avantgarde Theme',
-    'description': 'Avantgarde is a sophisticated theme to inspire and impress',
+    'description': 'Editorial side-grid layout under a hamburger nav, flowing into a dense features wall, carousel showcase, and chronological timeline before a quadrant block. Feature-heavy with editorial pacing rather than long-form passages / suited for design studios, art and culture magazines, creative agencies, and trend-driven blogs',
     'category': 'Theme/Creative',
     'summary': 'Design, Fine Art, Artwork, Creative, Creativity, Galleries, Trends, Shows, Magazines, Blogs',
     'sequence': 150,

--- a/theme_aviato/__manifest__.py
+++ b/theme_aviato/__manifest__.py
@@ -1,6 +1,6 @@
 {
     'name': 'Aviato Theme',
-    'description': 'Aviato Theme - Responsive Bootstrap Theme for Odoo CMS',
+    'description': 'Banner-led layout alternating text-and-image rows with a featured picture block, masonry gallery, team and testimonials, with connection line motifs accenting the banner. Narrative and image-forward / suited for travel agencies, tour operators, excursion booking, and destination marketing sites',
     'category': 'Theme/Creative',
     'summary': 'Travel, Excursion, Plane, Tour, Agency ',
     'sequence': 130,

--- a/theme_beauty/__manifest__.py
+++ b/theme_beauty/__manifest__.py
@@ -1,6 +1,6 @@
 {
     'name': 'Beauty Theme',
-    'description': 'Beauty Theme - Cosmetics, Beauty, Make Up, Hairdresser',
+    'description': 'Hero opens onto a mosaic masonry gallery, boxed price lists, and a features wall closing on a strong call-to-action, with circular image crops, bold geometric shapes, and grid-pattern accents throughout. Balances product browsing with explicit pricing and CTA-focused conversion / suited for cosmetics shops, makeup brands, hair salons, and personal-care services',
     'category': 'Theme/Retail',
     'summary': 'Beauty, Health, Care, Make Up, Cosmetics, Hair Dressers, Stores',
     'sequence': 170,

--- a/theme_bewise/__manifest__.py
+++ b/theme_bewise/__manifest__.py
@@ -1,6 +1,6 @@
 {
     'name': 'Be Wise Theme',
-    'description': 'Be Wise Theme',
+    'description': 'Centered striped hero leads into color-blocked information, a collapsible FAQ, and shape-cropped team cards, with bold geometric shape motifs accenting the team block. Information-driven / suited for universities, schools, kids education programs, and learning platforms',
     'category': 'Theme/Education',
     'summary': 'University, Education, Schools, Young, Play, Kids',
     'sequence': 240,

--- a/theme_bistro/__manifest__.py
+++ b/theme_bistro/__manifest__.py
@@ -1,6 +1,6 @@
 {
     'name': 'Bistro Theme',
-    'description': 'Bistro Theme - Restaurant, Food/Drink, Catering, Food trucks',
+    'description': 'Vertical sidebar navigation paired with an image-titled hero, key visuals, a cafe-style price list, and a testimonial carousel framed by a quadrant block, with bold geometric shapes accenting the testimonials. Menu-and-pricing forward with little long-form copy / suited for bistros, restaurants, bars, pubs, cafes, and catering services',
     'category': 'Theme/Food',
     'summary': 'Bistro, Restaurant, Bar, Pub, Cafe, Food, Catering',
     'sequence': 220,

--- a/theme_bookstore/__manifest__.py
+++ b/theme_bookstore/__manifest__.py
@@ -1,6 +1,6 @@
 {
     'name': 'Bookstore Theme',
-    'description': 'Books, Magazines, Music',
+    'description': 'Search-led header above a banner hero, curated key images, a title block, and accordion-with-image collapsible chapters, with heavily-rounded containers, circular image accents, and connection line motifs throughout. Catalog-discovery driven, balancing image presentation with browseable text / suited for bookstores, libraries, magazine archives, and music or media retailers',
     'category': 'Theme/Retail',
     'summary': 'Library, Books, Magazines, Literature, Musics, Media, Store',
     'sequence': 250,

--- a/theme_buzzy/__manifest__.py
+++ b/theme_buzzy/__manifest__.py
@@ -1,6 +1,6 @@
 {
     'name': 'Buzzy Theme',
-    'description': 'Buzzy Theme - Responsive Bootstrap Theme for Odoo CMS',
+    'description': 'Illustrative banner opens onto a discovery exploration block, product showcase, key-benefit grids, and accordion-with-image FAQ, with shaped containers and organic blob motifs throughout and recurring scribble-and-marker highlights on key heading words. Content-heavy and benefit-driven, leaning illustrative rather than photo-led / suited for corporate services, technology companies, and SaaS-style product marketing sites',
     'category': 'Theme/Corporate',
     'summary': 'Corporate, Services, Technology, Shapes, Illustrations',
     'sequence': 140,

--- a/theme_clean/__manifest__.py
+++ b/theme_clean/__manifest__.py
@@ -1,6 +1,6 @@
 {
     'name': 'Clean Theme',
-    'description': 'Clean Theme',
+    'description': 'Vertically-rhythmic layout pairing a banner with a color-blocked section, alternating text-and-image rows, a numbers showcase, basic team block, and accordion FAQ with patterned and line image-shape crops (sketched oval ring, dot pattern, labyrinth) carrying the visual signature across the hero and content rows. Text-driven and information-dense with generous whitespace / suited for legal practices, business consultancies, technology companies, and professional services',
     'category': 'Theme/Services',
     'summary': 'Legal, Corporate, Business, Tech, Services',
     'sequence': 120,

--- a/theme_cobalt/__manifest__.py
+++ b/theme_cobalt/__manifest__.py
@@ -1,6 +1,6 @@
 {
     'name': 'Cobalt Theme',
-    'description': 'Clean and sharp design.',
+    'description': 'Banner hero leads into alternating image-text rows, key visuals, detailed team profiles, and a references grid for client logos, with connection line motifs woven across the sections. Communicates credibility through structure and showcased work / suited for IT and software development studios, design agencies, and technology consultancies',
     'category': 'Theme/Corporate',
     'summary': 'Development, IT development, Design, Tech, Computers, IT, Blogs',
     'sequence': 110,

--- a/theme_enark/__manifest__.py
+++ b/theme_enark/__manifest__.py
@@ -1,6 +1,6 @@
 {
     'name': 'Enark Theme',
-    'description': 'Enark Theme',
+    'description': 'Free-grid hero opens an asymmetric, portfolio-like layout flowing into a features wall, numbered KPIs, and a full image wall before referenced work, with airy floating and connection motifs accenting the early sections. Balances structured authority with image-led project showcase / suited for architecture firms, finance and corporate practices, and high-trust business services',
     'category': 'Theme/Corporate',
     'summary': 'Architect, Corporate, Business, Finance, Services',
     'sequence': 190,

--- a/theme_graphene/__manifest__.py
+++ b/theme_graphene/__manifest__.py
@@ -1,6 +1,6 @@
 {
     'name': 'Graphene Theme',
-    'description': 'Light colours, thin text, clean and sharp design.',
+    'description': 'Cover hero opens onto alternating text-and-image rows, a numbers grid, mockup showcase, and side-by-side comparisons before client references, accented by connection, bold geometric, and rain-line motifs. Mockup-and-stats forward with credibility cues / suited for technology companies, robotics, IT services, and product-led corporate sites',
     'category': 'Theme/Corporate',
     'summary': 'Service, Corporate, Design, Technology, Robotics, Computers, IT, Blogs',
     'sequence': 110,

--- a/theme_kea/__manifest__.py
+++ b/theme_kea/__manifest__.py
@@ -1,6 +1,6 @@
 {
     'name': 'Kea Theme',
-    'description': 'Kea Theme',
+    'description': 'Cover hero feeds into alternating text-and-image rows, a featured picture, color-blocked information, and a media list — with organic blob crops on the picture and media images as the visual signature, layered over wavy line and floating shape motifs. Image-and-narrative driven / suited for technology companies, IT services, computer stores, and virtual-reality product sites',
     'category': 'Theme/Technology',
     'summary': 'Technology, Tech, IT, Computers, Stores, Virtual Reality',
     'sequence': 200,

--- a/theme_kiddo/__manifest__.py
+++ b/theme_kiddo/__manifest__.py
@@ -1,6 +1,6 @@
 {
     'name': 'Kiddo Theme',
-    'description': 'Kiddo theme for Odoo Website',
+    'description': 'Banner hero opens onto an activities text-image section and three service-pillar columns with mixed image-shape crops (solid blob, organic-outlined frame, rounded-square), then a services icon grid and a CTA, with floating and connection line motifs across the content rows. Warm and service-storytelling driven / suited for nurseries, childcare centers, kids activity programs, and family-oriented education services',
     'category': 'Theme/Retail',
     'summary': 'Nursery, Toys, Games, Kids, Boys, Girls, Stores',
     'sequence': 290,

--- a/theme_loftspace/__manifest__.py
+++ b/theme_loftspace/__manifest__.py
@@ -1,6 +1,6 @@
 {
     'name': 'Loftspace Theme',
-    'description': 'Loftspace Fashion Theme',
+    'description': 'Search-led header above a banner hero flows into striped intro sections, an e-commerce category showcase, a reviews wall, and a collapsible FAQ before a CTA, kept clean and photo-driven without background shape decoration. Catalog-discovery driven with social proof / suited for furniture retail, home goods stores, and lifestyle e-commerce',
     'category': 'Theme/Retail',
     'summary': 'Furniture, Toys, Games, Kids, Boys, Girls, Stores',
     'sequence': 130,

--- a/theme_monglia/__manifest__.py
+++ b/theme_monglia/__manifest__.py
@@ -1,6 +1,6 @@
 {
     'name': 'Monglia Theme',
-    'description': 'Monglia Catering Theme',
+    'description': 'Cover hero leads into a numbers grid, a diamond-cropped team block with highlighted artist names, a freegrid showcase, image wall, and collapsible FAQ before client references, with bold geometric shape motifs accenting key sections. Event-and-showcase driven with photos and credentials cues / suited for catering services, restaurants, bars, concert venues, and event organizers',
     'category': 'Theme/Services',
     'summary': 'Event, Restaurants, Bars, Pubs, Cafes, Catering, Food, Drinks, Concerts, Shows, Musics, Dance, Party',
     'sequence': 260,

--- a/theme_nano/__manifest__.py
+++ b/theme_nano/__manifest__.py
@@ -1,6 +1,6 @@
 {
     'name': 'Nano Theme',
-    'description': 'Nano Theme - Responsive Bootstrap Theme for Odoo CMS',
+    'description': 'Discovery block opens onto a parallax scene, text-driven sections, key visuals, an image-text-overlap layout, and a basic team grid before references and KPIs, kept photo-driven with restrained styling. Story-led and image-forward / suited for creative agencies, makers, design studios, and creative-IT services',
     'category': 'Theme/Lifestyle',
     'summary': 'Maker, Agencies, Creative, Design, IT, Services, Fancy',
     'sequence': 270,

--- a/theme_notes/__manifest__.py
+++ b/theme_notes/__manifest__.py
@@ -1,6 +1,6 @@
 {
     'name': 'Notes & Play Theme',
-    'description': 'Notes & Play Theme',
+    'description': 'Intro opens onto image-and-text storytelling, a three-column rhythm, a full image wall, and a shape-cropped team block before a strong call-to-action, with recurring underline highlights running across every section heading. Image-forward and event-driven / suited for bands, music labels, concert venues, record stores, and artist showcases',
     'category': 'Theme/Retail',
     'summary': 'Band, Musics, Sound, Concerts, Artists, Records, Event, Food, Stores',
     'sequence': 280,

--- a/theme_odoo_experts/__manifest__.py
+++ b/theme_odoo_experts/__manifest__.py
@@ -1,6 +1,6 @@
 {
     'name': 'Experts Theme',
-    'description': 'Experts Business Theme',
+    'description': 'Mockup hero leads into client references, alternating image-and-text proof rows, a feature showcase, and a collapsible FAQ before a CTA with device-mockup framing (phone, browser, tablet, laptop) running across the proof rows and underline highlights on key headings, accented by connection line motifs at the closing block. Credentials-and-proof driven / suited for business advisors, corporate consultancies, finance services, and IT advisory firms',
     'category': 'Theme/Corporate',
     'summary': 'Advisor, Corporate, Service, Business, Finance, IT',
     'sequence': 210,

--- a/theme_orchid/__manifest__.py
+++ b/theme_orchid/__manifest__.py
@@ -1,6 +1,6 @@
 {
     'name': 'Orchid Theme',
-    'description': 'Orchid Theme - Flowers, Beauty',
+    'description': 'Sales-led header above a kickoff hero opens onto key visuals, a process-steps narrative, a freegrid showcase, an image-text-overlap layout, and a basic team block before an image wall and references, accented by a varied vocabulary of connection, organic blob, and bold geometric motifs. Process-and-image driven / suited for florists, garden centers, beauty boutiques, and nature-led retail',
     'category': 'Theme/Retail',
     'summary': 'Florist, Gardens, Flowers, Nature, Green, Beauty, Stores',
     'sequence': 230,

--- a/theme_paptic/__manifest__.py
+++ b/theme_paptic/__manifest__.py
@@ -1,6 +1,6 @@
 {
     'name': 'Paptic Theme',
-    'description': 'Clean and sharp design.',
+    'description': 'Split cover hero leads into client references, alternating illustration-based proof rows, a two-panel masonry block, and a collapsible FAQ before an illustrated CTA, with custom line art illustrations as the primary visual throughout. Credentials-forward and illustration-driven / suited for consultancies, design studios, technology firms, and IT or blog-driven corporate sites',
     'category': 'Theme/Corporate',
     'summary': 'Consultancy, Design, Tech, Computers, IT, Blogs',
     'sequence': 110,

--- a/theme_real_estate/__manifest__.py
+++ b/theme_real_estate/__manifest__.py
@@ -1,6 +1,6 @@
 {
     'name': 'Real Estate Theme',
-    'description': 'Real Estate Theme - Houses, Appartments, Real Estate Agencies',
+    'description': 'Cover hero leads into stepped duo-panel text-and-image rows, a three-column listing layout, references, a numbers showcase, and a testimonial carousel before a call-to-action, with restrained airy floating motifs marking the title block. Listing-and-trust driven / suited for real estate agencies, construction services, vacation rentals, and accommodation listings',
     'category': 'Theme/Services',
     'summary': 'Real Estate, Agencies, Construction, Services, Accomodations, Lodging, Hosting, Houses, Appartments, Vacations, Holidays, Travels',
     'sequence': 320,

--- a/theme_treehouse/__manifest__.py
+++ b/theme_treehouse/__manifest__.py
@@ -1,6 +1,6 @@
 {
     'name': 'Treehouse Theme',
-    'description': 'Treehouse Theme - Responsive Bootstrap Theme for Odoo CMS',
+    'description': 'Asymmetric side-grid layout opens with numbered impact stats, color-blocked sections, partner references, and a freegrid showcase, with wavy line motifs accenting the side-grid hero. Image-led with stats and partner proof / suited for environmental NGOs, sustainable development non-profits, ecology initiatives, and conscious travel organizations',
     'category': 'Theme/Environment',
     'summary': 'Environment, Nature, Ecology, Sustainable Development, Non Profit, NGO, Travels',
     'sequence': 140,

--- a/theme_vehicle/__manifest__.py
+++ b/theme_vehicle/__manifest__.py
@@ -1,6 +1,6 @@
 {
     'name': 'Vehicle Theme',
-    'description': 'Vehicle Theme - Cars, Motorbikes, Bikes, Tires',
+    'description': 'Cover hero opens onto a title block, a three-column lineup, a featured picture, key visuals, charted KPIs, and a media list, kept clean and photo-driven throughout. Image-and-stats forward with technical credibility - suited for car dealerships, motorbike retailers, tire shops, mechanics, and vehicle repair services',
     'category': 'Theme/Services',
     'summary': 'Vehicle, Cars, Motorbikes, Bikes, Tires, Transports, Repair, Mechanics, Garages, Sports, Services',
     'sequence': 300,

--- a/theme_yes/__manifest__.py
+++ b/theme_yes/__manifest__.py
@@ -1,6 +1,6 @@
 {
     'name': 'Yes Theme',
-    'description': 'Yes Theme - Wedding',
+    'description': 'Kickoff hero leads into a title block, a featured team, an image-text-overlap layout, a feature highlight, and a freegrid before a testimonial carousel and call-to-action, accented by connection and floating motifs. Image-forward and emotion-driven / suited for wedding planners, love-themed services, photographers, and personal celebration sites',
     'category': 'Theme/Personal',
     'summary': 'Wedding, Love, Photography, Services',
     'sequence': 330,

--- a/theme_zap/__manifest__.py
+++ b/theme_zap/__manifest__.py
@@ -1,6 +1,6 @@
 {
     'name': 'Zap Theme',
-    'description': 'Zap Theme - Corporate, Business, Marketing, Copywriting',
+    'description': 'Sales-led header above a discovery exploration block flows into key visuals, striped sections, a feature showcase, an image-titled hero, and charted KPIs before a CTA card, with bold geometric shape motifs woven across the major sections. Pitch-forward / suited for digital marketing agencies, copywriting services, media companies, and event-driven corporate sites',
     'category': 'Theme/Corporate',
     'summary': 'Digital, Marketing, Copywriting, Media, Events, Non Profit, NGO, Corporate, Business, Services',
     'sequence': 160,


### PR DESCRIPTION
Before this commit, all themes descriptions were generic taglines with no structural content.

After this commit, to support coming AI-based theme selection, each description now encodes the homepage layout, visual signatures, and potential recommended industries.

task-6186549