### PR TITLE
[FIX] tooling: highlight only the active preview menu

### DIFF
--- a/theme_anelusia/static/description/preview.html
+++ b/theme_anelusia/static/description/preview.html
@@ -1096,12 +1096,12 @@
 </a>
 </li>
 <li class="nav-item border-top px-0" role="presentation">
-<a class="nav-link p-3 text-wrap active" href="/" role="menuitem">
+<a class="nav-link p-3 text-wrap" href="/shop" role="menuitem">
 <span>Shop</span>
 </a>
 </li>
 <li class="nav-item border-top border-bottom px-0" role="presentation">
-<a class="nav-link p-3 text-wrap active" href="/" role="menuitem">
+<a class="nav-link p-3 text-wrap" href="/event" role="menuitem">
 <span>Event</span>
 </a>
 </li>
@@ -1181,12 +1181,12 @@
 </a>
 </li>
 <li class="nav-item border-top px-0" role="presentation">
-<a class="nav-link p-3 text-wrap active" href="/" role="menuitem">
+<a class="nav-link p-3 text-wrap" href="/shop" role="menuitem">
 <span>Shop</span>
 </a>
 </li>
 <li class="nav-item border-top border-bottom px-0" role="presentation">
-<a class="nav-link p-3 text-wrap active" href="/" role="menuitem">
+<a class="nav-link p-3 text-wrap" href="/event" role="menuitem">
 <span>Event</span>
 </a>
 </li>

--- a/theme_artists/static/description/preview.html
+++ b/theme_artists/static/description/preview.html
@@ -871,12 +871,12 @@
 </a>
 </li>
 <li class="nav-item" role="presentation">
-<a class="nav-link active" href="/" role="menuitem">
+<a class="nav-link" href="/shop" role="menuitem">
 <span>Shop</span>
 </a>
 </li>
 <li class="nav-item" role="presentation">
-<a class="nav-link active" href="/" role="menuitem">
+<a class="nav-link" href="/event" role="menuitem">
 <span>Event</span>
 </a>
 </li>
@@ -926,12 +926,12 @@
 </a>
 </li>
 <li class="nav-item border-top px-0" role="presentation">
-<a class="nav-link p-3 text-wrap active" href="/" role="menuitem">
+<a class="nav-link p-3 text-wrap" href="/shop" role="menuitem">
 <span>Shop</span>
 </a>
 </li>
 <li class="nav-item border-top border-bottom px-0" role="presentation">
-<a class="nav-link p-3 text-wrap active" href="/" role="menuitem">
+<a class="nav-link p-3 text-wrap" href="/event" role="menuitem">
 <span>Event</span>
 </a>
 </li>

--- a/theme_avantgarde/static/description/preview.html
+++ b/theme_avantgarde/static/description/preview.html
@@ -1223,12 +1223,12 @@
 </a>
 </li>
 <li class="nav-item border-top px-0" role="presentation">
-<a class="nav-link p-3 text-wrap active" href="/" role="menuitem">
+<a class="nav-link p-3 text-wrap" href="/shop" role="menuitem">
 <span>Shop</span>
 </a>
 </li>
 <li class="nav-item border-top border-bottom px-0" role="presentation">
-<a class="nav-link p-3 text-wrap active" href="/" role="menuitem">
+<a class="nav-link p-3 text-wrap" href="/event" role="menuitem">
 <span>Event</span>
 </a>
 </li>
@@ -1308,12 +1308,12 @@
 </a>
 </li>
 <li class="nav-item border-top px-0" role="presentation">
-<a class="nav-link p-3 text-wrap active" href="/" role="menuitem">
+<a class="nav-link p-3 text-wrap" href="/shop" role="menuitem">
 <span>Shop</span>
 </a>
 </li>
 <li class="nav-item border-top border-bottom px-0" role="presentation">
-<a class="nav-link p-3 text-wrap active" href="/" role="menuitem">
+<a class="nav-link p-3 text-wrap" href="/event" role="menuitem">
 <span>Event</span>
 </a>
 </li>

--- a/theme_aviato/static/description/preview.html
+++ b/theme_aviato/static/description/preview.html
@@ -794,12 +794,12 @@
 </a>
 </li>
 <li class="nav-item" role="presentation">
-<a class="nav-link active" href="/" role="menuitem">
+<a class="nav-link" href="/shop" role="menuitem">
 <span>Shop</span>
 </a>
 </li>
 <li class="nav-item" role="presentation">
-<a class="nav-link active" href="/" role="menuitem">
+<a class="nav-link" href="/event" role="menuitem">
 <span>Event</span>
 </a>
 </li>
@@ -890,12 +890,12 @@
 </a>
 </li>
 <li class="nav-item border-top px-0" role="presentation">
-<a class="nav-link p-3 text-wrap active" href="/" role="menuitem">
+<a class="nav-link p-3 text-wrap" href="/shop" role="menuitem">
 <span>Shop</span>
 </a>
 </li>
 <li class="nav-item border-top border-bottom px-0" role="presentation">
-<a class="nav-link p-3 text-wrap active" href="/" role="menuitem">
+<a class="nav-link p-3 text-wrap" href="/event" role="menuitem">
 <span>Event</span>
 </a>
 </li>

--- a/theme_beauty/static/description/preview.html
+++ b/theme_beauty/static/description/preview.html
@@ -599,12 +599,12 @@
 </a>
 </li>
 <li class="nav-item" role="presentation">
-<a class="nav-link active" href="/" role="menuitem">
+<a class="nav-link" href="/shop" role="menuitem">
 <span>Shop</span>
 </a>
 </li>
 <li class="nav-item" role="presentation">
-<a class="nav-link active" href="/" role="menuitem">
+<a class="nav-link" href="/event" role="menuitem">
 <span>Event</span>
 </a>
 </li>
@@ -695,12 +695,12 @@
 </a>
 </li>
 <li class="nav-item border-top px-0" role="presentation">
-<a class="nav-link p-3 text-wrap active" href="/" role="menuitem">
+<a class="nav-link p-3 text-wrap" href="/shop" role="menuitem">
 <span>Shop</span>
 </a>
 </li>
 <li class="nav-item border-top border-bottom px-0" role="presentation">
-<a class="nav-link p-3 text-wrap active" href="/" role="menuitem">
+<a class="nav-link p-3 text-wrap" href="/event" role="menuitem">
 <span>Event</span>
 </a>
 </li>

--- a/theme_bewise/static/description/preview.html
+++ b/theme_bewise/static/description/preview.html
@@ -996,12 +996,12 @@
 </a>
 </li>
 <li class="nav-item" role="presentation">
-<a class="nav-link active" href="/" role="menuitem">
+<a class="nav-link" href="/shop" role="menuitem">
 <span>Shop</span>
 </a>
 </li>
 <li class="nav-item" role="presentation">
-<a class="nav-link active" href="/" role="menuitem">
+<a class="nav-link" href="/event" role="menuitem">
 <span>Event</span>
 </a>
 </li>
@@ -1092,12 +1092,12 @@
 </a>
 </li>
 <li class="nav-item border-top px-0" role="presentation">
-<a class="nav-link p-3 text-wrap active" href="/" role="menuitem">
+<a class="nav-link p-3 text-wrap" href="/shop" role="menuitem">
 <span>Shop</span>
 </a>
 </li>
 <li class="nav-item border-top border-bottom px-0" role="presentation">
-<a class="nav-link p-3 text-wrap active" href="/" role="menuitem">
+<a class="nav-link p-3 text-wrap" href="/event" role="menuitem">
 <span>Event</span>
 </a>
 </li>

--- a/theme_bistro/static/description/preview.html
+++ b/theme_bistro/static/description/preview.html
@@ -748,12 +748,12 @@
 </a>
 </li>
 <li class="nav-item" role="presentation">
-<a class="nav-link active" href="/" role="menuitem">
+<a class="nav-link" href="/shop" role="menuitem">
 <span>Shop</span>
 </a>
 </li>
 <li class="nav-item" role="presentation">
-<a class="nav-link active" href="/" role="menuitem">
+<a class="nav-link" href="/event" role="menuitem">
 <span>Event</span>
 </a>
 </li>
@@ -803,12 +803,12 @@
 </a>
 </li>
 <li class="nav-item border-top px-0" role="presentation">
-<a class="nav-link p-3 text-wrap active" href="/" role="menuitem">
+<a class="nav-link p-3 text-wrap" href="/shop" role="menuitem">
 <span>Shop</span>
 </a>
 </li>
 <li class="nav-item border-top border-bottom px-0" role="presentation">
-<a class="nav-link p-3 text-wrap active" href="/" role="menuitem">
+<a class="nav-link p-3 text-wrap" href="/event" role="menuitem">
 <span>Event</span>
 </a>
 </li>

--- a/theme_bookstore/static/description/preview.html
+++ b/theme_bookstore/static/description/preview.html
@@ -966,12 +966,12 @@
 </a>
 </li>
 <li class="nav-item" role="presentation">
-<a class="nav-link active" href="/" role="menuitem">
+<a class="nav-link" href="/shop" role="menuitem">
 <span>Shop</span>
 </a>
 </li>
 <li class="nav-item" role="presentation">
-<a class="nav-link active" href="/" role="menuitem">
+<a class="nav-link" href="/event" role="menuitem">
 <span>Event</span>
 </a>
 </li>
@@ -1052,12 +1052,12 @@
 </a>
 </li>
 <li class="nav-item border-top px-0" role="presentation">
-<a class="nav-link p-3 text-wrap active" href="/" role="menuitem">
+<a class="nav-link p-3 text-wrap" href="/shop" role="menuitem">
 <span>Shop</span>
 </a>
 </li>
 <li class="nav-item border-top border-bottom px-0" role="presentation">
-<a class="nav-link p-3 text-wrap active" href="/" role="menuitem">
+<a class="nav-link p-3 text-wrap" href="/event" role="menuitem">
 <span>Event</span>
 </a>
 </li>

--- a/theme_brutalist/static/description/preview.html
+++ b/theme_brutalist/static/description/preview.html
@@ -881,12 +881,12 @@
 </a>
 </li>
 <li class="nav-item" role="presentation">
-<a class="nav-link active" href="/" role="menuitem">
+<a class="nav-link" href="/shop" role="menuitem">
 <span>Shop</span>
 </a>
 </li>
 <li class="nav-item" role="presentation">
-<a class="nav-link active" href="/" role="menuitem">
+<a class="nav-link" href="/event" role="menuitem">
 <span>Event</span>
 </a>
 </li>
@@ -921,12 +921,12 @@
 </a>
 </li>
 <li class="nav-item border-top px-0" role="presentation">
-<a class="nav-link p-3 text-wrap active" href="/" role="menuitem">
+<a class="nav-link p-3 text-wrap" href="/shop" role="menuitem">
 <span>Shop</span>
 </a>
 </li>
 <li class="nav-item border-top border-bottom px-0" role="presentation">
-<a class="nav-link p-3 text-wrap active" href="/" role="menuitem">
+<a class="nav-link p-3 text-wrap" href="/event" role="menuitem">
 <span>Event</span>
 </a>
 </li>

--- a/theme_buzzy/static/description/preview.html
+++ b/theme_buzzy/static/description/preview.html
@@ -894,12 +894,12 @@
 </a>
 </li>
 <li class="nav-item" role="presentation">
-<a class="nav-link active" href="/" role="menuitem">
+<a class="nav-link" href="/shop" role="menuitem">
 <span>Shop</span>
 </a>
 </li>
 <li class="nav-item" role="presentation">
-<a class="nav-link active" href="/" role="menuitem">
+<a class="nav-link" href="/event" role="menuitem">
 <span>Event</span>
 </a>
 </li>
@@ -990,12 +990,12 @@
 </a>
 </li>
 <li class="nav-item border-top px-0" role="presentation">
-<a class="nav-link p-3 text-wrap active" href="/" role="menuitem">
+<a class="nav-link p-3 text-wrap" href="/shop" role="menuitem">
 <span>Shop</span>
 </a>
 </li>
 <li class="nav-item border-top border-bottom px-0" role="presentation">
-<a class="nav-link p-3 text-wrap active" href="/" role="menuitem">
+<a class="nav-link p-3 text-wrap" href="/event" role="menuitem">
 <span>Event</span>
 </a>
 </li>

--- a/theme_care/static/description/preview.html
+++ b/theme_care/static/description/preview.html
@@ -1097,12 +1097,12 @@
 </a>
 </li>
 <li class="nav-item" role="presentation">
-<a class="nav-link active" href="/" role="menuitem">
+<a class="nav-link" href="/shop" role="menuitem">
 <span>Shop</span>
 </a>
 </li>
 <li class="nav-item" role="presentation">
-<a class="nav-link active" href="/" role="menuitem">
+<a class="nav-link" href="/event" role="menuitem">
 <span>Event</span>
 </a>
 </li>
@@ -1193,12 +1193,12 @@
 </a>
 </li>
 <li class="nav-item border-top px-0" role="presentation">
-<a class="nav-link p-3 text-wrap active" href="/" role="menuitem">
+<a class="nav-link p-3 text-wrap" href="/shop" role="menuitem">
 <span>Shop</span>
 </a>
 </li>
 <li class="nav-item border-top border-bottom px-0" role="presentation">
-<a class="nav-link p-3 text-wrap active" href="/" role="menuitem">
+<a class="nav-link p-3 text-wrap" href="/event" role="menuitem">
 <span>Event</span>
 </a>
 </li>

--- a/theme_clean/static/description/preview.html
+++ b/theme_clean/static/description/preview.html
@@ -1422,12 +1422,12 @@
 </a>
 </li>
 <li class="nav-item" role="presentation">
-<a class="nav-link active" href="/" role="menuitem">
+<a class="nav-link" href="/shop" role="menuitem">
 <span>Shop</span>
 </a>
 </li>
 <li class="nav-item" role="presentation">
-<a class="nav-link active" href="/" role="menuitem">
+<a class="nav-link" href="/event" role="menuitem">
 <span>Event</span>
 </a>
 </li>
@@ -1518,12 +1518,12 @@
 </a>
 </li>
 <li class="nav-item border-top px-0" role="presentation">
-<a class="nav-link p-3 text-wrap active" href="/" role="menuitem">
+<a class="nav-link p-3 text-wrap" href="/shop" role="menuitem">
 <span>Shop</span>
 </a>
 </li>
 <li class="nav-item border-top border-bottom px-0" role="presentation">
-<a class="nav-link p-3 text-wrap active" href="/" role="menuitem">
+<a class="nav-link p-3 text-wrap" href="/event" role="menuitem">
 <span>Event</span>
 </a>
 </li>

--- a/theme_cobalt/static/description/preview.html
+++ b/theme_cobalt/static/description/preview.html
@@ -1205,12 +1205,12 @@
 </a>
 </li>
 <li class="nav-item" role="presentation">
-<a class="nav-link active" href="/" role="menuitem">
+<a class="nav-link" href="/shop" role="menuitem">
 <span>Shop</span>
 </a>
 </li>
 <li class="nav-item" role="presentation">
-<a class="nav-link active" href="/" role="menuitem">
+<a class="nav-link" href="/event" role="menuitem">
 <span>Event</span>
 </a>
 </li>
@@ -1301,12 +1301,12 @@
 </a>
 </li>
 <li class="nav-item border-top px-0" role="presentation">
-<a class="nav-link p-3 text-wrap active" href="/" role="menuitem">
+<a class="nav-link p-3 text-wrap" href="/shop" role="menuitem">
 <span>Shop</span>
 </a>
 </li>
 <li class="nav-item border-top border-bottom px-0" role="presentation">
-<a class="nav-link p-3 text-wrap active" href="/" role="menuitem">
+<a class="nav-link p-3 text-wrap" href="/event" role="menuitem">
 <span>Event</span>
 </a>
 </li>

--- a/theme_enark/static/description/preview.html
+++ b/theme_enark/static/description/preview.html
@@ -969,12 +969,12 @@
 </a>
 </li>
 <li class="nav-item h-100 border-start o_border_contrast" role="presentation">
-<a class="nav-link d-flex align-items-center h-100 active" href="/" role="menuitem">
+<a class="nav-link d-flex align-items-center h-100" href="/shop" role="menuitem">
 <span>Shop</span>
 </a>
 </li>
 <li class="nav-item h-100 border-start o_border_contrast" role="presentation">
-<a class="nav-link d-flex align-items-center h-100 active" href="/" role="menuitem">
+<a class="nav-link d-flex align-items-center h-100" href="/event" role="menuitem">
 <span>Event</span>
 </a>
 </li>
@@ -1062,12 +1062,12 @@
 </a>
 </li>
 <li class="nav-item border-top px-0" role="presentation">
-<a class="nav-link p-3 text-wrap active" href="/" role="menuitem">
+<a class="nav-link p-3 text-wrap" href="/shop" role="menuitem">
 <span>Shop</span>
 </a>
 </li>
 <li class="nav-item border-top border-bottom px-0" role="presentation">
-<a class="nav-link p-3 text-wrap active" href="/" role="menuitem">
+<a class="nav-link p-3 text-wrap" href="/event" role="menuitem">
 <span>Event</span>
 </a>
 </li>

--- a/theme_graphene/static/description/preview.html
+++ b/theme_graphene/static/description/preview.html
@@ -1002,12 +1002,12 @@
 </a>
 </li>
 <li class="nav-item h-100 border-start o_border_contrast" role="presentation">
-<a class="nav-link d-flex align-items-center h-100 active" href="/" role="menuitem">
+<a class="nav-link d-flex align-items-center h-100" href="/shop" role="menuitem">
 <span>Shop</span>
 </a>
 </li>
 <li class="nav-item h-100 border-start o_border_contrast" role="presentation">
-<a class="nav-link d-flex align-items-center h-100 active" href="/" role="menuitem">
+<a class="nav-link d-flex align-items-center h-100" href="/event" role="menuitem">
 <span>Event</span>
 </a>
 </li>
@@ -1095,12 +1095,12 @@
 </a>
 </li>
 <li class="nav-item border-top px-0" role="presentation">
-<a class="nav-link p-3 text-wrap active" href="/" role="menuitem">
+<a class="nav-link p-3 text-wrap" href="/shop" role="menuitem">
 <span>Shop</span>
 </a>
 </li>
 <li class="nav-item border-top border-bottom px-0" role="presentation">
-<a class="nav-link p-3 text-wrap active" href="/" role="menuitem">
+<a class="nav-link p-3 text-wrap" href="/event" role="menuitem">
 <span>Event</span>
 </a>
 </li>

--- a/theme_kea/static/description/preview.html
+++ b/theme_kea/static/description/preview.html
@@ -1241,12 +1241,12 @@
 </a>
 </li>
 <li class="nav-item" role="presentation">
-<a class="nav-link active" href="/" role="menuitem">
+<a class="nav-link" href="/shop" role="menuitem">
 <span>Shop</span>
 </a>
 </li>
 <li class="nav-item" role="presentation">
-<a class="nav-link active" href="/" role="menuitem">
+<a class="nav-link" href="/event" role="menuitem">
 <span>Event</span>
 </a>
 </li>
@@ -1337,12 +1337,12 @@
 </a>
 </li>
 <li class="nav-item border-top px-0" role="presentation">
-<a class="nav-link p-3 text-wrap active" href="/" role="menuitem">
+<a class="nav-link p-3 text-wrap" href="/shop" role="menuitem">
 <span>Shop</span>
 </a>
 </li>
 <li class="nav-item border-top border-bottom px-0" role="presentation">
-<a class="nav-link p-3 text-wrap active" href="/" role="menuitem">
+<a class="nav-link p-3 text-wrap" href="/event" role="menuitem">
 <span>Event</span>
 </a>
 </li>

--- a/theme_kiddo/static/description/preview.html
+++ b/theme_kiddo/static/description/preview.html
@@ -846,12 +846,12 @@
 </a>
 </li>
 <li class="nav-item" role="presentation">
-<a class="nav-link active" href="/" role="menuitem">
+<a class="nav-link" href="/shop" role="menuitem">
 <span>Shop</span>
 </a>
 </li>
 <li class="nav-item" role="presentation">
-<a class="nav-link active" href="/" role="menuitem">
+<a class="nav-link" href="/event" role="menuitem">
 <span>Event</span>
 </a>
 </li>
@@ -942,12 +942,12 @@
 </a>
 </li>
 <li class="nav-item border-top px-0" role="presentation">
-<a class="nav-link p-3 text-wrap active" href="/" role="menuitem">
+<a class="nav-link p-3 text-wrap" href="/shop" role="menuitem">
 <span>Shop</span>
 </a>
 </li>
 <li class="nav-item border-top border-bottom px-0" role="presentation">
-<a class="nav-link p-3 text-wrap active" href="/" role="menuitem">
+<a class="nav-link p-3 text-wrap" href="/event" role="menuitem">
 <span>Event</span>
 </a>
 </li>

--- a/theme_linea/static/description/preview.html
+++ b/theme_linea/static/description/preview.html
@@ -1052,12 +1052,12 @@
 </a>
 </li>
 <li class="nav-item border-top px-0" role="presentation">
-<a class="nav-link p-3 text-wrap active" href="/" role="menuitem">
+<a class="nav-link p-3 text-wrap" href="/shop" role="menuitem">
 <span>Shop</span>
 </a>
 </li>
 <li class="nav-item border-top border-bottom px-0" role="presentation">
-<a class="nav-link p-3 text-wrap active" href="/" role="menuitem">
+<a class="nav-link p-3 text-wrap" href="/event" role="menuitem">
 <span>Event</span>
 </a>
 </li>
@@ -1137,12 +1137,12 @@
 </a>
 </li>
 <li class="nav-item border-top px-0" role="presentation">
-<a class="nav-link p-3 text-wrap active" href="/" role="menuitem">
+<a class="nav-link p-3 text-wrap" href="/shop" role="menuitem">
 <span>Shop</span>
 </a>
 </li>
 <li class="nav-item border-top border-bottom px-0" role="presentation">
-<a class="nav-link p-3 text-wrap active" href="/" role="menuitem">
+<a class="nav-link p-3 text-wrap" href="/event" role="menuitem">
 <span>Event</span>
 </a>
 </li>

--- a/theme_loftspace/static/description/preview.html
+++ b/theme_loftspace/static/description/preview.html
@@ -746,12 +746,12 @@
 </a>
 </li>
 <li class="nav-item" role="presentation">
-<a class="nav-link active" href="/" role="menuitem">
+<a class="nav-link" href="/shop" role="menuitem">
 <span>Shop</span>
 </a>
 </li>
 <li class="nav-item" role="presentation">
-<a class="nav-link active" href="/" role="menuitem">
+<a class="nav-link" href="/event" role="menuitem">
 <span>Event</span>
 </a>
 </li>
@@ -832,12 +832,12 @@
 </a>
 </li>
 <li class="nav-item border-top px-0" role="presentation">
-<a class="nav-link p-3 text-wrap active" href="/" role="menuitem">
+<a class="nav-link p-3 text-wrap" href="/shop" role="menuitem">
 <span>Shop</span>
 </a>
 </li>
 <li class="nav-item border-top border-bottom px-0" role="presentation">
-<a class="nav-link p-3 text-wrap active" href="/" role="menuitem">
+<a class="nav-link p-3 text-wrap" href="/event" role="menuitem">
 <span>Event</span>
 </a>
 </li>

--- a/theme_monglia/static/description/preview.html
+++ b/theme_monglia/static/description/preview.html
@@ -889,12 +889,12 @@
 </a>
 </li>
 <li class="nav-item" role="presentation">
-<a class="nav-link active" href="/" role="menuitem">
+<a class="nav-link" href="/shop" role="menuitem">
 <span>Shop</span>
 </a>
 </li>
 <li class="nav-item" role="presentation">
-<a class="nav-link active" href="/" role="menuitem">
+<a class="nav-link" href="/event" role="menuitem">
 <span>Event</span>
 </a>
 </li>
@@ -985,12 +985,12 @@
 </a>
 </li>
 <li class="nav-item border-top px-0" role="presentation">
-<a class="nav-link p-3 text-wrap active" href="/" role="menuitem">
+<a class="nav-link p-3 text-wrap" href="/shop" role="menuitem">
 <span>Shop</span>
 </a>
 </li>
 <li class="nav-item border-top border-bottom px-0" role="presentation">
-<a class="nav-link p-3 text-wrap active" href="/" role="menuitem">
+<a class="nav-link p-3 text-wrap" href="/event" role="menuitem">
 <span>Event</span>
 </a>
 </li>

--- a/theme_muse/static/description/preview.html
+++ b/theme_muse/static/description/preview.html
@@ -1313,12 +1313,12 @@
 </a>
 </li>
 <li class="nav-item" role="presentation">
-<a class="nav-link active" href="/" role="menuitem">
+<a class="nav-link" href="/shop" role="menuitem">
 <span>Shop</span>
 </a>
 </li>
 <li class="nav-item" role="presentation">
-<a class="nav-link active" href="/" role="menuitem">
+<a class="nav-link" href="/event" role="menuitem">
 <span>Event</span>
 </a>
 </li>
@@ -1409,12 +1409,12 @@
 </a>
 </li>
 <li class="nav-item border-top px-0" role="presentation">
-<a class="nav-link p-3 text-wrap active" href="/" role="menuitem">
+<a class="nav-link p-3 text-wrap" href="/shop" role="menuitem">
 <span>Shop</span>
 </a>
 </li>
 <li class="nav-item border-top border-bottom px-0" role="presentation">
-<a class="nav-link p-3 text-wrap active" href="/" role="menuitem">
+<a class="nav-link p-3 text-wrap" href="/event" role="menuitem">
 <span>Event</span>
 </a>
 </li>

--- a/theme_nano/static/description/preview.html
+++ b/theme_nano/static/description/preview.html
@@ -1079,12 +1079,12 @@
 </a>
 </li>
 <li class="nav-item" role="presentation">
-<a class="nav-link active" href="/" role="menuitem">
+<a class="nav-link" href="/shop" role="menuitem">
 <span>Shop</span>
 </a>
 </li>
 <li class="nav-item" role="presentation">
-<a class="nav-link active" href="/" role="menuitem">
+<a class="nav-link" href="/event" role="menuitem">
 <span>Event</span>
 </a>
 </li>
@@ -1175,12 +1175,12 @@
 </a>
 </li>
 <li class="nav-item border-top px-0" role="presentation">
-<a class="nav-link p-3 text-wrap active" href="/" role="menuitem">
+<a class="nav-link p-3 text-wrap" href="/shop" role="menuitem">
 <span>Shop</span>
 </a>
 </li>
 <li class="nav-item border-top border-bottom px-0" role="presentation">
-<a class="nav-link p-3 text-wrap active" href="/" role="menuitem">
+<a class="nav-link p-3 text-wrap" href="/event" role="menuitem">
 <span>Event</span>
 </a>
 </li>

--- a/theme_notes/static/description/preview.html
+++ b/theme_notes/static/description/preview.html
@@ -1410,12 +1410,12 @@
 </a>
 </li>
 <li class="nav-item" role="presentation">
-<a class="nav-link active" href="/" role="menuitem">
+<a class="nav-link" href="/shop" role="menuitem">
 <span>Shop</span>
 </a>
 </li>
 <li class="nav-item" role="presentation">
-<a class="nav-link active" href="/" role="menuitem">
+<a class="nav-link" href="/event" role="menuitem">
 <span>Event</span>
 </a>
 </li>
@@ -1506,12 +1506,12 @@
 </a>
 </li>
 <li class="nav-item border-top px-0" role="presentation">
-<a class="nav-link p-3 text-wrap active" href="/" role="menuitem">
+<a class="nav-link p-3 text-wrap" href="/shop" role="menuitem">
 <span>Shop</span>
 </a>
 </li>
 <li class="nav-item border-top border-bottom px-0" role="presentation">
-<a class="nav-link p-3 text-wrap active" href="/" role="menuitem">
+<a class="nav-link p-3 text-wrap" href="/event" role="menuitem">
 <span>Event</span>
 </a>
 </li>

--- a/theme_odoo_experts/static/description/preview.html
+++ b/theme_odoo_experts/static/description/preview.html
@@ -1079,12 +1079,12 @@
 </a>
 </li>
 <li class="nav-item" role="presentation">
-<a class="nav-link active" href="/" role="menuitem">
+<a class="nav-link" href="/shop" role="menuitem">
 <span>Shop</span>
 </a>
 </li>
 <li class="nav-item" role="presentation">
-<a class="nav-link active" href="/" role="menuitem">
+<a class="nav-link" href="/event" role="menuitem">
 <span>Event</span>
 </a>
 </li>
@@ -1175,12 +1175,12 @@
 </a>
 </li>
 <li class="nav-item border-top px-0" role="presentation">
-<a class="nav-link p-3 text-wrap active" href="/" role="menuitem">
+<a class="nav-link p-3 text-wrap" href="/shop" role="menuitem">
 <span>Shop</span>
 </a>
 </li>
 <li class="nav-item border-top border-bottom px-0" role="presentation">
-<a class="nav-link p-3 text-wrap active" href="/" role="menuitem">
+<a class="nav-link p-3 text-wrap" href="/event" role="menuitem">
 <span>Event</span>
 </a>
 </li>

--- a/theme_orchid/static/description/preview.html
+++ b/theme_orchid/static/description/preview.html
@@ -677,12 +677,12 @@
 </a>
 </li>
 <li class="nav-item" role="presentation">
-<a class="nav-link active" href="/" role="menuitem">
+<a class="nav-link" href="/shop" role="menuitem">
 <span>Shop</span>
 </a>
 </li>
 <li class="nav-item" role="presentation">
-<a class="nav-link active" href="/" role="menuitem">
+<a class="nav-link" href="/event" role="menuitem">
 <span>Event</span>
 </a>
 </li>
@@ -773,12 +773,12 @@
 </a>
 </li>
 <li class="nav-item border-top px-0" role="presentation">
-<a class="nav-link p-3 text-wrap active" href="/" role="menuitem">
+<a class="nav-link p-3 text-wrap" href="/shop" role="menuitem">
 <span>Shop</span>
 </a>
 </li>
 <li class="nav-item border-top border-bottom px-0" role="presentation">
-<a class="nav-link p-3 text-wrap active" href="/" role="menuitem">
+<a class="nav-link p-3 text-wrap" href="/event" role="menuitem">
 <span>Event</span>
 </a>
 </li>

--- a/theme_paptic/static/description/preview.html
+++ b/theme_paptic/static/description/preview.html
@@ -1547,12 +1547,12 @@
 </a>
 </li>
 <li class="nav-item" role="presentation">
-<a class="nav-link active" href="/" role="menuitem">
+<a class="nav-link" href="/shop" role="menuitem">
 <span>Shop</span>
 </a>
 </li>
 <li class="nav-item" role="presentation">
-<a class="nav-link active" href="/" role="menuitem">
+<a class="nav-link" href="/event" role="menuitem">
 <span>Event</span>
 </a>
 </li>
@@ -1643,12 +1643,12 @@
 </a>
 </li>
 <li class="nav-item border-top px-0" role="presentation">
-<a class="nav-link p-3 text-wrap active" href="/" role="menuitem">
+<a class="nav-link p-3 text-wrap" href="/shop" role="menuitem">
 <span>Shop</span>
 </a>
 </li>
 <li class="nav-item border-top border-bottom px-0" role="presentation">
-<a class="nav-link p-3 text-wrap active" href="/" role="menuitem">
+<a class="nav-link p-3 text-wrap" href="/event" role="menuitem">
 <span>Event</span>
 </a>
 </li>

--- a/theme_pawtastic/static/description/preview.html
+++ b/theme_pawtastic/static/description/preview.html
@@ -825,12 +825,12 @@
 </a>
 </li>
 <li class="nav-item" role="presentation">
-<a class="nav-link active" href="/" role="menuitem">
+<a class="nav-link" href="/shop" role="menuitem">
 <span>Shop</span>
 </a>
 </li>
 <li class="nav-item" role="presentation">
-<a class="nav-link active" href="/" role="menuitem">
+<a class="nav-link" href="/event" role="menuitem">
 <span>Event</span>
 </a>
 </li>
@@ -921,12 +921,12 @@
 </a>
 </li>
 <li class="nav-item border-top px-0" role="presentation">
-<a class="nav-link p-3 text-wrap active" href="/" role="menuitem">
+<a class="nav-link p-3 text-wrap" href="/shop" role="menuitem">
 <span>Shop</span>
 </a>
 </li>
 <li class="nav-item border-top border-bottom px-0" role="presentation">
-<a class="nav-link p-3 text-wrap active" href="/" role="menuitem">
+<a class="nav-link p-3 text-wrap" href="/event" role="menuitem">
 <span>Event</span>
 </a>
 </li>

--- a/theme_real_estate/static/description/preview.html
+++ b/theme_real_estate/static/description/preview.html
@@ -1438,12 +1438,12 @@
 </a>
 </li>
 <li class="nav-item" role="presentation">
-<a class="nav-link active" href="/" role="menuitem">
+<a class="nav-link" href="/shop" role="menuitem">
 <span>Shop</span>
 </a>
 </li>
 <li class="nav-item" role="presentation">
-<a class="nav-link active" href="/" role="menuitem">
+<a class="nav-link" href="/event" role="menuitem">
 <span>Event</span>
 </a>
 </li>
@@ -1534,12 +1534,12 @@
 </a>
 </li>
 <li class="nav-item border-top px-0" role="presentation">
-<a class="nav-link p-3 text-wrap active" href="/" role="menuitem">
+<a class="nav-link p-3 text-wrap" href="/shop" role="menuitem">
 <span>Shop</span>
 </a>
 </li>
 <li class="nav-item border-top border-bottom px-0" role="presentation">
-<a class="nav-link p-3 text-wrap active" href="/" role="menuitem">
+<a class="nav-link p-3 text-wrap" href="/event" role="menuitem">
 <span>Event</span>
 </a>
 </li>

--- a/theme_test_custo/static/description/preview.html
+++ b/theme_test_custo/static/description/preview.html
@@ -890,12 +890,12 @@
 </ul>
 </li>
 <li class="nav-item" role="presentation">
-<a class="nav-link active" href="/" role="menuitem">
+<a class="nav-link" href="/shop" role="menuitem">
 <span>Shop</span>
 </a>
 </li>
 <li class="nav-item" role="presentation">
-<a class="nav-link active" href="/" role="menuitem">
+<a class="nav-link" href="/event" role="menuitem">
 <span>Event</span>
 </a>
 </li>

--- a/theme_treehouse/static/description/preview.html
+++ b/theme_treehouse/static/description/preview.html
@@ -747,12 +747,12 @@
 </a>
 </li>
 <li class="nav-item" role="presentation">
-<a class="nav-link active" href="/" role="menuitem">
+<a class="nav-link" href="/shop" role="menuitem">
 <span>Shop</span>
 </a>
 </li>
 <li class="nav-item" role="presentation">
-<a class="nav-link active" href="/" role="menuitem">
+<a class="nav-link" href="/event" role="menuitem">
 <span>Event</span>
 </a>
 </li>
@@ -802,12 +802,12 @@
 </a>
 </li>
 <li class="nav-item border-top px-0" role="presentation">
-<a class="nav-link p-3 text-wrap active" href="/" role="menuitem">
+<a class="nav-link p-3 text-wrap" href="/shop" role="menuitem">
 <span>Shop</span>
 </a>
 </li>
 <li class="nav-item border-top border-bottom px-0" role="presentation">
-<a class="nav-link p-3 text-wrap active" href="/" role="menuitem">
+<a class="nav-link p-3 text-wrap" href="/event" role="menuitem">
 <span>Event</span>
 </a>
 </li>

--- a/theme_vehicle/static/description/preview.html
+++ b/theme_vehicle/static/description/preview.html
@@ -1050,12 +1050,12 @@
 </a>
 </li>
 <li class="nav-item" role="presentation">
-<a class="nav-link active" href="/" role="menuitem">
+<a class="nav-link" href="/shop" role="menuitem">
 <span>Shop</span>
 </a>
 </li>
 <li class="nav-item" role="presentation">
-<a class="nav-link active" href="/" role="menuitem">
+<a class="nav-link" href="/event" role="menuitem">
 <span>Event</span>
 </a>
 </li>
@@ -1146,12 +1146,12 @@
 </a>
 </li>
 <li class="nav-item border-top px-0" role="presentation">
-<a class="nav-link p-3 text-wrap active" href="/" role="menuitem">
+<a class="nav-link p-3 text-wrap" href="/shop" role="menuitem">
 <span>Shop</span>
 </a>
 </li>
 <li class="nav-item border-top border-bottom px-0" role="presentation">
-<a class="nav-link p-3 text-wrap active" href="/" role="menuitem">
+<a class="nav-link p-3 text-wrap" href="/event" role="menuitem">
 <span>Event</span>
 </a>
 </li>

--- a/theme_yes/static/description/preview.html
+++ b/theme_yes/static/description/preview.html
@@ -978,12 +978,12 @@
 </a>
 </li>
 <li class="nav-item" role="presentation">
-<a class="nav-link active" href="/" role="menuitem">
+<a class="nav-link" href="/shop" role="menuitem">
 <span>Shop</span>
 </a>
 </li>
 <li class="nav-item" role="presentation">
-<a class="nav-link active" href="/" role="menuitem">
+<a class="nav-link" href="/event" role="menuitem">
 <span>Event</span>
 </a>
 </li>
@@ -1074,12 +1074,12 @@
 </a>
 </li>
 <li class="nav-item border-top px-0" role="presentation">
-<a class="nav-link p-3 text-wrap active" href="/" role="menuitem">
+<a class="nav-link p-3 text-wrap" href="/shop" role="menuitem">
 <span>Shop</span>
 </a>
 </li>
 <li class="nav-item border-top border-bottom px-0" role="presentation">
-<a class="nav-link p-3 text-wrap active" href="/" role="menuitem">
+<a class="nav-link p-3 text-wrap" href="/event" role="menuitem">
 <span>Event</span>
 </a>
 </li>

--- a/theme_zap/static/description/preview.html
+++ b/theme_zap/static/description/preview.html
@@ -1303,12 +1303,12 @@
 </a>
 </li>
 <li class="nav-item small" role="presentation">
-<a class="nav-link active" href="/" role="menuitem">
+<a class="nav-link" href="/shop" role="menuitem">
 <span>Shop</span>
 </a>
 </li>
 <li class="nav-item small" role="presentation">
-<a class="nav-link active" href="/" role="menuitem">
+<a class="nav-link" href="/event" role="menuitem">
 <span>Event</span>
 </a>
 </li>
@@ -1411,12 +1411,12 @@
 </a>
 </li>
 <li class="nav-item border-top px-0" role="presentation">
-<a class="nav-link p-3 text-wrap active" href="/" role="menuitem">
+<a class="nav-link p-3 text-wrap" href="/shop" role="menuitem">
 <span>Shop</span>
 </a>
 </li>
 <li class="nav-item border-top border-bottom px-0" role="presentation">
-<a class="nav-link p-3 text-wrap active" href="/" role="menuitem">
+<a class="nav-link p-3 text-wrap" href="/event" role="menuitem">
 <span>Event</span>
 </a>
 </li>

--- a/theme_zenith/static/description/preview.html
+++ b/theme_zenith/static/description/preview.html
@@ -704,12 +704,12 @@
 </a>
 </li>
 <li class="nav-item border-top px-0" role="presentation">
-<a class="nav-link p-3 text-wrap active" href="/" role="menuitem">
+<a class="nav-link p-3 text-wrap" href="/shop" role="menuitem">
 <span>Shop</span>
 </a>
 </li>
 <li class="nav-item border-top border-bottom px-0" role="presentation">
-<a class="nav-link p-3 text-wrap active" href="/" role="menuitem">
+<a class="nav-link p-3 text-wrap" href="/event" role="menuitem">
 <span>Event</span>
 </a>
 </li>
@@ -789,12 +789,12 @@
 </a>
 </li>
 <li class="nav-item border-top px-0" role="presentation">
-<a class="nav-link p-3 text-wrap active" href="/" role="menuitem">
+<a class="nav-link p-3 text-wrap" href="/shop" role="menuitem">
 <span>Shop</span>
 </a>
 </li>
 <li class="nav-item border-top border-bottom px-0" role="presentation">
-<a class="nav-link p-3 text-wrap active" href="/" role="menuitem">
+<a class="nav-link p-3 text-wrap" href="/event" role="menuitem">
 <span>Event</span>
 </a>
 </li>

--- a/tooling/theme_preview_generator.py
+++ b/tooling/theme_preview_generator.py
@@ -50,7 +50,7 @@ CONFIGURATOR_VALUES = {
     "skip_ai": True,
 }
 
-MENU_TITLES = ["Shop", "Event"]
+MENU_ITEMS = [("Shop", "/shop"), ("Event", "/event")]
 
 DOWNLOAD_SESSION = requests.Session()
 DOWNLOAD_SESSION.headers["User-Agent"] = (
@@ -216,11 +216,11 @@ def create_menu_items(session, context, website_id):
             "args": [[
                 {
                     "name": title,
-                    "url": "/",
+                    "url": url,
                     "website_id": website_id,
                     "parent_id": website["menu_id"][0],
                 }
-                for title in MENU_TITLES
+                for title, url in MENU_ITEMS
             ]],
             "kwargs": {"context": context},
         },


### PR DESCRIPTION
Theme previews created all sample menu links with the home URL, so they were all displayed as active. Give each link its own URL so only Home is highlighted on the homepage.

task-6368411