### PR TITLE
[FIX] theme_*: add missing color attributes to shapes

### DIFF
--- a/theme_graphene/views/customizations.xml
+++ b/theme_graphene/views/customizations.xml
@@ -58,8 +58,9 @@
         </div>
     </xpath>
     <xpath expr="//img" position="attributes">
-        <attribute name="src">/web_editor/image_shape/website.s_image_text_device_perspective/web_editor/devices/iphone_3d_portrait_02.svg</attribute>
+        <attribute name="src">/web_editor/image_shape/website.s_image_text_device_perspective/web_editor/devices/iphone_3d_portrait_02.svg?c5=o-color-5</attribute>
         <attribute name="data-shape">web_editor/devices/iphone_3d_portrait_02</attribute>
+        <attribute name="data-shape-colors">;;;;o-color-5</attribute>
     </xpath>
     <xpath expr="//p[1]" position="replace" mode="inner">
         Users are looking to consume engaging content.<br/>We empowers our teams to create the most relevant content.

--- a/theme_kea/views/snippets/s_image_hexagonal.xml
+++ b/theme_kea/views/snippets/s_image_hexagonal.xml
@@ -4,8 +4,9 @@
 <template id="s_image_hexagonal" inherit_id="website.s_image_hexagonal">
     <!-- Images -->
     <xpath expr="//img" position="attributes">
-        <attribute name="src">/web_editor/image_shape/website.s_media_list_default_image_1/web_editor/composition/composition_mixed_1.svg</attribute>
+        <attribute name="src">/web_editor/image_shape/website.s_media_list_default_image_1/web_editor/composition/composition_mixed_1.svg?c1=o-color-1&amp;c2=o-color-3&amp;c5=o-color-5</attribute>
         <attribute name="data-shape">web_editor/composition/composition_mixed_1</attribute>
+        <attribute name="data-shape-colors">o-color-1;o-color-3;;;o-color-5</attribute>
     </xpath>
     <xpath expr="(//img)[2]" position="attributes">
         <attribute name="src">/web/image/website.s_carousel_default_image_1</attribute>

--- a/theme_kiddo/views/snippets/s_image_hexagonal.xml
+++ b/theme_kiddo/views/snippets/s_image_hexagonal.xml
@@ -13,8 +13,9 @@
     </xpath>
     <!-- Images -->
     <xpath expr="//img" position="attributes">
-        <attribute name="src">/web_editor/image_shape/website.library_image_05/web_editor/composition/composition_mixed_1.svg</attribute>
+        <attribute name="src">/web_editor/image_shape/website.library_image_05/web_editor/composition/composition_mixed_1.svg?c1=o-color-1&amp;c2=o-color-3&amp;c5=o-color-5</attribute>
         <attribute name="data-shape">web_editor/composition/composition_mixed_1</attribute>
+        <attribute name="data-shape-colors">o-color-1;o-color-3;;;o-color-5</attribute>
     </xpath>
     <xpath expr="(//img)[2]" position="attributes">
         <attribute name="src">/web/image/website.s_cover_default_image</attribute>

--- a/theme_nano/views/snippets/s_image_text.xml
+++ b/theme_nano/views/snippets/s_image_text.xml
@@ -11,10 +11,10 @@
     </xpath>
     <!-- Image + Shape -->
     <xpath expr="//img" position="attributes">
-        <attribute name="src">/web_editor/image_shape/website.s_image_text_default_image/web_editor/composition/composition_planet_2.svg</attribute>
+        <attribute name="src">/web_editor/image_shape/website.s_image_text_default_image/web_editor/composition/composition_planet_2.svg?c1=o-color-1&amp;c2=o-color-3&amp;c5=o-color-5</attribute>
         <attribute name="data-file-name">s_image_text.svg</attribute>
         <attribute name="data-shape">web_editor/composition/composition_planet_2</attribute>
-        <attribute name="data-shape-colors">;;;;</attribute>
+        <attribute name="data-shape-colors">o-color-1;o-color-3;;;o-color-5</attribute>
     </xpath>
     <!-- Column #02 -->
     <xpath expr="//*[hasclass('row')]/*[2]" position="attributes">

--- a/theme_nano/views/snippets/s_text_image.xml
+++ b/theme_nano/views/snippets/s_text_image.xml
@@ -11,10 +11,10 @@
     </xpath>
     <!-- Image + Shape -->
     <xpath expr="//img" position="attributes">
-        <attribute name="src">/web_editor/image_shape/website.s_text_image_default_image/web_editor/pattern/pattern_point.svg</attribute>
+        <attribute name="src">/web_editor/image_shape/website.s_text_image_default_image/web_editor/pattern/pattern_point.svg?c1=o-color-1</attribute>
             <attribute name="data-file-name">s_text_image.svg</attribute>
         <attribute name="data-shape">web_editor/pattern/pattern_point</attribute>
-        <attribute name="data-shape-colors">;;;;</attribute>
+        <attribute name="data-shape-colors">o-color-1;;;;</attribute>
     </xpath>
 </template>
 

--- a/theme_odoo_experts/views/snippets/s_image_text.xml
+++ b/theme_odoo_experts/views/snippets/s_image_text.xml
@@ -25,11 +25,12 @@
 
     <!-- Image -->
     <xpath expr="//img" position="attributes">
-        <attribute name="src">/web_editor/image_shape/website.s_image_text_default_image/web_editor/devices/browser_03.svg?</attribute>
+        <attribute name="src">/web_editor/image_shape/website.s_image_text_default_image/web_editor/devices/browser_03.svg?c5=o-color-5</attribute>
         <attribute name="data-shape">web_editor/devices/browser_03</attribute>
         <attribute name="data-original-mimetype">image/jpg</attribute>
         <attribute name="data-file-name">s_image_text.svg</attribute>
         <attribute name="class" add="shadow" separator=" "/>
+        <attribute name="data-shape-colors">;;;;o-color-5</attribute>
     </xpath>
 </template>
 

--- a/theme_odoo_experts/views/snippets/s_showcase.xml
+++ b/theme_odoo_experts/views/snippets/s_showcase.xml
@@ -44,11 +44,12 @@
 
     <!-- Image -->
     <xpath expr="//img" position="attributes">
-        <attribute name="src">/web_editor/image_shape/website.s_showcase_default_image/web_editor/devices/macbook_front.svg?</attribute>
+        <attribute name="src">/web_editor/image_shape/website.s_showcase_default_image/web_editor/devices/macbook_front.svg?c3=o-color-2</attribute>
         <attribute name="data-shape">web_editor/devices/macbook_front</attribute>
         <attribute name="data-original-mimetype">image/jpg</attribute>
         <attribute name="data-file-name">s_showcase_default_image.svg</attribute>
         <attribute name="class" remove="rounded" separator=" "/>
+        <attribute name="data-shape-colors">;;o-color-2;;</attribute>
     </xpath>
 
     <xpath expr="(//div[hasclass('col-lg-6')])[2]" position="attributes">

--- a/theme_odoo_experts/views/snippets/s_text_image.xml
+++ b/theme_odoo_experts/views/snippets/s_text_image.xml
@@ -25,11 +25,12 @@
 
     <!-- Image -->
     <xpath expr="//img" position="attributes">
-        <attribute name="src">/web_editor/image_shape/website.s_text_image_default_image/web_editor/devices/ipad_front_landscape.svg</attribute>
+        <attribute name="src">/web_editor/image_shape/website.s_text_image_default_image/web_editor/devices/ipad_front_landscape.svg?c5=o-color-5</attribute>
         <attribute name="data-shape">web_editor/devices/ipad_front_landscape</attribute>
         <attribute name="data-original-mimetype">image/jpg</attribute>
         <attribute name="data-file-name">s_text_image.svg</attribute>
         <attribute name="class" remove="rounded" separator=" "/>
+        <attribute name="data-shape-colors">;;;;o-color-5</attribute>
     </xpath>
 </template>
 

--- a/theme_orchid/views/snippets/s_image_hexagonal.xml
+++ b/theme_orchid/views/snippets/s_image_hexagonal.xml
@@ -12,8 +12,9 @@
     </xpath>
     <!-- Images -->
     <xpath expr="//img" position="attributes">
-        <attribute name="src">/web_editor/image_shape/website.s_masonry_block_default_image_1/web_editor/composition/composition_square_1.svg</attribute>
+        <attribute name="src">/web_editor/image_shape/website.s_masonry_block_default_image_1/web_editor/composition/composition_square_1.svg?c1=o-color-1&amp;c2=o-color-3</attribute>
         <attribute name="data-shape">web_editor/composition/composition_square_1</attribute>
+        <attribute name="data-shape-colors">o-color-1;o-color-3;;;</attribute>
     </xpath>
     <xpath expr="(//img)[2]" position="attributes">
         <attribute name="src">/web/image/website.s_cover_default_image</attribute>

--- a/theme_treehouse/views/snippets/s_picture.xml
+++ b/theme_treehouse/views/snippets/s_picture.xml
@@ -8,10 +8,10 @@
     </xpath>
     <!-- Image + Shape -->
     <xpath expr="//img" position="attributes">
-        <attribute name="src">/web_editor/image_shape/website.s_picture_default_image/web_editor/special/special_filter.svg</attribute>
+        <attribute name="src">/web_editor/image_shape/website.s_picture_default_image/web_editor/special/special_filter.svg?c2=o-color-3</attribute>
         <attribute name="data-file-name">01.svg</attribute>
         <attribute name="data-shape">web_editor/special/special_filter</attribute>
-        <attribute name="data-shape-colors">;#046380;;;</attribute>
+        <attribute name="data-shape-colors">;o-color-3;;;</attribute>
     </xpath>
 </template>
 


### PR DESCRIPTION
[*]=graphene, kea, kiddo, nano, odoo_experts, orchid, treehouse

Before this PR, several shapes were missing color attributes, which prevented the color picker from appearing in the editor.

This PR adds the required color attributes so the color picker is properly available for shapes in the editor. Moreover, these colors are appended in the shape URL as params to ensure that the default colors are correctly applied to the shapes.

task-5880905