### PR TITLE
[FIX] themes: state illustration and device-mockup requirements

### DIFF
--- a/theme_buzzy/__manifest__.py
+++ b/theme_buzzy/__manifest__.py
@@ -1,6 +1,6 @@
 {
     'name': 'Buzzy Theme',
-    'description': 'Illustrative banner opens onto a discovery exploration block, product showcase, key-benefit grids, and accordion-with-image FAQ, with shaped containers and organic blob motifs throughout and recurring scribble-and-marker highlights on key heading words. Content-heavy and benefit-driven, leaning illustrative rather than photo-led / suited for corporate services, technology companies, and SaaS-style product marketing sites',
+    'description': 'Theme with illustration instead of images. Illustrative banner opens onto a discovery exploration block, product showcase, key-benefit grids, and accordion-with-image FAQ, with shaped containers and organic blob motifs throughout and recurring scribble-and-marker highlights on key heading words. Content-heavy and benefit-driven, leaning illustrative rather than photo-led / suited for corporate services, technology companies, and SaaS-style product marketing sites. Only for service businesses selling expertise; never recommend for shops or makers of physical goods (furniture, retail, e-commerce, food, construction, repair, craftsmen, etc.).',
     'category': 'Theme/Corporate',
     'summary': 'Corporate, Services, Technology, Shapes, Illustrations',
     'sequence': 140,

--- a/theme_cobalt/__manifest__.py
+++ b/theme_cobalt/__manifest__.py
@@ -1,6 +1,6 @@
 {
     'name': 'Cobalt Theme',
-    'description': 'Banner hero leads into alternating image-text rows, key visuals, detailed team profiles, and a references grid for client logos, with connection line motifs woven across the sections. Communicates credibility through structure and showcased work / suited for IT and software development studios, design agencies, and technology consultancies',
+    'description': 'Theme with illustration instead of images. Banner hero leads into alternating image-text rows, key visuals, detailed team profiles, and a references grid for client logos, with connection line motifs woven across the sections. Communicates credibility through structure and showcased work / suited for IT and software development studios, design agencies, and technology consultancies. Only for service businesses selling expertise; never recommend for shops or makers of physical goods (furniture, retail, e-commerce, food, construction, repair, craftsmen, etc.).',
     'category': 'Theme/Corporate',
     'summary': 'Development, IT development, Design, Tech, Computers, IT, Blogs',
     'sequence': 110,

--- a/theme_odoo_experts/__manifest__.py
+++ b/theme_odoo_experts/__manifest__.py
@@ -1,6 +1,6 @@
 {
     'name': 'Experts Theme',
-    'description': 'Mockup hero leads into client references, alternating image-and-text proof rows, a feature showcase, and a collapsible FAQ before a CTA with device-mockup framing (phone, browser, tablet, laptop) running across the proof rows and underline highlights on key headings. Credentials-and-proof driven / suited for business advisors, corporate consultancies, finance services, and IT advisory firms',
+    'description': 'Theme with device mockups instead of plain photos. Mockup hero leads into client references, alternating image-and-text proof rows, a feature showcase, and a collapsible FAQ before a CTA with device-mockup framing (phone, browser, tablet, laptop) running across the proof rows and underline highlights on key headings. Credentials-and-proof driven / suited for business advisors, corporate consultancies, finance services, and IT advisory firms. Only for service businesses selling expertise; never recommend for shops or makers of physical goods (furniture, retail, e-commerce, food, construction, repair, craftsmen, etc.). The device mockups need a digital product or interface to show on screen (app, dashboard, software UI).',
     'category': 'Theme/Corporate',
     'summary': 'Advisor, Corporate, Service, Business, Finance, IT',
     'sequence': 210,

--- a/theme_paptic/__manifest__.py
+++ b/theme_paptic/__manifest__.py
@@ -1,6 +1,6 @@
 {
     'name': 'Paptic Theme',
-    'description': 'Split cover hero leads into client references, alternating illustration-based proof rows, a two-panel masonry block, and a collapsible FAQ before an illustrated CTA, with custom line art illustrations as the primary visual throughout. Credentials-forward and illustration-driven / suited for consultancies, design studios, technology firms, and IT or blog-driven corporate sites',
+    'description': 'Theme with illustration instead of images. Split cover hero leads into client references, alternating illustration-based proof rows, a two-panel masonry block, and a collapsible FAQ before an illustrated CTA, with custom line art illustrations as the primary visual throughout. Credentials-forward and illustration-driven / suited for consultancies, design studios, technology firms, and IT or blog-driven corporate sites. Only for service businesses selling expertise; never recommend for shops or makers of physical goods (furniture, retail, e-commerce, food, construction, repair, craftsmen, etc.).',
     'category': 'Theme/Corporate',
     'summary': 'Consultancy, Design, Tech, Computers, IT, Blogs',
     'sequence': 110,


### PR DESCRIPTION
Descriptions didn't state that these themes use illustrations or device mockups instead of photos, so the AI recommender suggested them for shops, makers of physical goods, and businesses with no screen to show.

task-6456379