### PR TITLE
[FIX] theme_brutalist: fix intro snippet font-size in the preview

### DIFF
--- a/theme_brutalist/static/description/preview.html
+++ b/theme_brutalist/static/description/preview.html
@@ -926,8 +926,7 @@
 <div class="container">
 <div class="row o_grid_mode" data-row-count="13">
 <div class="o_grid_item g-col-lg-8 g-height-13 col-lg-8" style="--grid-item-padding-y: 0; --grid-item-padding-x: 0; grid-area: 1 / 1 / 14 / 9; order: 2; z-index: 1;">
-<h1>
-<span style="font-size: clamp(8px, 1em + 7.6402vw, 400px);">Emma<br/>Sophia Lee</span></h1>
+<h1 class="o_rfs" style="font-size: clamp(8px, 1em + 8.5vw, 400px);">Emma<br/>Sophia Lee</h1>
 </div>
 <div class="o_grid_item g-col-lg-4 g-height-3 col-lg-4" style="--grid-item-padding-y: 0; --grid-item-padding-x: 0; grid-area: 3 / 9 / 6 / 13; order: 3; z-index: 3;">
 <p class="lead" style="text-align: end;">This is a simple hero unit, a simple jumbotron-style component for calling extra attention to featured content or information.</p>


### PR DESCRIPTION
Inside the preview of the theme, the configuration was replacing
entirely the span on which the responsive font-size was set.

We move the responsive font size rule on the h1 itself, which will
never be replaced by the AI

task-6368821

| Before | After |
|--------|--------|
| <img width="553" height="438" alt="Screenshot 2026-07-07 at 10 27 24" src="https://github.com/user-attachments/assets/8481e9d4-f405-4e5c-a612-353606e42279" /> |  <img width="548" height="436" alt="Screenshot 2026-07-07 at 10 30 13" src="https://github.com/user-attachments/assets/ecbcc824-390e-45c6-8bf5-290f9aed20ea" /> |