### PR TITLE
[FIX] theme_*: fix xpath targeting the wrong element

### DIFF
--- a/theme_kiddo/static/description/preview.html
+++ b/theme_kiddo/static/description/preview.html
@@ -964,7 +964,7 @@
 <h1 class="display-3">
         A little place <br/>of paradise</h1>
 <p><br/></p>
-<p class="lead mb-0">
+<p class="lead">
         Our goal is to create a safe and nurturing environment for your child to learn and grow. We believe that every child is unique and should be treated as such.
     </p>
 <p><br/></p>

--- a/theme_kiddo/views/snippets/s_banner.xml
+++ b/theme_kiddo/views/snippets/s_banner.xml
@@ -41,9 +41,6 @@
     <xpath expr="//p[hasclass('lead')]" position="replace" mode="inner">
         Our goal is to create a safe and nurturing environment for your child to learn and grow. We believe that every child is unique and should be treated as such.
     </xpath>
-    <xpath expr="//div[hasclass('col-lg-6')]//p[2]" position="attributes">
-        <attribute name="class" add="mb-0" separator=" "/>
-    </xpath>
 </template>
 
 </odoo>

--- a/theme_nano/static/description/preview.html
+++ b/theme_nano/static/description/preview.html
@@ -1196,12 +1196,9 @@
 <strong>We are CreativeAgency.</strong>
 </h1>
 <p class="lead" style="text-align: center;">Write one or two paragraphs describing your product, services or a specific feature.<br/> To be successful your content needs to be useful to your readers.</p>
+<p><br/></p>
 <p>
 <a class="btn btn-lg btn-primary o_translate_inline" href="/contactus">Get Started</a></p>
-<p style="text-align: center;">
-<a class="btn btn-primary mb-2 o_translate_inline" href="/contactus">Our store</a>
-<a class="btn btn-secondary mb-2 o_translate_inline" href="/contactus">Contact us</a>
-</p>
 </div>
 </section><section class="s_parallax parallax s_parallax_is_fixed bg-black-50 o_three_quarter_height pt48 pb48" data-scroll-background-ratio="3" data-snippet="s_parallax">
 <span class="s_parallax_bg_wrap">

--- a/theme_nano/views/snippets/s_discovery.xml
+++ b/theme_nano/views/snippets/s_discovery.xml
@@ -18,7 +18,7 @@
             <strong>We are CreativeAgency.</strong>
         </h1>
     </xpath>
-    <xpath expr="//p[2]" position="replace" mode="inner">
+    <xpath expr="//p[3]" position="replace" mode="inner">
         <a t-att-href="cta_btn_href" class="btn btn-lg btn-primary o_translate_inline"><t t-out="cta_btn_text">Get Started</t></a>
     </xpath>
 </template>


### PR DESCRIPTION
*: kiddo, nano
This PR fixes an issue related to changes made in Commit[1].

In Commit[^1], the DOM of some snippet, including `s_banner` was reworked in order to restore the insertable command indication by wrapping `<br/>` within a `<p>` tag.

To do so, an extra `<p>` tag was added, meaning that some xpath using weak selector such as `//p` were targeting this first element, resulting in an undesired result.

This PR fixes the issue by updating the selector accordingly.

[^1]: https://github.com/odoo/odoo/commit/400e35eed90d0e1fcb8958871570be5f174f505b

task-6318860