### PR TITLE
[FIX] themes: mark illustration-based themes as service-only

### DIFF
--- a/theme_aviato/__manifest__.py
+++ b/theme_aviato/__manifest__.py
@@ -1,6 +1,6 @@
 {
     'name': 'Aviato Theme',
-    'description': 'Banner-led layout alternating text-and-image rows with a featured picture block, masonry gallery, team and testimonials, with connection line motifs accenting the banner. Narrative and image-forward / suited for travel agencies, tour operators, excursion booking, and destination marketing sites',
+    'description': 'Partly illustration-based: the text-image rows and the showcase use line-art illustrations instead of photos, the rest of the theme is photographic. Banner-led layout alternating text-and-image rows with a featured picture block, masonry gallery, team and testimonials, with connection line motifs accenting the banner. Narrative and image-forward / suited for travel agencies, tour operators, excursion booking, and destination marketing sites. Only for travel service businesses.',
     'category': 'Theme/Creative',
     'summary': 'Travel, Excursion, Plane, Tour, Agency ',
     'sequence': 20,

--- a/theme_buzzy/__manifest__.py
+++ b/theme_buzzy/__manifest__.py
@@ -1,6 +1,6 @@
 {
     'name': 'Buzzy Theme',
-    'description': 'Illustrative banner opens onto a discovery exploration block, product showcase, key-benefit grids, and accordion-with-image FAQ, with shaped containers and organic blob motifs throughout and recurring scribble-and-marker highlights on key heading words. Content-heavy and benefit-driven, leaning illustrative rather than photo-led / suited for corporate services, technology companies, and SaaS-style product marketing sites',
+    'description': 'Theme with illustration instead of images. Illustrative banner opens onto a discovery exploration block, product showcase, key-benefit grids, and accordion-with-image FAQ, with shaped containers and organic blob motifs throughout and recurring scribble-and-marker highlights on key heading words. Content-heavy and benefit-driven, leaning illustrative rather than photo-led / suited for corporate services, technology companies, and SaaS-style product marketing sites. Only for service businesses selling expertise; never recommend for shops or makers of physical goods (furniture, retail, e-commerce, food, construction, repair, craftsmen, etc.).',
     'category': 'Theme/Corporate',
     'summary': 'Corporate, Services, Technology, Shapes, Illustrations',
     'sequence': 140,

--- a/theme_cobalt/__manifest__.py
+++ b/theme_cobalt/__manifest__.py
@@ -1,6 +1,6 @@
 {
     'name': 'Cobalt Theme',
-    'description': 'Banner hero leads into alternating image-text rows, key visuals, detailed team profiles, and a references grid for client logos, with connection line motifs woven across the sections. Communicates credibility through structure and showcased work / suited for IT and software development studios, design agencies, and technology consultancies',
+    'description': 'Theme with illustration instead of images. Banner hero leads into alternating image-text rows, key visuals, detailed team profiles, and a references grid for client logos, with connection line motifs woven across the sections. Communicates credibility through structure and showcased work / suited for IT and software development studios, design agencies, and technology consultancies. Only for service businesses selling expertise; never recommend for shops or makers of physical goods (furniture, retail, e-commerce, food, construction, repair, craftsmen, etc.).',
     'category': 'Theme/Corporate',
     'summary': 'Development, IT development, Design, Tech, Computers, IT, Blogs',
     'sequence': 110,

--- a/theme_graphene/__manifest__.py
+++ b/theme_graphene/__manifest__.py
@@ -1,6 +1,6 @@
 {
     'name': 'Graphene Theme',
-    'description': 'Cover hero opens onto alternating text-and-image rows, a numbers grid, mockup showcase, and side-by-side comparisons before client references, accented by connection, bold geometric, and rain-line motifs. Mockup-and-stats forward with credibility cues / suited for technology companies, robotics, IT services, and product-led corporate sites',
+    'description': 'Theme with device mockups instead of plain photos. Cover hero opens onto alternating text-and-image rows, a numbers grid, mockup showcase, and side-by-side comparisons before client references, accented by connection, bold geometric, and rain-line motifs. Mockup-and-stats forward with credibility cues / suited for technology companies, robotics, IT services, and product-led corporate sites. Visuals are framed in device mockups (phone, tablet, browser, laptop), so it needs a digital product or interface to show on screen (app, dashboard, software UI); never recommend for businesses with nothing screen-based to display.',
     'category': 'Theme/Corporate',
     'summary': 'Service, Corporate, Design, Technology, Robotics, Computers, IT, Blogs',
     'sequence': 110,

--- a/theme_kea/__manifest__.py
+++ b/theme_kea/__manifest__.py
@@ -1,6 +1,6 @@
 {
     'name': 'Kea Theme',
-    'description': 'Cover hero feeds into alternating text-and-image rows, a featured picture, color-blocked information, and a media list — with organic blob crops on the picture and media images as the visual signature, layered over wavy line and floating shape motifs. Image-and-narrative driven / suited for technology companies, IT services, computer stores, and virtual-reality product sites',
+    'description': 'Partly illustration-based: the text-image rows use line-art illustrations instead of photos, the rest of the theme is photographic. Cover hero feeds into alternating text-and-image rows, a featured picture, color-blocked information, and a media list — with organic blob crops on the picture and media images as the visual signature, layered over wavy line and floating shape motifs. Image-and-narrative driven / suited for technology companies, IT services, computer stores, and virtual-reality product sites',
     'category': 'Theme/Technology',
     'summary': 'Technology, Tech, IT, Computers, Stores, Virtual Reality',
     'sequence': 200,

--- a/theme_odoo_experts/__manifest__.py
+++ b/theme_odoo_experts/__manifest__.py
@@ -1,6 +1,6 @@
 {
     'name': 'Experts Theme',
-    'description': 'Mockup hero leads into client references, alternating image-and-text proof rows, a feature showcase, and a collapsible FAQ before a CTA with device-mockup framing (phone, browser, tablet, laptop) running across the proof rows and underline highlights on key headings, accented by connection line motifs at the closing block. Credentials-and-proof driven / suited for business advisors, corporate consultancies, finance services, and IT advisory firms',
+    'description': 'Theme with illustration and device mockups instead of photos. Mockup hero leads into client references, alternating image-and-text proof rows, a feature showcase, and a collapsible FAQ before a CTA with device-mockup framing (phone, browser, tablet, laptop) running across the proof rows and underline highlights on key headings, accented by connection line motifs at the closing block. Credentials-and-proof driven / suited for business advisors, corporate consultancies, finance services, and IT advisory firms. Only for service businesses selling expertise; never recommend for shops or makers of physical goods (furniture, retail, e-commerce, food, construction, repair, craftsmen, etc.). The device mockups need a digital product or interface to show on screen (app, dashboard, software UI).',
     'category': 'Theme/Corporate',
     'summary': 'Advisor, Corporate, Service, Business, Finance, IT',
     'sequence': 210,

--- a/theme_paptic/__manifest__.py
+++ b/theme_paptic/__manifest__.py
@@ -1,6 +1,6 @@
 {
     'name': 'Paptic Theme',
-    'description': 'Split cover hero leads into client references, alternating illustration-based proof rows, a two-panel masonry block, and a collapsible FAQ before an illustrated CTA, with custom line art illustrations as the primary visual throughout. Credentials-forward and illustration-driven / suited for consultancies, design studios, technology firms, and IT or blog-driven corporate sites',
+    'description': 'Theme with illustration instead of images. Split cover hero leads into client references, alternating illustration-based proof rows, a two-panel masonry block, and a collapsible FAQ before an illustrated CTA, with custom line art illustrations as the primary visual throughout. Credentials-forward and illustration-driven / suited for consultancies, design studios, technology firms, and IT or blog-driven corporate sites. Only for service businesses selling expertise; never recommend for shops or makers of physical goods (furniture, retail, e-commerce, food, construction, repair, craftsmen, etc.).',
     'category': 'Theme/Corporate',
     'summary': 'Consultancy, Design, Tech, Computers, IT, Blogs',
     'sequence': 110,


### PR DESCRIPTION
Descriptions didn't state these themes use illustrations instead of photos, so the AI recommender suggested them for shops and makers of physical goods, which need real pictures.