### PR TITLE
[FIX] theme_muse: fix theme preview

### DIFF
--- a/theme_muse/static/description/preview.html
+++ b/theme_muse/static/description/preview.html
@@ -1460,21 +1460,18 @@
 </div>
 </section><section class="s_about_bold pt112 pb88" data-snippet="s_about_bold">
 <div class="container s_allow_columns">
+<div class="row">
+<div class="col-lg-12">
 <h2 class="display-4-fs">Your trusted partner in navigating today's challenges. <font style="color: rgb(125, 125, 125);">We provide reliable service and proven expertise.</font></h2>
 <div class="s_hr pt32 pb32" data-name="Separator" data-snippet="s_hr">
 <hr class="w-100 mx-auto"/>
 </div>
-<div class="o_text_columns">
-<div class="row">
-<div class="o_snippet_mobile_invisible d-none d-lg-block col-12 col-lg-5">
-<p><br/></p>
 </div>
-<div class="col-12 col-lg-7">
+<div class="offset-lg-5 col-lg-7">
 <p>We help organizations turn goals into clear strategies, dependable solutions, and consistent execution that delivers measurable results. By combining industry knowledge, proven processes, and continuous improvement, we ensure every engagement creates lasting value.</p>
 <p>We support clients across planning, implementation, and ongoing operations—delivering reliable service, accountable teams, and outcomes they can track.</p>
 <p><br/></p>
 <img alt="" class="img img-fluid mx-auto" loading="lazy" src="/web/image/website.set_avatars_square_md_1" style="width: 100% !important;"/>
-</div>
 </div>
 </div>
 </div>


### PR DESCRIPTION
This PR updates the preview for `theme_muse` according to the new `s_about_bold` snippet design. Prior to this commit, the structure of the `s_about_bold` snippet was reworked to avoid using text columns, because they were creating a horizontal scroll, which are visible in the preview as well.

Now that the snippet uses a standard row and col structure, we need to update the preview to match that layout.

task-6318818