### PR TITLE
[REF] test_themes: replace useState with proxy

### DIFF
--- a/test_themes/static/src/systray_items/website_switcher.js
+++ b/test_themes/static/src/systray_items/website_switcher.js
@@ -3,14 +3,14 @@
 import { patch } from "@web/core/utils/patch";
 import { useService } from '@web/core/utils/hooks';
 import { WebsiteSwitcherSystrayItem } from "@website/client_actions/website_preview/website_switcher_systray_item";
-import { onMounted, useState } from "@odoo/owl";
+import { onMounted, proxy } from "@odoo/owl";
 
 patch(WebsiteSwitcherSystrayItem.prototype, {
     setup() {
         super.setup();
 
         this.orm = useService('orm');
-        this.tooltips = useState({});
+        this.tooltips = proxy({});
         // Disable the notification service to avoid having a notification for each theme.
         this.notificationService = { add: () => () => null };
 


### PR DESCRIPTION
In Owl3, uses of `useState` or replace with `proxy`. This commit removes `useState` from the compatibility layer, provides tooling for the migration in `owl3-migration` and removes the last uses of `useState`.