### PR TITLE
[IMP] theme_graphene: support updated background shape

### DIFF
--- a/theme_graphene/static/src/scss/primary_variables.scss
+++ b/theme_graphene/static/src/scss/primary_variables.scss
@@ -152,3 +152,4 @@ $o-bg-shapes: change-shape-colors-mapping('html_builder', 'Origins/02_001', (4: 
 $o-bg-shapes: add-extra-shape-colors-mapping('html_builder', 'Origins/02_001', 'second', (4: 2, 5: rgba(0, 0, 0, 0)));
 $o-bg-shapes: change-shape-colors-mapping('html_builder', 'Origins/06_001', (3: 2));
 $o-bg-shapes: change-shape-colors-mapping('html_builder', 'Zigs/01_001', (2: 4));
+$o-bg-shapes: change-shape-colors-mapping('html_builder', 'Zigs/01_002', (2: 4, 3: 4));


### PR DESCRIPTION
Before this commit, the updated `Miscellaneous 08` shape did not use the Graphene color mapping.

After this commit, both shape colors use the same default theme color while remaining independently customizable.

task-6259086