### PR TITLE
[IMP] test_themes, tooling: remove obsolete configurator values

### DIFF
--- a/test_themes/tests/test_theme_standalone.py
+++ b/test_themes/tests/test_theme_standalone.py
@@ -68,16 +68,9 @@ def test_02_theme_default_generate_primary_templates(env):
         website.ensure_one()
         with MockRequest(env, website=website):
             website.configurator_apply(
-                selected_features=[
-                    env.ref('website.feature_page_about_us').id,
-                    env.ref('website.feature_page_our_services').id,
-                    env.ref('website.feature_page_pricing').id,
-                    env.ref('website.feature_module_news').id,
-                ],
                 industry_id=2836,
                 industry_name='private university',
                 selected_palette='default-15',
                 theme_name='theme_bewise',
-                website_purpose='get_leads',
                 website_type='business',
             )

--- a/tooling/theme_preview_generator.py
+++ b/tooling/theme_preview_generator.py
@@ -82,9 +82,7 @@ def build_odoo_args():
 CONFIGURATOR_VALUES = {
     "industry_id": 0,
     "industry_name": "business",
-    "selected_features": [],
     "selected_palette": "base-1",
-    "website_purpose": "general",
     "website_type": "business",
     "skip_ai": True,
 }


### PR DESCRIPTION
The CTA changes introduced in [1] no longer use `website_purpose`, as
CTA generation is now based on website type and installed applications.

The configurator changes introduced in [2] removed the feature selection
step, making `selected_features` unnecessary.

This commit removes both values from the theme standalone tests and
preview generator to keep them aligned with the current configurator
behavior.

[1]: https://github.com/odoo/odoo/pull/261542
[2]: https://github.com/odoo/odoo/pull/262484

task-[4678541](https://www.odoo.com/odoo/project/974/tasks/4678541)