### PR TITLE
[FIX] theme_zenith: fix incorrect snippet category/name in tour

### DIFF
--- a/theme_zenith/static/src/js/tour.js
+++ b/theme_zenith/static/src/js/tour.js
@@ -10,8 +10,8 @@ const snippets = [
     },
     {
         id: 's_freegrid',
-        name: 'Freegrid',
-        groupName: "Images",
+        name: 'Free grid',
+        groupName: "Columns",
     },
     {
         id: 's_title',


### PR DESCRIPTION
This PR fixes an incorrect snippet name and category within the theme tour, ensuring it runs smoothly.

task-6420823