### PR TITLE
[FIX] test_themes: accept extra kwargs in OLG api mock

### DIFF
--- a/test_themes/tests/test_theme_standalone.py
+++ b/test_themes/tests/test_theme_standalone.py
@@ -32,7 +32,7 @@ def test_02_theme_default_generate_primary_templates(env):
         assert path.startswith("/api/website/2/configurator/custom_resources")
         return {'images': {}}
 
-    def fake_olg_api(self, path, payload):
+    def fake_olg_api(self, path, payload, **kwargs):
         # Placeholder generator used by configurator
         assert path == "/api/olg/1/generate_placeholder"
         placeholders = payload.get("placeholders", [])


### PR DESCRIPTION
Commit [1] added a `timeout=30` kwarg to the `_OLG_api_rpc` call made by `configurator_apply.

`test_02_theme_default_generate_primary_templates` patches that method with a stub only accepting `(self, path, payload)`. `autospec=True` checks the call against the real signature, which does accept extra kwargs, so it goes through; the stub itself is then called with `timeout=30`, which it does not accept, and the test fails

This commit lets the mock swallow any extra kwargs so it does not have to track the real signature.

[1] https://github.com/odoo/odoo/commit/7bd2c7140d974c578614bd16b54a72ae1d988a0f

runbot-945703