### PR TITLE
[FIX] theme_*: adapt images for new record and missed occurences

### DIFF
--- a/theme_enark/views/snippets/s_cta_box.xml
+++ b/theme_enark/views/snippets/s_cta_box.xml
@@ -21,7 +21,6 @@
     </xpath>
     <!-- Image -->
     <xpath expr="//img" position="attributes">
-        <attribute name="src">/theme_enark/static/src/img/snippets/library_image_02.webp</attribute>
         <attribute name="class" remove="rounded-end" separator=" "/>
     </xpath>
     <!-- Button -->

--- a/theme_graphene/views/customizations.xml
+++ b/theme_graphene/views/customizations.xml
@@ -6,7 +6,7 @@
     <xpath expr="//section" position="attributes">
         <attribute name="class" add="oe_img_bg" remove="s_parallax_is_fixed" separator=" "/>
         <attribute name="data-scroll-background-ratio">0</attribute>
-        <attribute name="style">background-image: url('/web/image/website.landscape_xl_1');</attribute>
+        <attribute name="style">background-image: url('/web/image/website.ultrawide_lg_6');</attribute>
     </xpath>
     <xpath expr="//span[hasclass('s_parallax_bg_wrap')]" position="replace"/>
     <xpath expr="//div[hasclass('col-lg-12')]" position="attributes">

--- a/theme_monglia/views/customizations.xml
+++ b/theme_monglia/views/customizations.xml
@@ -200,7 +200,7 @@
         <attribute name="src">/html_editor/image_shape/website.set_2_square_md_5/html_builder/panel/panel_duo_step.svg</attribute>
         <attribute name="data-shape">html_builder/panel/panel_duo_step</attribute>
         <attribute name="data-format-mimetype">image/webp</attribute>
-        <attribute name="data-file-name">s_masonry_block_default_image_1.webp</attribute>
+        <attribute name="data-file-name">set_2_square_md_5.webp</attribute>
         <attribute name="data-shape-colors">;;;;</attribute>
     </xpath>
 </template>

--- a/theme_orchid/views/snippets/s_image_text_overlap.xml
+++ b/theme_orchid/views/snippets/s_image_text_overlap.xml
@@ -17,7 +17,6 @@
     </xpath>
 
     <xpath expr="//img" position="attributes">
-        <attribute name="src">/theme_orchid/static/src/img/snippets/configurator_s_image_text_overlap.webp</attribute>
         <attribute name="class" add="img-thumbnail" separator=" "/>
         <attribute name="style" add="padding: 16px" separator=";"/>
     </xpath>


### PR DESCRIPTION
In theme_graphene we used `landscape_xl_1` but since the shape is
cropping the image to an ultrawide format, ultrawide is more adapted for
this snippet.

theme_enark, theme_monglia, theme_orchid

In https://github.com/odoo/design-themes/commit/d851c17c03f1 we rebinded the themes to use the new records but some occurences of direct file xpath were missed.

task-6321389