### PR TITLE
[FIX] theme_*: update insertSnippet call in tours

### DIFF
--- a/theme_anelusia/static/src/js/tour.js
+++ b/theme_anelusia/static/src/js/tour.js
@@ -46,7 +46,7 @@ wTourUtils.registerThemeHomepageTour("anelusia_tour", () => [
     ...wTourUtils.clickOnText(snippets[0], 'h1', 'top'),
     wTourUtils.goBackToBlocks(),
     ...wTourUtils.insertSnippet(snippets[1]),
-    ...wTourUtils.insertSnippet(snippets[2], 'top'),
+    ...wTourUtils.insertSnippet(snippets[2], { position: "top" }),
     ...wTourUtils.insertSnippet(snippets[3]),
     ...wTourUtils.insertSnippet(snippets[4]),
     ...wTourUtils.clickOnSnippet(snippets[4], 'top'),

--- a/theme_artists/static/src/js/tour.js
+++ b/theme_artists/static/src/js/tour.js
@@ -42,7 +42,7 @@ const snippets = [
 
 wTourUtils.registerThemeHomepageTour("artists_tour", () => [
     wTourUtils.assertCssVariable('--color-palettes-name', '"artists-1"'),
-    ...wTourUtils.insertSnippet(snippets[0], 'top'),
+    ...wTourUtils.insertSnippet(snippets[0], { position: "top" }),
     ...wTourUtils.insertSnippet(snippets[1]),
     ...wTourUtils.clickOnText(snippets[1], 'h2'),
     wTourUtils.goBackToBlocks(),

--- a/theme_avantgarde/static/src/js/tour.js
+++ b/theme_avantgarde/static/src/js/tour.js
@@ -31,11 +31,11 @@ const snippets = [
 
 wTourUtils.registerThemeHomepageTour("avantgarde_tour", () => [
     wTourUtils.assertCssVariable('--color-palettes-name', '"default-15"'),
-    ...wTourUtils.insertSnippet(snippets[0], 'top'),
+    ...wTourUtils.insertSnippet(snippets[0], { position: "top" }),
     ...wTourUtils.clickOnText(snippets[0], 'h1', 'left'),
     wTourUtils.goBackToBlocks(),
-    ...wTourUtils.insertSnippet(snippets[1], 'left'),
-    ...wTourUtils.insertSnippet(snippets[2], 'top'),
-    ...wTourUtils.insertSnippet(snippets[3], 'top'),
-    ...wTourUtils.insertSnippet(snippets[4], 'top'),
+    ...wTourUtils.insertSnippet(snippets[1], { position: "left" }),
+    ...wTourUtils.insertSnippet(snippets[2], { position: "top" }),
+    ...wTourUtils.insertSnippet(snippets[3], { position: "top" }),
+    ...wTourUtils.insertSnippet(snippets[4], { position: "top" }),
 ]);

--- a/theme_bewise/static/src/js/tour.js
+++ b/theme_bewise/static/src/js/tour.js
@@ -36,12 +36,12 @@ const snippets = [
 
 wTourUtils.registerThemeHomepageTour("bewise_tour", () => [
     wTourUtils.assertCssVariable('--color-palettes-name', '"default-19"'),
-    ...wTourUtils.insertSnippet(snippets[0], 'top'),
+    ...wTourUtils.insertSnippet(snippets[0], { position: "top" }),
     ...wTourUtils.clickOnText(snippets[0], 'h1', 'top'),
     wTourUtils.goBackToBlocks(),
-    ...wTourUtils.insertSnippet(snippets[1], 'top'),
-    ...wTourUtils.insertSnippet(snippets[2], 'top'),
-    ...wTourUtils.insertSnippet(snippets[3], 'top'),
-    ...wTourUtils.insertSnippet(snippets[4], 'top'),
-    ...wTourUtils.insertSnippet(snippets[5], 'top'),
+    ...wTourUtils.insertSnippet(snippets[1], { position: "top" }),
+    ...wTourUtils.insertSnippet(snippets[2], { position: "top" }),
+    ...wTourUtils.insertSnippet(snippets[3], { position: "top" }),
+    ...wTourUtils.insertSnippet(snippets[4], { position: "top" }),
+    ...wTourUtils.insertSnippet(snippets[5], { position: "top" }),
 ]);

--- a/theme_graphene/static/src/js/tour.js
+++ b/theme_graphene/static/src/js/tour.js
@@ -45,9 +45,9 @@ wTourUtils.registerThemeHomepageTour("graphene_tour", () => [
     ...wTourUtils.insertSnippet(snippets[1]),
 
     ...wTourUtils.insertSnippet(snippets[2]),
-    ...wTourUtils.insertSnippet(snippets[3], 'top'),
+    ...wTourUtils.insertSnippet(snippets[3], { position: "top" }),
 
-    ...wTourUtils.insertSnippet(snippets[4], 'top'),
+    ...wTourUtils.insertSnippet(snippets[4], { position: "top" }),
     ...wTourUtils.clickOnSnippet(snippets[4], 'top'),
     wTourUtils.changeBackgroundColor('left'),
     wTourUtils.selectColorPalette(),

--- a/theme_paptic/static/src/js/tour.js
+++ b/theme_paptic/static/src/js/tour.js
@@ -43,12 +43,12 @@ const snippets = [
 
 wTourUtils.registerThemeHomepageTour("paptic_tour", () => [
     wTourUtils.assertCssVariable('--color-palettes-name', '"base-2"'),
-    ...wTourUtils.insertSnippet(snippets[0], 'top'),
+    ...wTourUtils.insertSnippet(snippets[0], { position: "top" }),
     ...wTourUtils.clickOnText(snippets[0], 'h1', 'top'),
     wTourUtils.goBackToBlocks(),
-    ...wTourUtils.insertSnippet(snippets[1], 'top'),
-    ...wTourUtils.insertSnippet(snippets[2], 'top'),
-    ...wTourUtils.insertSnippet(snippets[3], 'top'),
-    ...wTourUtils.insertSnippet(snippets[4], 'top'),
-    ...wTourUtils.insertSnippet(snippets[5], 'top'),
+    ...wTourUtils.insertSnippet(snippets[1], { position: "top" }),
+    ...wTourUtils.insertSnippet(snippets[2], { position: "top" }),
+    ...wTourUtils.insertSnippet(snippets[3], { position: "top" }),
+    ...wTourUtils.insertSnippet(snippets[4], { position: "top" }),
+    ...wTourUtils.insertSnippet(snippets[5], { position: "top" }),
 ]);


### PR DESCRIPTION
[*] = anelusia, artists, avantgarde, bewise, graphene, paptic

Before this PR, insertSnippet was called with the position passed directly as an argument. However, since the [commit](https://github.com/odoo/odoo/commit/9fe45e2b7ddbbfd0445ffe25a859e67), the function expects the position to be provided inside an options object.

This PR updates all insertSnippet calls to pass the position as an object, which is the expected format.

task-6090157