### PR TITLE
[FIX] theme_kea: keep text readable with light palettes

### DIFF
--- a/theme_kea/static/description/preview.html
+++ b/theme_kea/static/description/preview.html
@@ -1564,14 +1564,14 @@
 <div class="s_announcement_scroll_marquee_container d-flex s_announcement_scroll_heading_family">
 <div class="o_not_editable s_announcement_scroll_marquee_item lh-1">Free Shipping • Secure payment • Easy Return •</div>
 </div>
-</section><section class="s_card_offset pt88 pb168" data-oe-shape-data='{"shape":"html_builder/Connections/14","colors":{"c5":"o-color-5"},"flip":[],"showOnMobile":false,"shapeAnimationSpeed":"0"}' data-snippet="s_card_offset">
+</section><section class="s_card_offset pt88 pb168 o_colored_level o_cc o_cc1" data-oe-shape-data='{"shape":"html_builder/Connections/14","colors":{"c5":"o-color-5"},"flip":[],"showOnMobile":false,"shapeAnimationSpeed":"0"}' data-snippet="s_card_offset">
 <div class="o_we_shape o_html_builder_Connections_14" style="background-image: url('/html_editor/shape/html_builder/Connections/14.svg?c5=o-color-5');"></div>
 <div class="container">
 <div class="row o_grid_mode" data-row-count="13">
 <div class="o_grid_item o_grid_item_image g-col-lg-11 g-height-10 col-lg-11 o_colored_level" style="z-index: 1; grid-area: 2 / 1 / 12 / 12; --grid-item-padding-x: 0px; --grid-item-padding-y: 0px;">
 <img alt="" class="img img-fluid mx-auto rounded" industry_image_key="website.ultrawide_lg_6" loading="lazy" src="/theme_kea/static/src/img/configurator/ultrawide_lg_6.webp"/>
 </div>
-<div class="o_grid_item o_bg_blur_option g-height-7 g-col-lg-5 col-lg-5 offset-1 offset-lg-0 col-10 rounded o_colored_level border" style="z-index: 2; grid-area: 7 / 8 / 14 / 13; --grid-item-padding-y: 40px; --grid-item-padding-x: 32px; background-color: rgba(0, 0, 0, 0.75); --o-bg-blur: 10;">
+<div class="o_grid_item o_bg_blur_option g-height-7 g-col-lg-5 col-lg-5 offset-1 offset-lg-0 col-10 rounded o_colored_level o_cc o_cc5 border" style="z-index: 2; grid-area: 7 / 8 / 14 / 13; --grid-item-padding-y: 40px; --grid-item-padding-x: 32px; background-color: rgba(0, 0, 0, 0.75); --o-bg-blur: 10;">
 <h2 class="h3-fs">The Future of Innovation</h2>
 <p class="lead">Write one or two paragraphs describing your product or services. To be successful your content needs to be useful to your readers.</p>
 <p>
@@ -1714,7 +1714,7 @@
 </span>
 <div class="container-fluid">
 <div class="row o_grid_mode" data-row-count="7">
-<div class="o_grid_item o_cc o_cc1 g-col-lg-6 g-height-7 col-lg-6 o_bg_blur_option border rounded" style="grid-area: 1 / 2 / 8 / 8;z-index: 3;--grid-item-padding-y: 32px;--grid-item-padding-x: 40px;background-color: rgba(0, 0, 0, 0.75);--o-bg-blur: 10;--box-border-right-width: 0px;--box-border-bottom-right-radius: 0px;--box-border-top-right-radius: 0px">
+<div class="o_grid_item o_cc o_cc5 g-col-lg-6 g-height-7 col-lg-6 o_bg_blur_option border rounded" style="grid-area: 1 / 2 / 8 / 8;z-index: 3;--grid-item-padding-y: 32px;--grid-item-padding-x: 40px;background-color: rgba(0, 0, 0, 0.75);--o-bg-blur: 10;--box-border-right-width: 0px;--box-border-bottom-right-radius: 0px;--box-border-top-right-radius: 0px">
 <h2 class="display-4-fs">Let’s get in touch</h2>
 <p class="lead"><u>info@yourcompany.example.com</u></p>
 </div>

--- a/theme_kea/views/global_customizations.xml
+++ b/theme_kea/views/global_customizations.xml
@@ -19,19 +19,6 @@
     <xpath expr="//div[hasclass('container')]" position="before">
         <div class="o_we_shape o_html_builder_Blurry_03" style="background-image: url('/html_editor/shape/html_builder/Blurry/03.svg?c1=o-color-1&amp;c2=o-color-4&amp;c3=o-color-4&amp;c4=o-color-1');"/>
     </xpath>
-    <!-- Image Boxes -->
-    <xpath expr="(//div[hasclass('o_grid_item')])[1]" position="attributes">
-        <attribute name="class" add="o_cc1" remove="o_cc5" separator=" "/>
-    </xpath>
-    <xpath expr="(//div[hasclass('o_grid_item')])[2]" position="attributes">
-        <attribute name="class" add="o_cc1" remove="o_cc5" separator=" "/>
-    </xpath>
-    <xpath expr="(//div[hasclass('o_grid_item')])[4]" position="attributes">
-        <attribute name="class" add="o_cc1" remove="o_cc5" separator=" "/>
-    </xpath>
-    <xpath expr="(//div[hasclass('o_grid_item')])[5]" position="attributes">
-        <attribute name="class" add="o_cc1" remove="o_cc5" separator=" "/>
-    </xpath>
     <!-- Discount Box -->
     <xpath expr="(//div[hasclass('o_grid_item')])[3]" position="attributes">
         <attribute name="class" add="o_cc4" remove="o_cc5" separator=" "/>
@@ -51,7 +38,7 @@
     </xpath>
     <!-- Title -->
     <xpath expr="(//div[hasclass('o_grid_item')])[2]" position="attributes">
-        <attribute name="class" add="o_bg_blur_option border rounded" separator=" "/>
+        <attribute name="class" add="o_cc5 o_bg_blur_option border rounded" remove="o_cc1" separator=" "/>
         <attribute name="style" add="background-color: rgba(0, 0, 0, 0.75); --o-bg-blur: 10; --box-border-right-width: 0px; --box-border-bottom-right-radius: 0px; --box-border-top-right-radius: 0px;" separator=";"/>
     </xpath>
     <!-- Hours columns -->

--- a/theme_kea/views/homepage_customizations.xml
+++ b/theme_kea/views/homepage_customizations.xml
@@ -46,7 +46,7 @@
 <template id="configurator_s_card_offset" inherit_id="website.configurator_s_card_offset">
     <!-- Section -->
     <xpath expr="//section" position="attributes">
-        <attribute name="class" add="pt88 pb168" remove="pt64 pb64 o_cc o_cc5" separator=" "/>
+        <attribute name="class" add="pt88 pb168 o_cc1" remove="pt64 pb64 o_cc5" separator=" "/>
         <attribute name="data-oe-shape-data">{"shape":"html_builder/Connections/14","colors":{"c5":"o-color-5"},"flip":[],"showOnMobile":false,"shapeAnimationSpeed":"0"}</attribute>
     </xpath>
     <!-- Shape -->


### PR DESCRIPTION
Steps to reproduce:
- Select Kea and a light color palette in the website configurator.
- Generate a website with the default homepage.
- Check the "Bento Grid" and "Opening Hours" blocks. => Some text is not readable over the dark backgrounds.

Before this commit, Kea replaced `o_cc5` with `o_cc1` on the Bento Grid items and kept `o_cc1` on the blurred Opening Hours element. With a light palette, these presets displayed dark text over fixed dark backgrounds.

After this commit, these elements use `o_cc5` with light palettes. For dark palettes, `adaptDarkPaletteContent` automatically replaces it with `o_cc1` to preserve the contrast.

task-6485048